### PR TITLE
Add install.sh for sandbox/CI installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+command -v uv >/dev/null 2>&1 || { curl -LsSf https://astral.sh/uv/install.sh | sh; source "$HOME/.local/bin/env"; }
+uv tool install "rlm @ git+https://${GH_TOKEN}@github.com/PrimeIntellect-ai/rlm.git"


### PR DESCRIPTION
Pipeable script that installs uv (if missing) and rlm as an isolated tool via uv tool install. Requires GH_TOKEN for private repo auth.