### PR TITLE
flush_repl_state, max_turns_in_context, small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ All configuration is via environment variables:
 | `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |
 | `RLM_EXEC_TIMEOUT` | `300` | Seconds per IPython execution |
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
+| `RLM_MAX_TURNS_IN_CONTEXT` | `-1` | Max assistant turns retained in the live context (`-1` disables; `0` and `1` are invalid) |
 | `RLM_MAX_TOKENS` | `0` | Optional completion-token budget (`0` disables) |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 | `SERPER_API_KEY` | — | Optional API key for the bundled `skills/websearch` script |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ All configuration is via environment variables:
 | `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |
 | `RLM_EXEC_TIMEOUT` | `300` | Seconds per IPython execution |
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
-| `RLM_MAX_CONTEXT` | `128000` | Context-window warning threshold base |
 | `RLM_MAX_TOKENS` | `0` | Optional completion-token budget (`0` disables) |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 | `SERPER_API_KEY` | — | Optional API key for the bundled `skills/websearch` script |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A minimal CLI coding agent with a persistent IPython execution environment and o
 The model gets two built-in tools:
 
 - `ipython` for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash`
-- `summarize` for dropping old turns from context
+- `summarize` for dropping old turns from context and optionally resetting REPL state
 
 Inside the IPython session, the `rlm` module is pre-imported. When recursion is allowed, the model can call `await rlm.run(...)` to spawn sub-agents.
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import json
 import os
 import time
@@ -14,6 +15,13 @@ from rlm.prompt import build_system_prompt
 from rlm.session import Session
 from rlm.tools import SKILLS_DIR, IPythonREPL, get_active_tools
 from rlm.types import RLMResult, TokenUsage
+
+
+@dataclass
+class SummarizeResult:
+    content: str
+    num_turns: int = 0
+    flush_repl_state: bool = False
 
 
 class RLMEngine:
@@ -181,8 +189,10 @@ class RLMEngine:
             tool_name = tc.function.name
             tool_args = json.loads(tc.function.arguments)
             t0 = time.time()
+            summarize_result = None
             if tool_name == "summarize":
-                result = self._execute_summarize(tool_args, messages)
+                summarize_result = self._execute_summarize(tool_args, messages)
+                result = summarize_result.content
             else:
                 result = await asyncio.to_thread(
                     self._execute_tool, tool_name, tool_args
@@ -190,11 +200,15 @@ class RLMEngine:
             duration = time.time() - t0
 
             summarize_num_turns = 0
-            if tool_name == "summarize" and not result.startswith("[no-op]"):
-                summarize_num_turns = tool_args.get("num_turns", 0)
+            flush_repl_state = False
+            if summarize_result is not None:
+                summarize_num_turns = summarize_result.num_turns
+                flush_repl_state = summarize_result.flush_repl_state
 
             if self.max_output > 0 and len(result) > self.max_output:
                 result = result[: self.max_output] + "\n... [output truncated]"
+            if flush_repl_state:
+                result += "\n[repl state flushed]"
             if tool_name == "ipython" and self.max_turns_in_context is not None:
                 turns_in_context = self._count_turns_in_context(messages)
                 result += (
@@ -215,6 +229,8 @@ class RLMEngine:
             # Drop old turn-groups after summarize
             if summarize_num_turns > 0:
                 self._drop_turns(messages, summarize_num_turns)
+            if flush_repl_state:
+                self._repl.restart_kernel()
 
             if self.max_turns_in_context is not None:
                 turns_in_context = self._count_turns_in_context(messages)
@@ -253,25 +269,37 @@ class RLMEngine:
             self.session.log_sub_spawn(child_name, "(spawned via rlm())")
         self._known_children = current
 
-    def _execute_summarize(self, args: dict, messages: list[dict]) -> str:
+    def _execute_summarize(self, args: dict, messages: list[dict]) -> SummarizeResult:
         num_turns = args.get("num_turns")
         summary = args.get("summary", "")
+        flush_repl_state = bool(args.get("flush_repl_state", False))
 
         droppable = sum(1 for m in messages if m["role"] == "assistant") - 1
 
         if num_turns is None or num_turns <= 0:
-            return f"[no-op] num_turns is required and must be > 0 (got {num_turns}). No context was dropped."
+            return SummarizeResult(
+                content=(
+                    "[no-op] num_turns is required and must be > 0 "
+                    f"(got {num_turns}). No context was dropped."
+                )
+            )
         if num_turns > droppable:
-            return (
-                f"[no-op] num_turns={num_turns} exceeds droppable turns "
-                f"({droppable}). No context was dropped."
+            return SummarizeResult(
+                content=(
+                    f"[no-op] num_turns={num_turns} exceeds droppable turns "
+                    f"({droppable}). No context was dropped."
+                )
             )
 
         start = self._dropped_turn_count
         end = start + num_turns - 1
         self._summaries.append(f"[turns {start}-{end}] {summary}")
         self._dropped_turn_count += num_turns
-        return "\n\n".join(self._summaries)
+        return SummarizeResult(
+            content="\n\n".join(self._summaries),
+            num_turns=num_turns,
+            flush_repl_state=flush_repl_state,
+        )
 
     @staticmethod
     def _count_turns_in_context(messages: list[dict]) -> int:

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -38,11 +38,6 @@ class RLMEngine:
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
 
-        # Context window awareness
-        self.max_context = int(os.environ.get("RLM_MAX_CONTEXT", "128000"))
-        self._context_warning_sent = False
-        self._last_prompt_tokens = 0
-
         # Token budget
         _max_tok = int(os.environ.get("RLM_MAX_TOKENS", "0"))
         self.max_tokens = _max_tok if _max_tok > 0 else None
@@ -117,16 +112,20 @@ class RLMEngine:
 
         for turn in range(self.max_turns):
             # Call LLM
+            request_kwargs = {
+                "model": self.model,
+                "messages": messages,
+            }
+            if active_tools:
+                request_kwargs["tools"] = active_tools
+                request_kwargs["parallel_tool_calls"] = False
             response = await self.client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                tools=active_tools if active_tools else None,
+                **request_kwargs,
             )
 
             usage = extract_usage(response)
             self._total_usage.prompt_tokens += usage.prompt_tokens
             self._total_usage.completion_tokens += usage.completion_tokens
-            self._last_prompt_tokens = usage.prompt_tokens
 
             msg = response.choices[0].message
             msg_dict = msg.model_dump(exclude_none=True)
@@ -145,6 +144,13 @@ class RLMEngine:
                 ]
             self.session.log_assistant(turn, tool_calls_log, msg.content)
 
+            if msg.tool_calls and len(msg.tool_calls) > 1:
+                final_text = (
+                    "[protocol violation: emitted multiple tool calls in one turn; "
+                    "at most 1 is allowed]"
+                )
+                break
+
             # Token budget check
             if (
                 self.max_tokens
@@ -158,61 +164,33 @@ class RLMEngine:
                 final_text = msg.content or ""
                 break
 
-            # Execute tool calls
-            summarize_num_turns = 0
-
-            async def _exec_one(tc):
-                n = tc.function.name
-                a = json.loads(tc.function.arguments)
-                t0 = time.time()
-                if n == "summarize":
-                    r = self._execute_summarize(a, messages)
-                else:
-                    r = await asyncio.to_thread(self._execute_tool, n, a)
-                return tc, r, time.time() - t0
-
-            tool_results = await asyncio.gather(
-                *[_exec_one(tc) for tc in msg.tool_calls]
-            )
-
-            for tc, result, duration in tool_results:
-                if tc.function.name == "summarize" and not result.startswith("[no-op]"):
-                    summarize_num_turns = json.loads(tc.function.arguments).get(
-                        "num_turns", 0
-                    )
-
-                # Append execution duration
-                if tc.function.name != "summarize":
-                    result += f"\n[executed in {duration:.1f}s]"
-
-                # Append token budget info
-                if self.max_tokens:
-                    result += f"\n[{self._total_usage.completion_tokens}/{self.max_tokens} completion tokens used]"
-
-                # Context window warning (once, at 80%)
-                if (
-                    not self._context_warning_sent
-                    and self._last_prompt_tokens >= self.max_context * 0.80
-                ):
-                    pct = self._last_prompt_tokens / self.max_context
-                    result += (
-                        f"\n\n[CONTEXT LIMIT WARNING] "
-                        f"You have used {self._last_prompt_tokens:,} of "
-                        f"{self.max_context:,} tokens ({pct:.0%}). "
-                        f"Wrap up your task soon."
-                    )
-                    self._context_warning_sent = True
-
-                if self.max_output > 0 and len(result) > self.max_output:
-                    result = result[: self.max_output]
-                self.session.log_tool_result(turn, tc.function.name, result, duration)
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": result,
-                    }
+            # Execute the single allowed tool call
+            tc = msg.tool_calls[0]
+            tool_name = tc.function.name
+            tool_args = json.loads(tc.function.arguments)
+            t0 = time.time()
+            if tool_name == "summarize":
+                result = self._execute_summarize(tool_args, messages)
+            else:
+                result = await asyncio.to_thread(
+                    self._execute_tool, tool_name, tool_args
                 )
+            duration = time.time() - t0
+
+            summarize_num_turns = 0
+            if tool_name == "summarize" and not result.startswith("[no-op]"):
+                summarize_num_turns = tool_args.get("num_turns", 0)
+
+            if self.max_output > 0 and len(result) > self.max_output:
+                result = result[: self.max_output]
+            self.session.log_tool_result(turn, tool_name, result, duration)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": result,
+                }
+            )
 
             # Detect new child sessions spawned via rlm()
             self._detect_new_children()

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -21,6 +21,7 @@ class RLMEngine:
         self,
         model: str | None = None,
         max_turns: int | None = None,
+        max_turns_in_context: int | None = None,
         cwd: str | None = None,
         session: Session | None = None,
         client: AsyncOpenAI | None = None,
@@ -35,6 +36,12 @@ class RLMEngine:
                 "RLM_MAX_OUTPUT must be positive, or -1 to disable truncation"
             )
         self.max_output = max_output
+        limit = max_turns_in_context
+        if limit is None:
+            limit = int(os.environ.get("RLM_MAX_TURNS_IN_CONTEXT", "-1"))
+        if limit < -1 or limit in (0, 1):
+            raise ValueError("RLM_MAX_TURNS_IN_CONTEXT must be -1 (unlimited) or >= 2")
+        self.max_turns_in_context = None if limit == -1 else limit
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
 
@@ -94,12 +101,17 @@ class RLMEngine:
 
     async def _run_loop(self, prompt: str) -> RLMResult:
         active_tools = get_active_tools()
+        summarize_enabled = any(
+            tool["function"]["name"] == "summarize" for tool in active_tools
+        )
         messages_path = str(self.session.dir / "messages.jsonl")
         system_prompt = build_system_prompt(
             self.cwd,
             str(SKILLS_DIR),
             messages_path,
             allow_recursion=self.depth < self.max_depth,
+            max_turns_in_context=self.max_turns_in_context,
+            summarize_enabled=summarize_enabled,
         )
 
         messages = [
@@ -182,7 +194,12 @@ class RLMEngine:
                 summarize_num_turns = tool_args.get("num_turns", 0)
 
             if self.max_output > 0 and len(result) > self.max_output:
-                result = result[: self.max_output]
+                result = result[: self.max_output] + "\n... [output truncated]"
+            if tool_name == "ipython" and self.max_turns_in_context is not None:
+                turns_in_context = self._count_turns_in_context(messages)
+                result += (
+                    f"\n[context turns: {turns_in_context}/{self.max_turns_in_context}]"
+                )
             self.session.log_tool_result(turn, tool_name, result, duration)
             messages.append(
                 {
@@ -198,6 +215,15 @@ class RLMEngine:
             # Drop old turn-groups after summarize
             if summarize_num_turns > 0:
                 self._drop_turns(messages, summarize_num_turns)
+
+            if self.max_turns_in_context is not None:
+                turns_in_context = self._count_turns_in_context(messages)
+                if turns_in_context > self.max_turns_in_context:
+                    final_text = (
+                        f"[context limit exceeded: {turns_in_context}/"
+                        f"{self.max_turns_in_context} turns in context]"
+                    )
+                    break
         else:
             final_text = msg.content or "[max turns reached]"
 
@@ -246,6 +272,10 @@ class RLMEngine:
         self._summaries.append(f"[turns {start}-{end}] {summary}")
         self._dropped_turn_count += num_turns
         return "\n\n".join(self._summaries)
+
+    @staticmethod
+    def _count_turns_in_context(messages: list[dict]) -> int:
+        return sum(1 for message in messages if message["role"] == "assistant")
 
     @staticmethod
     def _drop_turns(messages: list[dict], num_turns: int) -> None:

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -9,6 +9,8 @@ def build_system_prompt(
     messages_path: str,
     *,
     allow_recursion: bool,
+    max_turns_in_context: int | None,
+    summarize_enabled: bool,
 ) -> str:
     """Build the system prompt."""
     parts = [
@@ -28,6 +30,19 @@ def build_system_prompt(
         "",
         f"Your conversation is logged to {messages_path}.",
     ]
+
+    if max_turns_in_context is not None:
+        parts.extend(
+            [
+                "",
+                "The current context may contain at most "
+                f"{max_turns_in_context} assistant turns.",
+            ]
+        )
+        if summarize_enabled:
+            parts.append(
+                "Use `summarize` to drop older turns and stay within this limit."
+            )
 
     if allow_recursion:
         parts[6:6] = [

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -13,6 +13,7 @@ def build_system_prompt(
     """Build the system prompt."""
     parts = [
         "You are a coding agent. You solve tasks by writing and executing code, observing results, and iterating.",
+        "Call at most one built-in tool per turn.",
         "",
         "You have a persistent IPython session. Variables, imports, and function definitions persist across calls.",
         "Use !command for shell commands (e.g. !git status, !ls -la, !pip install foo).",

--- a/src/rlm/tools.py
+++ b/src/rlm/tools.py
@@ -67,7 +67,8 @@ SUMMARIZE_SCHEMA = {
         "description": (
             "Summarize and drop old turns from context to free up space. "
             "A turn is one assistant response plus all its tool results. "
-            "Dropping num_turns removes the oldest complete turns from context."
+            "Dropping num_turns removes the oldest complete turns from context. "
+            "Optionally flush the persistent IPython state after summarization."
         ),
         "parameters": {
             "type": "object",
@@ -79,6 +80,13 @@ SUMMARIZE_SCHEMA = {
                 "summary": {
                     "type": "string",
                     "description": "Your summary of the content being dropped.",
+                },
+                "flush_repl_state": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, restart the persistent IPython kernel after "
+                        "summarization so Python state is reset."
+                    ),
                 },
             },
             "required": ["num_turns", "summary"],
@@ -152,7 +160,7 @@ import rlm
             ):
                 return True
 
-    def _restart_kernel(self):
+    def restart_kernel(self):
         """Restart the kernel and restore the initial REPL state."""
         if self._kc:
             self._kc.stop_channels()
@@ -166,7 +174,7 @@ import rlm
         """Interrupt the running cell and restart the kernel if needed."""
         self._km.interrupt_kernel()
         if not self._wait_for_idle(timeout=2):
-            self._restart_kernel()
+            self.restart_kernel()
 
     def execute(self, code: str, timeout: int | None = None) -> str:
         """Execute code and return combined output."""


### PR DESCRIPTION
This PR does three things: adds a retained-context turn limit, enforces one built-in tool call per turn, and extends `summarize` so it can optionally flush REPL state.

**1. Add `max_turns_in_context`**

Adds `RLM_MAX_TURNS_IN_CONTEXT` with `-1` meaning unlimited and `0`, `1`, or values below `-1` rejected early. When set, the model is told the limit in the system prompt, `ipython` results include a `[context turns: X/Y]` footer, and the rollout stops if retained assistant turns exceed the limit after tool execution and any summarization.

**2. Add `flush_repl_state` to `summarize` and enforce one built-in tool call at a time**

`summary` now accepts `flush_repl_state: bool = False`. When set to `True` on a successful summarize call, the engine drops the requested turns, logs `[repl state flushed]`, and restarts the persistent IPython kernel so Python state is reset before the next turn.

To make that behavior well-defined, built-in tool usage is now strictly single-call-per-turn. The system prompt tells the model to call at most one built-in tool per turn, chat completions are requested with `parallel_tool_calls=False`, and the rollout aborts with a protocol-violation result if the model emits multiple built-in tool calls in one assistant message.

**3. Misc cleanup**

Removes the execution-duration, token-budget, and old context-window warning annotations from tool results. Truncated tool outputs now end with `... [output truncated]`, and the context-turn footer is appended after truncation so it is always visible. README docs were updated accordingly.
