### PR TITLE
Gate skills behind RLM_ENABLED_TOOLS (default: edit)

### DIFF
--- a/src/rlm/kernel_shim.py
+++ b/src/rlm/kernel_shim.py
@@ -85,18 +85,29 @@ def _make_proxy(name: str, parameters: dict) -> types.ModuleType:
     return mod
 
 
+def _parse_enabled_tools() -> frozenset[str] | None:
+    """Mirror of rlm.tools._parse_enabled_tools (duplicated to keep this
+    module independent of rlm.__init__, which pulls in openai)."""
+    raw = os.environ.get("RLM_ENABLED_TOOLS", "edit").strip()
+    if raw == "*":
+        return None
+    return frozenset(name.strip() for name in raw.split(",") if name.strip())
+
+
 def install_shims(skills_dir: str) -> list[str]:
     """Register proxy modules for all skills found in *skills_dir*.
 
-    Always installs shims regardless of whether a same-named module is
-    already importable — this guarantees the kernel uses the rlm
-    checkout's version of each skill, not an unrelated package.
+    Respects ``RLM_ENABLED_TOOLS`` so that disabled skills are neither
+    importable nor listed in the system prompt. The CLI itself remains
+    on PATH — we only gate the Python shim and the prompt exposure.
 
     Returns the list of skill names that were shimmed.
     """
     skills_path = Path(skills_dir)
     if not skills_path.is_dir():
         return []
+
+    enabled = _parse_enabled_tools()
 
     shimmed = []
     for skill_dir in sorted(skills_path.iterdir()):
@@ -111,6 +122,9 @@ def install_shims(skills_dir: str) -> list[str]:
                 name = candidate.name
                 break
         else:
+            continue
+
+        if enabled is not None and name not in enabled:
             continue
 
         # Skip if the CLI isn't on PATH

--- a/src/rlm/tools.py
+++ b/src/rlm/tools.py
@@ -39,14 +39,32 @@ def _normalize_skill_name(name: str) -> str:
     return name.replace("-", "_")
 
 
+DEFAULT_ENABLED_TOOLS = "edit"
+
+
+def _parse_enabled_tools() -> frozenset[str] | None:
+    """Parse RLM_ENABLED_TOOLS into an allowlist of skill names.
+
+    Returns None when the env var is ``*`` (allow every discovered skill).
+    Empty string disables every skill. Unset defaults to ``edit``.
+    """
+    raw = os.environ.get("RLM_ENABLED_TOOLS", DEFAULT_ENABLED_TOOLS).strip()
+    if raw == "*":
+        return None
+    return frozenset(name.strip() for name in raw.split(",") if name.strip())
+
+
 def get_installed_skills() -> list[str]:
-    """Return installed skill names discovered from distribution metadata."""
+    """Return installed skill names, filtered by RLM_ENABLED_TOOLS."""
     skills: set[str] = set()
     prefix = "rlm-skill-"
     for dist in metadata.distributions():
         name = dist.metadata.get("Name", "")
         if name.startswith(prefix):
             skills.add(_normalize_skill_name(name[len(prefix) :]))
+    enabled = _parse_enabled_tools()
+    if enabled is not None:
+        skills &= enabled
     return sorted(skills)
 
 


### PR DESCRIPTION
## Summary

Adds an allowlist env var \`RLM_ENABLED_TOOLS\` that filters discovered skills in two places:

- \`tools.get_installed_skills()\` — the list surfaced in the system prompt's "Installed skills" line
- \`kernel_shim.install_shims()\` — the proxy modules registered in the external ipython kernel so \`import <skill>\` works

The CLI binaries themselves stay on PATH (we only gate the Python shim and prompt exposure).

| \`RLM_ENABLED_TOOLS\` | behavior |
| --- | --- |
| unset | defaults to \`edit\` |
| \`edit,websearch\` | allowlist of names |
| \`*\` | no filtering (keep all) |
| \`\` (empty) | disable all skills |

### Motivation

Both \`edit\` and \`websearch\` are installed unconditionally by \`install.sh\`. Previously this meant every rollout had websearch available regardless of the training config, and there was no way to turn it off short of deleting the skill from the repo or filtering at install time. This env var lets training orchestrators opt skills in/out per run.

## Test plan

Verified in a live sandbox (python:3.11-slim):

- \`get_installed_skills()\` unset → \`['edit']\`
- \`RLM_ENABLED_TOOLS=edit,websearch\` → \`['edit', 'websearch']\`
- \`RLM_ENABLED_TOOLS=*\` → \`['edit', 'websearch']\`
- \`RLM_ENABLED_TOOLS=""\` → \`[]\`
- \`build_system_prompt(...)\` with default env prints \`Installed skills: \`edit\`.\` (no websearch)

\_kernel_shim_'s filter logic mirrors \`tools\`, so the same allowlist applies to proxy-module registration in external ipython kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized env-var gating around skill enumeration and shim registration; main risk is misconfiguration unintentionally hiding required tools.
> 
> **Overview**
> Introduces `RLM_ENABLED_TOOLS` as an allowlist to control which skills are exposed at runtime, defaulting to `edit`, supporting `*` for no filtering and empty string for disabling all.
> 
> Updates `tools.get_installed_skills()` to filter discovered skill distributions via this allowlist, and updates `kernel_shim.install_shims()` to only register proxy modules for enabled skills so disabled tools are neither importable in external IPython kernels nor shown in the system prompt (while leaving the underlying CLIs on `PATH`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b7209ed29cd58a707f4be2f9778c19031776bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->