### PR TITLE
Support RLM_KERNEL_PYTHON for sandbox package access

### DIFF
--- a/src/rlm/tools.py
+++ b/src/rlm/tools.py
@@ -127,15 +127,12 @@ class IPythonREPL:
         """Start the IPython kernel."""
         from jupyter_client import KernelManager
 
-        self._km = KernelManager(
-            kernel_cmd=[
-                sys.executable,
-                "-m",
-                "ipykernel_launcher",
-                "-f",
-                "{connection_file}",
-            ]
-        )
+        kernel_python = os.environ.get("RLM_KERNEL_PYTHON") or sys.executable
+        self._km = KernelManager()
+        # Point the kernel spec at the desired Python interpreter.
+        self._km.kernel_spec.argv = [
+            kernel_python, "-m", "ipykernel_launcher", "-f", "{connection_file}",
+        ]
         self._km.start_kernel(cwd=self.cwd)
         self._kc = self._km.client()
         self._kc.start_channels()
@@ -156,7 +153,10 @@ import nest_asyncio
 nest_asyncio.apply()
 
 import asyncio
-import rlm
+try:
+    import rlm
+except ImportError:
+    pass
 """
         self._execute_silent(setup_code)
 


### PR DESCRIPTION
## Summary
When `RLM_KERNEL_PYTHON` is set, the ipython kernel runs in that interpreter instead of rlm's own Python. This lets the agent inline-import project packages (numpy, pandas, etc.) while rlm stays in its isolated tool venv.

## How it works
- rlm process runs in its tool venv (Python 3.10, has openai/ipykernel/etc.)
- The ipython kernel spawns in `RLM_KERNEL_PYTHON` (e.g. `/testbed/.venv/bin/python3`)
- The kernel has the sandbox's packages (numpy, pandas, Orange, etc.)
- Standard Jupyter architecture — server and kernel are decoupled

## Changes
- `tools.py`: read `RLM_KERNEL_PYTHON` env var, override `kernel_spec.argv` to use it
- `tools.py`: guard `import rlm` in `_inject_startup` since rlm won't be installed in the kernel's Python

## Tested
On R2E-Gym sandbox (`orange3_final`, Python 3.7 .venv):
- Kernel reports Python 3.7.9 from `/testbed/.venv/bin/python3`
- `import numpy` → 1.17.5 (inline, no `!` needed)
- `import Orange` → 3.17.0.dev (inline)

On Multi-SWE-RL sandbox (`syncthing`, no .venv):
- Falls back to rlm's Python 3.10 (default behavior)
- Skills discovered, shell commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)