### PR TITLE
Add system prompt file override

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ uv run rlm "fix the auth bug in login.py"
 # Override model/limits
 RLM_MODEL=gpt-4o RLM_MAX_TURNS=50 uv run rlm "refactor the parser"
 
+# Append extra instructions to the generated system prompt
+uv run rlm --custom-instructions "Always run tests before finishing." "solve the task"
+
 # Replace the generated system prompt from a file
 uv run rlm --system-prompt-path /tmp/system.txt "solve the task"
 ```
@@ -53,13 +56,14 @@ All configuration is via environment variables:
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
 | `RLM_MAX_TURNS_IN_CONTEXT` | `-1` | Max assistant turns retained in the live context (`-1` disables; `0` and `1` are invalid) |
 | `RLM_MAX_TOKENS` | `0` | Optional completion-token budget (`0` disables) |
+| `RLM_CUSTOM_INSTRUCTIONS` | — | Extra instructions appended to the generated system prompt |
 | `RLM_SYSTEM_PROMPT_PATH` | — | Path to a file whose contents fully replace the generated system prompt |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 | `SERPER_API_KEY` | — | Optional API key for the bundled `skills/websearch` script |
 | `RLM_WEBSEARCH_TIMEOUT` | `45` | Timeout for `skills/websearch` requests |
 | `RLM_WEBSEARCH_NUM_RESULTS` | `5` | Organic results returned by `skills/websearch` |
 
-CLI flags override env vars: `uv run rlm --model gpt-4o --max-turns 50 --system-prompt-path /tmp/system.txt "prompt"`.
+`RLM_SYSTEM_PROMPT_PATH` takes precedence over `RLM_CUSTOM_INSTRUCTIONS`. CLI flags override env vars: `uv run rlm --model gpt-4o --max-turns 50 --custom-instructions "..." --system-prompt-path /tmp/system.txt "prompt"`.
 
 ## Recursion
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ uv run rlm "fix the auth bug in login.py"
 RLM_MODEL=gpt-4o RLM_MAX_TURNS=50 uv run rlm "refactor the parser"
 
 # Append extra instructions to the generated system prompt
-uv run rlm --custom-instructions "Always run tests before finishing." "solve the task"
+uv run rlm --append-to-system-prompt "Always run tests before finishing." "solve the task"
 
 # Replace the generated system prompt from a file
 uv run rlm --system-prompt-path /tmp/system.txt "solve the task"
@@ -56,14 +56,14 @@ All configuration is via environment variables:
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
 | `RLM_MAX_TURNS_IN_CONTEXT` | `-1` | Max assistant turns retained in the live context (`-1` disables; `0` and `1` are invalid) |
 | `RLM_MAX_TOKENS` | `0` | Optional completion-token budget (`0` disables) |
-| `RLM_CUSTOM_INSTRUCTIONS` | — | Extra instructions appended to the generated system prompt |
+| `RLM_APPEND_TO_SYSTEM_PROMPT` | — | Extra instructions appended to the generated system prompt |
 | `RLM_SYSTEM_PROMPT_PATH` | — | Path to a file whose contents fully replace the generated system prompt |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 | `SERPER_API_KEY` | — | Optional API key for the bundled `skills/websearch` script |
 | `RLM_WEBSEARCH_TIMEOUT` | `45` | Timeout for `skills/websearch` requests |
 | `RLM_WEBSEARCH_NUM_RESULTS` | `5` | Organic results returned by `skills/websearch` |
 
-`RLM_SYSTEM_PROMPT_PATH` takes precedence over `RLM_CUSTOM_INSTRUCTIONS`. CLI flags override env vars: `uv run rlm --model gpt-4o --max-turns 50 --custom-instructions "..." --system-prompt-path /tmp/system.txt "prompt"`.
+`RLM_SYSTEM_PROMPT_PATH` takes precedence over `RLM_APPEND_TO_SYSTEM_PROMPT`. CLI flags override env vars: `uv run rlm --model gpt-4o --max-turns 50 --append-to-system-prompt "..." --system-prompt-path /tmp/system.txt "prompt"`.
 
 ## Recursion
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ uv run rlm "fix the auth bug in login.py"
 
 # Override model/limits
 RLM_MODEL=gpt-4o RLM_MAX_TURNS=50 uv run rlm "refactor the parser"
+
+# Replace the generated system prompt from a file
+uv run rlm --system-prompt-path /tmp/system.txt "solve the task"
 ```
 
 ## Python SDK
