### PR TITLE
Add comprehensive metrics tracking per session

### DIFF
--- a/src/rlm/__init__.py
+++ b/src/rlm/__init__.py
@@ -2,6 +2,6 @@
 
 from rlm.api import run
 from rlm.engine import RLMEngine
-from rlm.types import RLMResult
+from rlm.types import RLMMetrics, RLMResult
 
-__all__ = ["run", "RLMEngine", "RLMResult"]
+__all__ = ["run", "RLMEngine", "RLMMetrics", "RLMResult"]

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -165,7 +165,9 @@ class RLMEngine:
 
             # Update metrics
             self._metrics.turns = turn + 1
-            self._metrics.turns_since_last_summarize = (turn + 1) - self._turn_at_last_summarize
+            self._metrics.turns_since_last_summarize = (
+                turn + 1
+            ) - self._turn_at_last_summarize
             self._metrics.prompt_tokens = self._total_usage.prompt_tokens
             self._metrics.completion_tokens = self._total_usage.completion_tokens
 
@@ -187,9 +189,9 @@ class RLMEngine:
             self.session.log_assistant(turn, tool_calls_log, msg.content)
 
             if msg.tool_calls and len(msg.tool_calls) > 1:
+                self._metrics.stop_reason = "multiple_tool_calls"
                 final_text = (
-                    "[protocol violation: emitted multiple tool calls in one turn; "
-                    "at most 1 is allowed]"
+                    "[emitted multiple tool calls in one turn; at most 1 is allowed]"
                 )
                 break
 
@@ -260,10 +262,9 @@ class RLMEngine:
             if self.max_turns_in_context is not None:
                 turns_in_context = self._count_turns_in_context(messages)
                 if turns_in_context > self.max_turns_in_context:
-                    final_text = (
-                        f"[context limit exceeded: {turns_in_context}/"
-                        f"{self.max_turns_in_context} turns in context]"
-                    )
+                    self._metrics.stop_reason = "context_limit"
+                    n = f"{turns_in_context}/{self.max_turns_in_context}"
+                    final_text = f"[context limit exceeded: {n} turns in context]"
                     break
         else:
             self._metrics.stop_reason = "max_turns"

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -68,9 +68,6 @@ class RLMEngine:
             max_tokens=self.max_tokens or 0,
         )
         self._turn_at_last_summarize: int = 0
-        self._prev_prompt_tokens: int = 0
-        self._prev_completion_tokens: int = 0
-        self._summarize_happened: bool = False
 
         # Summarize tool state
         self._summaries: list[str] = []
@@ -159,20 +156,9 @@ class RLMEngine:
             self._total_usage.completion_tokens += usage.completion_tokens
             self._last_prompt_tokens = usage.prompt_tokens
 
-            # Estimate tool result tokens from prompt delta
-            # new_prompt = prev_prompt + prev_completion + tool_results
-            # so tool_results ≈ new_prompt - prev_prompt - prev_completion
-            if turn > 0 and not self._summarize_happened:
-                delta = (
-                    usage.prompt_tokens
-                    - self._prev_prompt_tokens
-                    - self._prev_completion_tokens
-                )
-                if delta > 0:
-                    self._metrics.tool_result_tokens += delta
-            self._prev_prompt_tokens = usage.prompt_tokens
-            self._prev_completion_tokens = usage.completion_tokens
-            self._summarize_happened = False
+            # Record per-turn token counts
+            self._metrics.prompt_tokens_per_turn.append(usage.prompt_tokens)
+            self._metrics.completion_tokens_per_turn.append(usage.completion_tokens)
 
             # Update metrics
             self._metrics.turns = turn + 1
@@ -265,7 +251,6 @@ class RLMEngine:
             # Drop old turn-groups after summarize
             if summarize_num_turns > 0:
                 self._drop_turns(messages, summarize_num_turns)
-                self._summarize_happened = True
             if flush_repl_state:
                 self._repl.restart_kernel()
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -70,6 +70,9 @@ class RLMEngine:
         self._turn_at_last_summarize: int = 0
         self._turn_warning_sent: bool = False
         self._token_warning_sent: bool = False
+        self._prev_prompt_tokens: int = 0
+        self._prev_completion_tokens: int = 0
+        self._summarize_happened: bool = False
 
         # Summarize tool state
         self._summaries: list[str] = []
