### PR TITLE
Install skill executables and always upgrade uv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,11 +4,9 @@ set -eo pipefail
 # Ensure curl is available (Multi-SWE-RL images may lack it)
 command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl; }
 
-# Install uv if missing
-if ! command -v uv >/dev/null 2>&1; then
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env" || export PATH="$HOME/.local/bin:$PATH"
-fi
+# Always install latest uv (sandbox images may have stale versions)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env" || export PATH="$HOME/.local/bin:$PATH"
 
 # Install ripgrep if missing
 command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }
@@ -19,10 +17,12 @@ rm -rf "$RLM_CHECKOUT"
 git clone --depth 1 "https://${GH_TOKEN:+${GH_TOKEN}@}github.com/PrimeIntellect-ai/rlm.git" "$RLM_CHECKOUT"
 
 # Install rlm as an isolated CLI tool (separate venv, on PATH).
-# Discover workspace skill packages and include them so that
-# get_installed_skills() finds them via importlib.metadata.
+# Discover workspace skill packages and include them with their
+# executables so that skills are both importable and on PATH.
 SKILL_ARGS=""
 for skill_dir in "$RLM_CHECKOUT"/skills/*/; do
-    [ -f "$skill_dir/pyproject.toml" ] && SKILL_ARGS="$SKILL_ARGS --with-editable $skill_dir"
+    [ -f "$skill_dir/pyproject.toml" ] || continue
+    skill_name=$(grep '^name' "$skill_dir/pyproject.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+    SKILL_ARGS="$SKILL_ARGS --with-editable $skill_dir --with-executables-from $skill_name"
 done
 uv tool install --python 3.10 --editable "$RLM_CHECKOUT" $SKILL_ARGS


### PR DESCRIPTION
## Summary
- Always install latest uv (sandbox images may ship stale versions that lack `--with-executables-from`)
- Add `--with-executables-from` for each skill so `edit` and `websearch` CLIs are on PATH alongside `rlm`

Without this, only the `rlm` executable is installed — skill CLIs are missing and `!edit` fails in ipython.

## Tested
On R2E-Gym sandbox: `rlm`, `edit`, `websearch` all installed to `~/.local/bin/`. `!edit --path /tmp/test.txt --old-str "hello" --new-str "goodbye"` works from ipython kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)