### PR TITLE
Install ripgrep if not present

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -e
 command -v uv >/dev/null 2>&1 || { curl -LsSf https://astral.sh/uv/install.sh | sh; source "$HOME/.local/bin/env"; }
+command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }
 uv tool install --python 3.11 "rlm @ git+https://${GH_TOKEN}@github.com/PrimeIntellect-ai/rlm.git"


### PR DESCRIPTION
## Summary
- Detects if `rg` is available, installs via `apt-get` if missing
- rlm uses ripgrep for code search; sandbox images may not have it

🤖 Generated with [Claude Code](https://claude.com/claude-code)