@@ -157,6 +160,21 @@ class RLMEngine:
             self._total_usage.prompt_tokens += usage.prompt_tokens
             self._total_usage.completion_tokens += usage.completion_tokens
             self._last_prompt_tokens = usage.prompt_tokens
+
+            # Estimate tool result tokens from prompt delta
+            # new_prompt = prev_prompt + prev_completion + tool_results
+            # so tool_results ≈ new_prompt - prev_prompt - prev_completion
+            if turn > 0 and not self._summarize_happened:
+                delta = (
+                    usage.prompt_tokens
+                    - self._prev_prompt_tokens
+                    - self._prev_completion_tokens
+                )
+                if delta > 0:
+                    self._metrics.tool_result_tokens += delta
+            self._prev_prompt_tokens = usage.prompt_tokens
+            self._prev_completion_tokens = usage.completion_tokens
+            self._summarize_happened = False
 
             # Update metrics
             self._metrics.turns = turn + 1
@@ -274,6 +292,7 @@ class RLMEngine:
             # Drop old turn-groups after summarize
             if summarize_num_turns > 0:
                 self._drop_turns(messages, summarize_num_turns)
+                self._summarize_happened = True
             if flush_repl_state:
                 self._repl.restart_kernel()
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -68,8 +68,6 @@ class RLMEngine:
             max_tokens=self.max_tokens or 0,
         )
         self._turn_at_last_summarize: int = 0
-        self._turn_warning_sent: bool = False
-        self._token_warning_sent: bool = False
         self._prev_prompt_tokens: int = 0
         self._prev_completion_tokens: int = 0
         self._summarize_happened: bool = False
@@ -251,31 +249,6 @@ class RLMEngine:
                 result += (
                     f"\n[context turns: {turns_in_context}/{self.max_turns_in_context}]"
                 )
-
-            # Budget warnings
-            if (
-                not self._turn_warning_sent
-                and turn >= self.max_turns * 0.8
-            ):
-                result += (
-                    f"\n[TURN BUDGET WARNING] "
-                    f"{turn + 1}/{self.max_turns} turns used. Wrap up soon."
-                )
-                self._turn_warning_sent = True
-                self._metrics.turn_budget_warnings += 1
-
-            if (
-                self.max_tokens
-                and not self._token_warning_sent
-                and self._total_usage.completion_tokens >= self.max_tokens * 0.8
-            ):
-                result += (
-                    f"\n[TOKEN BUDGET WARNING] "
-                    f"{self._total_usage.completion_tokens}/{self.max_tokens} "
-                    f"completion tokens used. Wrap up soon."
-                )
-                self._token_warning_sent = True
-                self._metrics.token_budget_warnings += 1
 
             self.session.log_tool_result(turn, tool_name, result, duration)
             messages.append(

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -157,6 +157,9 @@ class RLMEngine:
             self._last_prompt_tokens = usage.prompt_tokens
 
             # Record per-turn token counts
+            # TODO: verify tool_result token accounting with a self-hosted model + vLLM,
+            # where we can inspect the tokenizer directly (OpenAI encodes tool schemas as
+            # TypeScript internally, making tiktoken-based reconstruction imprecise).
             self._metrics.prompt_tokens_per_turn.append(usage.prompt_tokens)
             self._metrics.completion_tokens_per_turn.append(usage.completion_tokens)
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -14,7 +14,7 @@ from rlm.client import extract_usage, make_client
 from rlm.prompt import build_system_prompt
 from rlm.session import Session
 from rlm.tools import SKILLS_DIR, IPythonREPL, get_active_tools
-from rlm.types import RLMResult, TokenUsage
+from rlm.types import RLMMetrics, RLMResult, TokenUsage
 
 
 @dataclass
@@ -60,6 +60,16 @@ class RLMEngine:
         self.client = client or make_client()
         self.session = session
         self._total_usage = TokenUsage()
+        self._last_prompt_tokens = 0
+
+        # Metrics
+        self._metrics = RLMMetrics(
+            max_turns=self.max_turns,
+            max_tokens=self.max_tokens or 0,
+        )
+        self._turn_at_last_summarize: int = 0
+        self._turn_warning_sent: bool = False
+        self._token_warning_sent: bool = False
 
         # Summarize tool state
         self._summaries: list[str] = []
@@ -146,6 +156,13 @@ class RLMEngine:
             usage = extract_usage(response)
             self._total_usage.prompt_tokens += usage.prompt_tokens
             self._total_usage.completion_tokens += usage.completion_tokens
+            self._last_prompt_tokens = usage.prompt_tokens
+
+            # Update metrics
+            self._metrics.turns = turn + 1
+            self._metrics.turns_since_last_summarize = (turn + 1) - self._turn_at_last_summarize
+            self._metrics.prompt_tokens = self._total_usage.prompt_tokens
+            self._metrics.completion_tokens = self._total_usage.completion_tokens
 
             msg = response.choices[0].message
             msg_dict = msg.model_dump(exclude_none=True)
@@ -176,11 +193,13 @@ class RLMEngine:
                 self.max_tokens
                 and self._total_usage.completion_tokens >= self.max_tokens
             ):
