### PR TITLE
normalize tool names in prompt

### DIFF
--- a/src/rlm/tools.py
+++ b/src/rlm/tools.py
@@ -34,6 +34,11 @@ def _find_skills_dir() -> Path | None:
 SKILLS_DIR = _find_skills_dir()
 
 
+def _normalize_skill_name(name: str) -> str:
+    """Normalize a discovered skill token to the import/CLI form."""
+    return name.replace("-", "_")
+
+
 def get_installed_skills() -> list[str]:
     """Return installed skill names discovered from distribution metadata."""
     skills: set[str] = set()
@@ -41,7 +46,7 @@ def get_installed_skills() -> list[str]:
     for dist in metadata.distributions():
         name = dist.metadata.get("Name", "")
         if name.startswith(prefix):
-            skills.add(name[len(prefix) :])
+            skills.add(_normalize_skill_name(name[len(prefix) :]))
     return sorted(skills)
 
 


### PR DESCRIPTION
change "-" to "_" so that the model sees the tool-names the way it needs to use them.

the tool names are extracted by uv from names that use hyphens and a prefix (e.g. "rlm-skill-open-webpage"); the prefix is extracted (-> "open-webpage"), and now, the dash is also replaced with an underscore, so the model is told the tool-name as "open_webpage" in its prompt, which is how it should import it in Python and use it on the CLI.