@@ -50,12 +53,13 @@ All configuration is via environment variables:
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
 | `RLM_MAX_TURNS_IN_CONTEXT` | `-1` | Max assistant turns retained in the live context (`-1` disables; `0` and `1` are invalid) |
 | `RLM_MAX_TOKENS` | `0` | Optional completion-token budget (`0` disables) |
+| `RLM_SYSTEM_PROMPT_PATH` | — | Path to a file whose contents fully replace the generated system prompt |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 | `SERPER_API_KEY` | — | Optional API key for the bundled `skills/websearch` script |
 | `RLM_WEBSEARCH_TIMEOUT` | `45` | Timeout for `skills/websearch` requests |
 | `RLM_WEBSEARCH_NUM_RESULTS` | `5` | Organic results returned by `skills/websearch` |
 
-CLI flags override env vars: `uv run rlm --model gpt-4o --max-turns 50 "prompt"`.
+CLI flags override env vars: `uv run rlm --model gpt-4o --max-turns 50 --system-prompt-path /tmp/system.txt "prompt"`.
 
 ## Recursion
 

--- a/src/rlm/cli.py
+++ b/src/rlm/cli.py
@@ -35,6 +35,11 @@ def main():
         default=None,
         help="Path to a file whose contents replace the generated system prompt",
     )
+    parser.add_argument(
+        "--custom-instructions",
+        default=None,
+        help="Extra instructions appended to the generated system prompt",
+    )
     args = parser.parse_args()
 
     # Apply CLI overrides to env
@@ -44,6 +49,8 @@ def main():
         os.environ["RLM_MAX_TURNS"] = str(args.max_turns)
     if args.system_prompt_path:
         os.environ["RLM_SYSTEM_PROMPT_PATH"] = args.system_prompt_path
+    if args.custom_instructions:
+        os.environ["RLM_CUSTOM_INSTRUCTIONS"] = args.custom_instructions
 
     if args.prompt:
         print(asyncio.run(rlm.run(args.prompt)).answer)

--- a/src/rlm/cli.py
+++ b/src/rlm/cli.py
@@ -36,7 +36,7 @@ def main():
         help="Path to a file whose contents replace the generated system prompt",
     )
     parser.add_argument(
-        "--custom-instructions",
+        "--append-to-system-prompt",
         default=None,
         help="Extra instructions appended to the generated system prompt",
     )
@@ -49,8 +49,8 @@ def main():
         os.environ["RLM_MAX_TURNS"] = str(args.max_turns)
     if args.system_prompt_path:
         os.environ["RLM_SYSTEM_PROMPT_PATH"] = args.system_prompt_path
-    if args.custom_instructions:
-        os.environ["RLM_CUSTOM_INSTRUCTIONS"] = args.custom_instructions
+    if args.append_to_system_prompt:
+        os.environ["RLM_APPEND_TO_SYSTEM_PROMPT"] = args.append_to_system_prompt
 
     if args.prompt:
         print(asyncio.run(rlm.run(args.prompt)).answer)

--- a/src/rlm/cli.py
+++ b/src/rlm/cli.py
@@ -30,6 +30,11 @@ def main():
         default=None,
         help="Max turns (overrides RLM_MAX_TURNS)",
     )
+    parser.add_argument(
+        "--system-prompt-path",
+        default=None,
+        help="Path to a file whose contents replace the generated system prompt",
+    )
     args = parser.parse_args()
 
     # Apply CLI overrides to env
@@ -37,6 +42,8 @@ def main():
         os.environ["RLM_MODEL"] = args.model
     if args.max_turns:
         os.environ["RLM_MAX_TURNS"] = str(args.max_turns)
+    if args.system_prompt_path:
+        os.environ["RLM_SYSTEM_PROMPT_PATH"] = args.system_prompt_path
 
     if args.prompt:
         print(asyncio.run(rlm.run(args.prompt)).answer)

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -32,7 +32,7 @@ class RLMEngine:
         max_turns: int | None = None,
         max_turns_in_context: int | None = None,
         system_prompt_path: str | None = None,
-        custom_instructions: str | None = None,
+        append_to_system_prompt: str | None = None,
         cwd: str | None = None,
         session: Session | None = None,
         client: AsyncOpenAI | None = None,
@@ -56,8 +56,8 @@ class RLMEngine:
         self.system_prompt_path = system_prompt_path or os.environ.get(
             "RLM_SYSTEM_PROMPT_PATH"
         )
