### PR TITLE
Skip clone in install.sh if checkout already exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,19 +15,21 @@ command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq 
 RLM_REPO_URL="${RLM_REPO_URL:-github.com/PrimeIntellect-ai/rlm.git}"
 RLM_REPO_BRANCH="${RLM_REPO_BRANCH:-main}"
 RLM_CHECKOUT="${RLM_CHECKOUT_PATH:-/tmp/rlm-checkout}"
-rm -rf "$RLM_CHECKOUT"
-case "$RLM_REPO_URL" in
-    https://*|http://*)
-        CLONE_URL="$RLM_REPO_URL"
-        ;;
-    github.com/*)
-        CLONE_URL="https://${GH_TOKEN:+${GH_TOKEN}@}${RLM_REPO_URL}"
-        ;;
-    *)
-        CLONE_URL="$RLM_REPO_URL"
-        ;;
-esac
-git clone --depth 1 --branch "$RLM_REPO_BRANCH" "$CLONE_URL" "$RLM_CHECKOUT"
+if [ ! -d "$RLM_CHECKOUT/.git" ]; then
+    case "$RLM_REPO_URL" in
+        https://*|http://*)
+            CLONE_URL="$RLM_REPO_URL"
+            ;;
+        github.com/*)
+            CLONE_URL="https://${GH_TOKEN:+${GH_TOKEN}@}${RLM_REPO_URL}"
+            ;;
+        *)
+            CLONE_URL="$RLM_REPO_URL"
+            ;;
+    esac
+    rm -rf "$RLM_CHECKOUT"
+    git clone --depth 1 --branch "$RLM_REPO_BRANCH" "$CLONE_URL" "$RLM_CHECKOUT"
+fi
 
 # Install rlm as an isolated CLI tool (separate venv, on PATH).
 # Discover workspace skill packages and include them with their


### PR DESCRIPTION
When the harness pre-clones the repo via git protocol (to avoid raw.githubusercontent.com rate limits), install.sh shouldn't re-clone. Skips if `.git` already exists at the checkout path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell-script control-flow change limited to install-time cloning behavior; main risk is incorrect `.git` detection leading to using a stale or unexpected checkout.
> 
> **Overview**
> Updates `install.sh` to **skip re-cloning** the repository when the checkout directory already contains a `.git` folder, enabling workflows that pre-clone the repo (e.g., to avoid rate limits). When cloning is needed, it still constructs the same `CLONE_URL`, wipes the checkout directory, and performs a shallow `git clone` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd467216bfea48e75b0cc9cdf92bcddf4bf5a6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->