### PR TITLE
allow installation from arbitrary branch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,21 +12,10 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }
 
 # Clone the repo
-RLM_REPO_URL="${RLM_REPO_URL:-github.com/PrimeIntellect-ai/rlm.git}"
 RLM_REPO_BRANCH="${RLM_REPO_BRANCH:-main}"
 RLM_CHECKOUT="${RLM_CHECKOUT_PATH:-/tmp/rlm-checkout}"
 rm -rf "$RLM_CHECKOUT"
-case "$RLM_REPO_URL" in
-    https://*|http://*)
-        CLONE_URL="$RLM_REPO_URL"
-        ;;
-    github.com/*)
-        CLONE_URL="https://${GH_TOKEN:+${GH_TOKEN}@}${RLM_REPO_URL}"
-        ;;
-    *)
-        CLONE_URL="$RLM_REPO_URL"
-        ;;
-esac
+CLONE_URL="https://${GH_TOKEN:+${GH_TOKEN}@}github.com/PrimeIntellect-ai/rlm.git"
 git clone --depth 1 --branch "$RLM_REPO_BRANCH" "$CLONE_URL" "$RLM_CHECKOUT"
 
 # Install rlm as an isolated CLI tool (separate venv, on PATH).

--- a/install.sh
+++ b/install.sh
@@ -12,10 +12,21 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }
 
 # Clone the repo
+RLM_REPO_URL="${RLM_REPO_URL:-github.com/PrimeIntellect-ai/rlm.git}"
 RLM_REPO_BRANCH="${RLM_REPO_BRANCH:-main}"
 RLM_CHECKOUT="${RLM_CHECKOUT_PATH:-/tmp/rlm-checkout}"
 rm -rf "$RLM_CHECKOUT"
-CLONE_URL="https://${GH_TOKEN:+${GH_TOKEN}@}github.com/PrimeIntellect-ai/rlm.git"
+case "$RLM_REPO_URL" in
+    https://*|http://*)
+        CLONE_URL="$RLM_REPO_URL"
+        ;;
+    github.com/*)
+        CLONE_URL="https://${GH_TOKEN:+${GH_TOKEN}@}${RLM_REPO_URL}"
+        ;;
+    *)
+        CLONE_URL="$RLM_REPO_URL"
+        ;;
+esac
 git clone --depth 1 --branch "$RLM_REPO_BRANCH" "$CLONE_URL" "$RLM_CHECKOUT"
 
 # Install rlm as an isolated CLI tool (separate venv, on PATH).

--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,22 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }
 
 # Clone the repo
+RLM_REPO_URL="${RLM_REPO_URL:-github.com/PrimeIntellect-ai/rlm.git}"
+RLM_REPO_BRANCH="${RLM_REPO_BRANCH:-main}"
 RLM_CHECKOUT="${RLM_CHECKOUT_PATH:-/tmp/rlm-checkout}"
 rm -rf "$RLM_CHECKOUT"
-git clone --depth 1 "https://${GH_TOKEN:+${GH_TOKEN}@}github.com/PrimeIntellect-ai/rlm.git" "$RLM_CHECKOUT"
+case "$RLM_REPO_URL" in
+    https://*|http://*)
+        CLONE_URL="$RLM_REPO_URL"
+        ;;
+    github.com/*)
+        CLONE_URL="https://${GH_TOKEN:+${GH_TOKEN}@}${RLM_REPO_URL}"
+        ;;
+    *)
+        CLONE_URL="$RLM_REPO_URL"
+        ;;
+esac
+git clone --depth 1 --branch "$RLM_REPO_BRANCH" "$CLONE_URL" "$RLM_CHECKOUT"
 
 # Install rlm as an isolated CLI tool (separate venv, on PATH).
 # Discover workspace skill packages and include them with their


### PR DESCRIPTION
Previously, rlm-swe could take the install script from an arbitrary repo, but that script would then install from the same repo and branch, always. This now makes the install script respect the selected repo and branch.