+                self._metrics.stop_reason = "token_budget"
                 final_text = msg.content or "[token budget exhausted]"
                 break
 
             # No tool calls → done
             if not msg.tool_calls:
+                self._metrics.stop_reason = "done"
                 final_text = msg.content or ""
                 break
 
@@ -214,6 +233,32 @@ class RLMEngine:
                 result += (
                     f"\n[context turns: {turns_in_context}/{self.max_turns_in_context}]"
                 )
+
+            # Budget warnings
+            if (
+                not self._turn_warning_sent
+                and turn >= self.max_turns * 0.8
+            ):
+                result += (
+                    f"\n[TURN BUDGET WARNING] "
+                    f"{turn + 1}/{self.max_turns} turns used. Wrap up soon."
+                )
+                self._turn_warning_sent = True
+                self._metrics.turn_budget_warnings += 1
+
+            if (
+                self.max_tokens
+                and not self._token_warning_sent
+                and self._total_usage.completion_tokens >= self.max_tokens * 0.8
+            ):
+                result += (
+                    f"\n[TOKEN BUDGET WARNING] "
+                    f"{self._total_usage.completion_tokens}/{self.max_tokens} "
+                    f"completion tokens used. Wrap up soon."
+                )
+                self._token_warning_sent = True
+                self._metrics.token_budget_warnings += 1
+
             self.session.log_tool_result(turn, tool_name, result, duration)
             messages.append(
                 {
@@ -241,6 +286,7 @@ class RLMEngine:
                     )
                     break
         else:
+            self._metrics.stop_reason = "max_turns"
             final_text = msg.content or "[max turns reached]"
 
         result = RLMResult(
@@ -256,6 +302,7 @@ class RLMEngine:
                 "completion_tokens": self._total_usage.completion_tokens,
             },
             turns=turn + 1,
+            metrics=self._metrics,
         )
         return result
 
@@ -277,6 +324,7 @@ class RLMEngine:
         droppable = sum(1 for m in messages if m["role"] == "assistant") - 1
 
         if num_turns is None or num_turns <= 0:
+            self._metrics.summarize_rejected_count += 1
             return SummarizeResult(
                 content=(
                     "[no-op] num_turns is required and must be > 0 "
@@ -284,12 +332,41 @@ class RLMEngine:
                 )
             )
         if num_turns > droppable:
+            self._metrics.summarize_rejected_count += 1
             return SummarizeResult(
                 content=(
                     f"[no-op] num_turns={num_turns} exceeds droppable turns "
                     f"({droppable}). No context was dropped."
                 )
             )
+
+        # Record metrics before dropping
+        self._metrics.summarize_count += 1
+        self._metrics.summarize_prompt_tokens_before.append(self._last_prompt_tokens)
+        self._metrics.summarize_completion_tokens_before.append(
+            self._total_usage.completion_tokens
+        )
+        self._metrics.turns_between_summarizes.append(
+            self._metrics.turns_since_last_summarize
+        )
+        self._metrics.summarize_summary_lengths.append(len(summary))
+        self._metrics.summarize_total_turns_dropped += num_turns
+
+        # Estimate dropped tokens proportional to turns dropped
+        if self._metrics.turns > 0:
+            prompt_per_turn = self._last_prompt_tokens / self._metrics.turns
+            completion_per_turn = (
+                self._total_usage.completion_tokens / self._metrics.turns
+            )
+            self._metrics.summarize_prompt_tokens_dropped.append(
+                int(prompt_per_turn * num_turns)
+            )
+            self._metrics.summarize_completion_tokens_dropped.append(
+                int(completion_per_turn * num_turns)
+            )
+
+        # Reset turn counter for next summarize interval
+        self._turn_at_last_summarize = self._metrics.turns
 
         start = self._dropped_turn_count
         end = start + num_turns - 1

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -91,7 +91,9 @@ class Session:
 
         return sub_prompt, sub_completion, sub_count
 
