### PR TITLE
Add install.sh for sandbox/CI installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 command -v uv >/dev/null 2>&1 || { curl -LsSf https://astral.sh/uv/install.sh | sh; source "$HOME/.local/bin/env"; }
-uv tool install "rlm @ git+https://${GH_TOKEN}@github.com/PrimeIntellect-ai/rlm.git"
+uv tool install --python 3.11 "rlm @ git+https://${GH_TOKEN}@github.com/PrimeIntellect-ai/rlm.git"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+command -v uv >/dev/null 2>&1 || { curl -LsSf https://astral.sh/uv/install.sh | sh; source "$HOME/.local/bin/env"; }
+uv tool install "rlm @ git+https://${GH_TOKEN}@github.com/PrimeIntellect-ai/rlm.git"


### PR DESCRIPTION
## Summary
- Pipeable install script: `curl ... | bash`
- Installs `uv` if missing, then `rlm` as an isolated tool via `uv tool install`
- Pins Python 3.11 to avoid issues with old system Python (e.g. R2E sandbox images ship Python 3.7)
- Requires `GH_TOKEN` env var for private repo auth

## Usage
```bash
GH_TOKEN=... bash install.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)