### PR TITLE
Restore install.sh with isolated tool install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Ensure curl is available (Multi-SWE-RL images may lack it)
+command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl; }
+
+# Install uv if missing
+if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env" || export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Install ripgrep if missing
+command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }
+
+# Clone the repo
+RLM_CHECKOUT="${RLM_CHECKOUT_PATH:-/tmp/rlm-checkout}"
+rm -rf "$RLM_CHECKOUT"
+git clone --depth 1 "https://${GH_TOKEN:+${GH_TOKEN}@}github.com/PrimeIntellect-ai/rlm.git" "$RLM_CHECKOUT"
+
+# Install rlm as an isolated CLI tool (separate venv, on PATH).
+# Discover workspace skill packages and include them so that
+# get_installed_skills() finds them via importlib.metadata.
+SKILL_ARGS=""
+for skill_dir in "$RLM_CHECKOUT"/skills/*/; do
+    [ -f "$skill_dir/pyproject.toml" ] && SKILL_ARGS="$SKILL_ARGS --with-editable $skill_dir"
+done
+eval uv tool install --python 3.10 --editable "$RLM_CHECKOUT" $SKILL_ARGS

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -20,6 +20,7 @@ def build_system_prompt(
         "",
         "You have a persistent IPython session. Variables, imports, and function definitions persist across calls.",
         "Use !command for shell commands (e.g. !git status, !ls -la, !pip install foo).",
+        "Use !python3 to run code with the project's own packages (e.g. !python3 -m pytest, !python3 -c 'import numpy').",
         "Use %%bash for multi-line shell scripts.",
         "",
         "Work one step at a time: execute code, read the output, then decide your next step.",


### PR DESCRIPTION
## Summary
PR #20 deleted `install.sh` and switched to `uv run --project`, which ran rlm inside the checkout's venv. This hijacked the sandbox's Python — the agent's ipython couldn't import sandbox packages (numpy, pandas), giving **0% solve rate** on R2E-Gym (old run had 19%).

Restores `install.sh` using `uv tool install --editable` which creates an isolated tool venv. Skill packages under `skills/*/` are discovered dynamically via `--with-editable`.

## What this gives us
- **Isolated venv**: rlm + skills in their own tool venv, sandbox Python untouched
- **Editable**: changes to `/tmp/rlm-checkout/src/rlm/` reflected without reinstall
- **Skills discovered**: `get_installed_skills()` finds `rlm-skill-edit`, `rlm-skill-websearch` via `importlib.metadata`
- **Python 3.10**: pinned to match rlm's minimum requirement, avoids picking up old venv pythons on PATH

## Known limitation
Inline `import numpy` in ipython uses rlm's isolated Python 3.10 venv, which doesn't have the sandbox's project packages. Some R2E-Gym sandboxes have their `.venv` on an older Python (e.g. 3.7), so we can't inject those site-packages due to C-extension incompatibility.

The agent must use `!python3` (shell out) for sandbox package interactions — e.g. `!python3 -c "import numpy; ..."` or `!python3 -m pytest`. This mirrors the old `bash` tool behavior where all commands ran in the sandbox shell. Will address inline import support in a follow-up.

## Tested
On fresh R2E-Gym (`orange3_final`) and Multi-SWE-RL (`syncthing`) sandboxes:
- rlm + both skills install into Python 3.10 tool venv
- `rlm` on PATH and works
- Sandbox Python untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)