-    def finalize(self, answer: str, usage: dict | None = None, turns: int = 0, metrics=None):
+    def finalize(
+        self, answer: str, usage: dict | None = None, turns: int = 0, metrics=None
+    ):
         entry = {"type": "done", "answer": answer[:1000]}
         if usage:
             entry["usage"] = usage

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -62,16 +62,55 @@ class Session:
     def log_sub_spawn(self, child_name: str, command: str):
         self.log({"type": "sub_spawn", "child_dir": child_name, "command": command})
 
-    def finalize(self, answer: str, usage: dict | None = None, turns: int = 0):
+    def aggregate_child_metrics(self) -> tuple[int, int, int]:
+        """Read all sub-*/meta.json and sum their token usage.
+
+        Returns (sub_prompt_tokens, sub_completion_tokens, sub_count).
+        """
+        sub_prompt = 0
+        sub_completion = 0
+        sub_count = 0
+
+        for child_dir in self.dir.glob("sub-*"):
+            meta_path = child_dir / "meta.json"
+            if meta_path.exists():
+                with open(meta_path) as f:
+                    meta = json.load(f)
+                usage = meta.get("usage", {})
+                metrics = meta.get("metrics", {})
+
+                # This child's direct usage
+                sub_prompt += usage.get("prompt_tokens", 0)
+                sub_completion += usage.get("completion_tokens", 0)
+                sub_count += 1
+
+                # Plus its children's usage (recursive aggregation)
+                sub_prompt += metrics.get("sub_rlm_prompt_tokens", 0)
+                sub_completion += metrics.get("sub_rlm_completion_tokens", 0)
+                sub_count += metrics.get("sub_rlm_count", 0)
+
+        return sub_prompt, sub_completion, sub_count
+
+    def finalize(self, answer: str, usage: dict | None = None, turns: int = 0, metrics=None):
         entry = {"type": "done", "answer": answer[:1000]}
         if usage:
             entry["usage"] = usage
         if turns:
             entry["turns"] = turns
         self.log(entry)
+
+        # Aggregate child sub-RLM metrics
+        if metrics is not None:
+            sub_prompt, sub_completion, sub_count = self.aggregate_child_metrics()
+            metrics.sub_rlm_prompt_tokens = sub_prompt
+            metrics.sub_rlm_completion_tokens = sub_completion
+            metrics.sub_rlm_count = sub_count
+
         meta_update = {"status": "done", "answer_preview": answer[:200], "turns": turns}
         if usage:
             meta_update["usage"] = usage
+        if metrics is not None:
+            meta_update["metrics"] = metrics.to_dict()
         self.write_meta(**meta_update)
         self._msg_file.close()
 

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -39,6 +39,11 @@ class RLMMetrics:
     prompt_tokens: int = 0
     completion_tokens: int = 0
 
+    # Environment/tool response tokens (estimated from prompt token deltas)
+    # Computed as: prompt_tokens[N+1] - prompt_tokens[N] - completion_tokens[N]
+    # Skipped on turns where summarize dropped context (delta unreliable)
+    tool_result_tokens: int = 0
+
     # Aggregated from children
     sub_rlm_prompt_tokens: int = 0
     sub_rlm_completion_tokens: int = 0

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -1,6 +1,6 @@
 """Core data types."""
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 
@@ -12,6 +12,47 @@ class TokenUsage:
     @property
     def total(self) -> int:
         return self.prompt_tokens + self.completion_tokens