-        self.custom_instructions = custom_instructions or os.environ.get(
-            "RLM_CUSTOM_INSTRUCTIONS"
+        self.append_to_system_prompt = append_to_system_prompt or os.environ.get(
+            "RLM_APPEND_TO_SYSTEM_PROMPT"
         )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
@@ -272,8 +272,8 @@ class RLMEngine:
             max_turns_in_context=self.max_turns_in_context,
             summarize_enabled=summarize_enabled,
         )
-        if self.custom_instructions:
-            system_prompt += "\n\n" + self.custom_instructions
+        if self.append_to_system_prompt:
+            system_prompt += "\n\n" + self.append_to_system_prompt
         return system_prompt
 
     def _detect_new_children(self):

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -32,6 +32,7 @@ class RLMEngine:
         max_turns: int | None = None,
         max_turns_in_context: int | None = None,
         system_prompt_path: str | None = None,
+        custom_instructions: str | None = None,
         cwd: str | None = None,
         session: Session | None = None,
         client: AsyncOpenAI | None = None,
@@ -54,6 +55,9 @@ class RLMEngine:
         self.max_turns_in_context = None if limit == -1 else limit
         self.system_prompt_path = system_prompt_path or os.environ.get(
             "RLM_SYSTEM_PROMPT_PATH"
+        )
+        self.custom_instructions = custom_instructions or os.environ.get(
+            "RLM_CUSTOM_INSTRUCTIONS"
         )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
@@ -260,7 +264,7 @@ class RLMEngine:
     def _load_system_prompt(self, messages_path: str, summarize_enabled: bool) -> str:
         if self.system_prompt_path:
             return Path(self.system_prompt_path).read_text()
-        return build_system_prompt(
+        system_prompt = build_system_prompt(
             self.cwd,
             str(SKILLS_DIR),
             messages_path,
@@ -268,6 +272,9 @@ class RLMEngine:
             max_turns_in_context=self.max_turns_in_context,
             summarize_enabled=summarize_enabled,
         )
+        if self.custom_instructions:
+            system_prompt += "\n\n" + self.custom_instructions
+        return system_prompt
 
     def _detect_new_children(self):
         """Scan session dir for new sub-* directories and log them."""

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass
 import json
 import os
+from pathlib import Path
 import time
 
 from openai import AsyncOpenAI
@@ -30,6 +31,7 @@ class RLMEngine:
         model: str | None = None,
         max_turns: int | None = None,
         max_turns_in_context: int | None = None,
+        system_prompt_path: str | None = None,
         cwd: str | None = None,
         session: Session | None = None,
         client: AsyncOpenAI | None = None,
@@ -50,6 +52,9 @@ class RLMEngine:
         if limit < -1 or limit in (0, 1):
             raise ValueError("RLM_MAX_TURNS_IN_CONTEXT must be -1 (unlimited) or >= 2")
         self.max_turns_in_context = None if limit == -1 else limit
+        self.system_prompt_path = system_prompt_path or os.environ.get(
+            "RLM_SYSTEM_PROMPT_PATH"
+        )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
 
@@ -113,14 +118,7 @@ class RLMEngine:
             tool["function"]["name"] == "summarize" for tool in active_tools
         )
         messages_path = str(self.session.dir / "messages.jsonl")
-        system_prompt = build_system_prompt(
-            self.cwd,
-            str(SKILLS_DIR),
-            messages_path,
-            allow_recursion=self.depth < self.max_depth,
-            max_turns_in_context=self.max_turns_in_context,
-            summarize_enabled=summarize_enabled,
-        )
+        system_prompt = self._load_system_prompt(messages_path, summarize_enabled)
 
         messages = [
             {"role": "system", "content": system_prompt},
@@ -258,6 +256,18 @@ class RLMEngine:
             turns=turn + 1,
         )
         return result
+
+    def _load_system_prompt(self, messages_path: str, summarize_enabled: bool) -> str:
+        if self.system_prompt_path:
+            return Path(self.system_prompt_path).read_text()
+        return build_system_prompt(
+            self.cwd,
+            str(SKILLS_DIR),
+            messages_path,
+            allow_recursion=self.depth < self.max_depth,
+            max_turns_in_context=self.max_turns_in_context,
+            summarize_enabled=summarize_enabled,
+        )
 
     def _detect_new_children(self):
         """Scan session dir for new sub-* directories and log them."""


### PR DESCRIPTION
Enable overriding the system prompt by setting `RLM_SYSTEM_PROMPT_PATH` or `--system-prompt-path`.

Enable adding to the system prompt (appending a string to it) via `RLM_CUSTOM_INSTRUCTIONS` or `--custom-instructions`