### PR TITLE
Add kernel skill shims for external ipython kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,34 @@ Workspace expectations:
 - each skill should expose exactly one console script named `<name>`
 - duplicate import names or console-script names will conflict at install/runtime, so skill authors must avoid them
 
+## Kernel Modes
+
+The IPython kernel can run in two modes depending on the environment.
+
+### Native kernel (default)
+
+The kernel runs inside rlm's own Python. All skills and the `rlm` module are importable natively. This is the default when `RLM_KERNEL_PYTHON` is unset.
+
+Use this for non-Python projects (Go, Java, Rust) or when the sandbox has no `.venv`.
+
+### External kernel (`RLM_KERNEL_PYTHON`)
+
+Set `RLM_KERNEL_PYTHON` to point the kernel at a different Python interpreter — typically the sandbox's `.venv/bin/python3`. The kernel then runs inside the sandbox's Python with access to all its packages (numpy, pandas, etc.) for inline imports. The target Python must have `ipykernel` and `nest_asyncio` installed.
+
+In training, the verifiers harness detects the sandbox `.venv`, installs `ipykernel`, and sets `RLM_KERNEL_PYTHON` automatically. For manual use:
+
+```bash
+export RLM_KERNEL_PYTHON=$(pwd)/.venv/bin/python3
+rlm "fix the failing test"
+```
+
+Lightweight proxy modules are always registered at kernel startup, guaranteeing the kernel uses the rlm checkout's skills rather than any same-named packages in the sandbox. The proxies provide the same API (`import edit`, `edit.PARAMETERS`, `await edit.run(...)`) but delegate to the skill CLIs on PATH via subprocess.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RLM_KERNEL_PYTHON` | `sys.executable` | Python interpreter for the IPython kernel |
+| `RLM_CHECKOUT_PATH` | `/tmp/rlm-checkout` | Path to the rlm source checkout (used to locate skill source for proxy generation) |
+
 ## Interactive Mode
 
 Running `rlm` with no prompts enters a placeholder interactive mode. The TUI is not implemented yet.

--- a/src/rlm/kernel_shim.py
+++ b/src/rlm/kernel_shim.py
@@ -1,0 +1,144 @@
+"""Skill shims for external ipython kernels.
+
+Registers lightweight proxy modules so that ``import edit``,
+``edit.PARAMETERS``, and ``await edit.run(...)`` work in the ipython
+kernel — delegating to the skill CLIs on PATH via subprocess.
+
+Shims are always installed regardless of whether a same-named module
+exists, guaranteeing the kernel uses the rlm checkout's skills.
+
+Usage (called from _inject_startup)::
+
+    from rlm.kernel_shim import install_shims
+    install_shims("/tmp/rlm-checkout/skills")
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+import shutil
+import sys
+import types
+from pathlib import Path
+
+
+def _read_parameters(skill_src: Path) -> dict:
+    """Extract the PARAMETERS dict from skill source without importing it."""
+    for pyfile in skill_src.rglob("*.py"):
+        try:
+            tree = ast.parse(pyfile.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "PARAMETERS"
+            ):
+                try:
+                    return ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    continue
+    return {}
+
+
+def _make_run(cli_name: str):
+    """Create an async run() that delegates to the skill CLI."""
+
+    async def run(**kwargs) -> str:
+        cmd = [cli_name]
+        for key, value in kwargs.items():
+            flag = f"--{key.replace('_', '-')}"
+            if isinstance(value, (list, tuple)):
+                cmd.append(flag)
+                cmd.extend(str(v) for v in value)
+            elif isinstance(value, bool):
+                if value:
+                    cmd.append(flag)
+            else:
+                cmd.extend([flag, str(value)])
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        out = stdout.decode().strip()
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            return err or out or f"{cli_name} exited with code {proc.returncode}"
+        return out
+
+    return run
+
+
+def _make_proxy(name: str, parameters: dict) -> types.ModuleType:
+    """Create a proxy module for a skill."""
+    mod = types.ModuleType(name)
+    mod.__doc__ = f"Proxy for the {name} skill (delegates to CLI)."
+    mod.__path__ = []  # make it look like a package
+    mod.PARAMETERS = parameters
+    mod.run = _make_run(name)
+    return mod
+
+
+def install_shims(skills_dir: str) -> list[str]:
+    """Register proxy modules for all skills found in *skills_dir*.
+
+    Always installs shims regardless of whether a same-named module is
+    already importable — this guarantees the kernel uses the rlm
+    checkout's version of each skill, not an unrelated package.
+
+    Returns the list of skill names that were shimmed.
+    """
+    skills_path = Path(skills_dir)
+    if not skills_path.is_dir():
+        return []
+
+    shimmed = []
+    for skill_dir in sorted(skills_path.iterdir()):
+        if not (skill_dir / "pyproject.toml").is_file():
+            continue
+        src = skill_dir / "src"
+        if not src.is_dir():
+            continue
+        # The importable name is the subdirectory under src/
+        for candidate in src.iterdir():
+            if candidate.is_dir() and candidate.name != "__pycache__":
+                name = candidate.name
+                break
+        else:
+            continue
+
+        # Skip if the CLI isn't on PATH
+        if not shutil.which(name):
+            continue
+
+        parameters = _read_parameters(src)
+        sys.modules[name] = _make_proxy(name, parameters)
+        shimmed.append(name)
+
+    # Also shim `rlm` itself for sub-agent recursion
+    if shutil.which("rlm"):
+        mod = types.ModuleType("rlm")
+        mod.__doc__ = "Proxy for the rlm CLI (sub-agent recursion)."
+        mod.__path__ = []
+
+        async def _rlm_run(prompt: str, **kwargs) -> types.SimpleNamespace:
+            cmd = ["rlm", prompt]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            return types.SimpleNamespace(answer=stdout.decode().strip())
+
+        mod.run = _rlm_run
+        sys.modules["rlm"] = mod
+        shimmed.append("rlm")
+
+    return shimmed

--- a/src/rlm/tools.py
+++ b/src/rlm/tools.py
@@ -145,11 +145,16 @@ class IPythonREPL:
         self._inject_startup()
 
     def _inject_startup(self):
-        """Set up kernel: cwd, nest_asyncio, env vars, import rlm SDK."""
+        """Set up kernel: cwd, nest_asyncio, env vars, skill shims."""
         session_dir = str(self.session.dir) if self.session else None
         depth = int(os.environ.get("RLM_DEPTH", "0"))
+        checkout = os.environ.get("RLM_CHECKOUT_PATH", "/tmp/rlm-checkout")
+        # Path to kernel_shim.py in the rlm source tree
+        shim_path = str(Path(__file__).resolve().parent)
+        skills_dir = str(Path(checkout) / "skills")
+
         setup_code = f"""\