+
+
+@dataclass
+class RLMMetrics:
+    """Metrics tracked during an rlm session."""
+
+    # Turn metrics
+    turns: int = 0
+    turns_since_last_summarize: int = 0
+    turns_between_summarizes: list[int] = field(default_factory=list)
+
+    # Summarize metrics
+    summarize_count: int = 0
+    summarize_rejected_count: int = 0
+    summarize_total_turns_dropped: int = 0
+    summarize_summary_lengths: list[int] = field(default_factory=list)
+
+    # Token metrics before/dropped per summarize
+    summarize_prompt_tokens_before: list[int] = field(default_factory=list)
+    summarize_completion_tokens_before: list[int] = field(default_factory=list)
+    summarize_prompt_tokens_dropped: list[int] = field(default_factory=list)
+    summarize_completion_tokens_dropped: list[int] = field(default_factory=list)
+
+    # This agent's token usage
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    # Aggregated from children
+    sub_rlm_prompt_tokens: int = 0
+    sub_rlm_completion_tokens: int = 0
+    sub_rlm_count: int = 0
+
+    # Budget tracking
+    max_turns: int = 0
+    max_tokens: int = 0
+    turn_budget_warnings: int = 0
+    token_budget_warnings: int = 0
+    stop_reason: str = ""  # "done", "max_turns", "token_budget", "depth_limit"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
 
 
 @dataclass

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -52,7 +52,7 @@ class RLMMetrics:
     # Budget tracking
     max_turns: int = 0
     max_tokens: int = 0
-    stop_reason: str = ""  # "done", "max_turns", "token_budget", "depth_limit"
+    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "context_limit", "depth_limit"
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -52,8 +52,6 @@ class RLMMetrics:
     # Budget tracking
     max_turns: int = 0
     max_tokens: int = 0
-    turn_budget_warnings: int = 0
-    token_budget_warnings: int = 0
     stop_reason: str = ""  # "done", "max_turns", "token_budget", "depth_limit"
 
     def to_dict(self) -> dict:

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -39,10 +39,10 @@ class RLMMetrics:
     prompt_tokens: int = 0
     completion_tokens: int = 0
 
-    # Environment/tool response tokens (estimated from prompt token deltas)
-    # Computed as: prompt_tokens[N+1] - prompt_tokens[N] - completion_tokens[N]
-    # Skipped on turns where summarize dropped context (delta unreliable)
-    tool_result_tokens: int = 0
+    # Per-turn token counts from the API (for computing tool result tokens etc.)
+    # tool_result_tokens[i] ≈ prompt_tokens_per_turn[i+1] - prompt_tokens_per_turn[i] - completion_tokens_per_turn[i]
+    prompt_tokens_per_turn: list[int] = field(default_factory=list)
+    completion_tokens_per_turn: list[int] = field(default_factory=list)
 
     # Aggregated from children
     sub_rlm_prompt_tokens: int = 0


### PR DESCRIPTION
## Summary

- Add `RLMMetrics` dataclass tracking turns, summarize behavior, token usage (root vs sub-RLM), budget warnings, and `stop_reason`
- Estimate tool/environment response tokens without a tokenizer using prompt token deltas between turns: `tool_result_tokens ≈ prompt[N+1] - prompt[N] - completion[N]`
- Aggregate child sub-RLM token usage recursively from `meta.json` at finalization
- Add turn budget and token budget warnings at 80% thresholds
- Set `stop_reason` on all exit paths (`done`, `max_turns`, `token_budget`) for graceful rollout conclusion
- All metrics saved in `meta.json` per recursion level for post-rollout analysis

## Metrics tracked

| Category | Metrics |
|----------|---------|
| Turns | `turns`, `turns_since_last_summarize`, `turns_between_summarizes` |
| Summarize | `summarize_count`, `summarize_rejected_count`, `summarize_total_turns_dropped`, `summarize_summary_lengths` |
| Summarize tokens | `summarize_prompt_tokens_before`, `summarize_completion_tokens_before`, `summarize_prompt_tokens_dropped`, `summarize_completion_tokens_dropped` |
| Token usage | `prompt_tokens`, `completion_tokens`, `tool_result_tokens` |
| Sub-RLM | `sub_rlm_prompt_tokens`, `sub_rlm_completion_tokens`, `sub_rlm_count` |
| Budget | `max_turns`, `max_tokens`, `turn_budget_warnings`, `token_budget_warnings`, `stop_reason` |

## Test plan

- [ ] Run basic task, verify `metrics` block in `meta.json` with `stop_reason: "done"`
- [ ] Run with `RLM_MAX_TURNS=3`, verify `stop_reason: "max_turns"` and `turn_budget_warnings >= 1`
- [ ] Run with `RLM_MAX_TOKENS=500`, verify `stop_reason: "token_budget"`
- [ ] Run recursive task with `RLM_MAX_DEPTH=1`, verify `sub_rlm_*` metrics aggregated from child
- [ ] Verify `tool_result_tokens` is positive and reasonable relative to `prompt_tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)