### PR TITLE
Fix install.sh for sandboxes without curl/wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -e
-command -v uv >/dev/null 2>&1 || { (curl -LsSf https://astral.sh/uv/install.sh || wget -qO- https://astral.sh/uv/install.sh) | sh; . "$HOME/.local/bin/env"; }
+command -v uv >/dev/null 2>&1 || {
+    command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl; }
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env" || export PATH="$HOME/.local/bin:$PATH"
+}
 command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }
 uv tool install --python 3.11 "rlm @ git+https://${GH_TOKEN}@github.com/PrimeIntellect-ai/rlm.git"


### PR DESCRIPTION
## Summary
- Multi-SWE-RL sandbox images (e.g. `iamkun/dayjs`, `sveltejs/svelte`, `checkstyle/checkstyle`) ship without `curl` or `wget`, causing 100% install failures
- Install `curl` via `apt-get` when it's not available, drop the `wget` fallback
- Guard the `env` file source with a fallback `PATH` export for robustness

## Context
The `rlm-swe` training run is stuck at step 101 because all multi-swe-rl rollouts fail with:
```
/bin/sh: 1: curl: not found
/bin/sh: 1: wget: not found
```
or:
```
/tmp/rlm-install.sh: line 3: /root/.local/bin/env: No such file or directory
```

43,123 failed rollouts, 0 completed — ever.

## Test plan
- [x] Verified on `mswebench/iamkun_m_dayjs:pr-769` sandbox with production PATH — fix installs curl, then uv, then ripgrep successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)