-import os
+import os, sys
 os.chdir({self.cwd!r})
 os.environ['RLM_SESSION_DIR'] = {session_dir!r} or ''
 os.environ['RLM_DEPTH'] = str({depth!r} + 1)
@@ -158,10 +163,15 @@ import nest_asyncio
 nest_asyncio.apply()
 
 import asyncio
-try:
-    import rlm
-except ImportError:
-    pass
+
+# Install skill shims so `import edit`, `import rlm` etc. work
+# even when the kernel runs in a different Python.  Load kernel_shim
+# directly by path to avoid triggering rlm's __init__ (which needs openai).
+import importlib.util as _ilu
+_spec = _ilu.spec_from_file_location("kernel_shim", {shim_path + "/kernel_shim.py"!r})
+_shim = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_shim)
+_shim.install_shims({skills_dir!r})
 """
         self._execute_silent(setup_code)
 


### PR DESCRIPTION
## Kernel Modes

The IPython kernel can run in two modes depending on the environment.

**Native kernel (default):** The kernel runs inside rlm's own Python. All skills and the `rlm` module are importable natively. Use this for non-Python projects (Go, Java, Rust) or when the sandbox has no `.venv`.

**External kernel (`RLM_KERNEL_PYTHON`):** Points the kernel at a different Python interpreter — typically the sandbox's `.venv/bin/python3`. The kernel runs inside the sandbox's Python with access to all its packages (numpy, pandas, etc.) for inline imports. The target Python must have `ipykernel` and `nest_asyncio` installed. In training, the verifiers harness detects the sandbox `.venv`, installs `ipykernel`, and sets `RLM_KERNEL_PYTHON` automatically.

Lightweight proxy modules are always registered at kernel startup, guaranteeing the kernel uses the rlm checkout's skills rather than any same-named packages in the sandbox. The proxies provide the same API (`import edit`, `edit.PARAMETERS`, `await edit.run(...)`) but delegate to the skill CLIs on PATH via subprocess.

---

## Implementation

1. `kernel_shim.py`: standalone module (loaded by file path to avoid triggering `rlm/__init__` which needs openai)
2. `install_shims()` iterates skill dirs, always registers proxies for every skill with a CLI on PATH
3. Reads `PARAMETERS` from skill source via `ast.literal_eval`, creates a proxy module with `run()` → subprocess CLI call
4. Also shims `import rlm` for sub-agent recursion

## Tested

**R2E-Gym** (Python 3.7 kernel, shims active):
- `import numpy` inline ✓
- `import edit` → shim, `edit.PARAMETERS` ✓, `await edit.run()` edits file ✓
- `import websearch` → shim ✓
- `import rlm` → shim ✓

**Multi-SWE-RL** (Python 3.10 native kernel, shims active):
- `import edit` → shim ✓, `await edit.run()` ✓
- `import rlm` → shim ✓
- `!ls` shell commands ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)