### PR TITLE
install.sh: pin UV_INSTALL_DIR so PATH tracks actual uv install location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,16 @@ set -eo pipefail
 # Ensure curl is available (Multi-SWE-RL images may lack it)
 command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl; }
 
-# Always install latest uv (sandbox images may have stale versions)
+# Always install latest uv (sandbox images may have stale versions). Pin
+# UV_INSTALL_DIR so the PATH export below agrees with where the installer
+# actually writes — on images that set XDG_DATA_HOME independent of HOME
+# (e.g. SWE-rebench-V2 python images with HOME=/root, XDG_DATA_HOME=
+# /workspace/.local/share), the astral installer resolves its target via
+# $XDG_DATA_HOME/../bin and lands uv there, while a $HOME-based PATH
+# export points at an empty dir and leaves uv off PATH.
+export UV_INSTALL_DIR="${UV_INSTALL_DIR:-$HOME/.local/bin}"
 curl -LsSf https://astral.sh/uv/install.sh | sh
-[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env" || export PATH="$HOME/.local/bin:$PATH"
+export PATH="$UV_INSTALL_DIR:$PATH"
 
 # Install ripgrep if missing
 command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq ripgrep; }


### PR DESCRIPTION
## Summary
Fixes an install-time failure on sandbox images that set `XDG_DATA_HOME` independent of `HOME`. The astral uv installer resolves its target in priority `UV_INSTALL_DIR` → `XDG_BIN_HOME` → `${XDG_DATA_HOME:-$HOME/.local/share}/../bin`, so on e.g. SWE-rebench-V2 python images (`HOME=/root`, `XDG_DATA_HOME=/workspace/.local/share`), `uv` lands at `/workspace/.local/bin/uv` while the old line 9 looked for `env` and exported PATH based on `$HOME`. `uv` never ended up on PATH, and line 46's `uv tool install ...` failed with exit 127:

```
installing to /workspace/.local/share/../bin
  uv
  uvx
everything's installed!
...
/tmp/rlm-checkout/install.sh: line 46: uv: command not found
```

## Fix
Export `UV_INSTALL_DIR` (defaulting to `$HOME/.local/bin`) before the `curl | sh`, so the installer writes uv to a location we've named, then export PATH pointing at the same variable. No more divergence between where the installer wrote and where PATH looks.

Also removes the brittle `[ -f X ] && . X || export Y` one-liner — the classic `a && b || c` shape silently falls through to `c` if `b` fails mid-way, a lurking footgun independent of this bug.

## Regression risk
Zero on images where the old code worked. `UV_INSTALL_DIR` defaults to `$HOME/.local/bin`, which is exactly where the installer was landing uv on working images (`$HOME/.local/share/../bin` == `$HOME/.local/bin`, minus the `..` indirection). Override-friendly: users or images that want uv elsewhere can pre-set `UV_INSTALL_DIR` and both the installer and the PATH export will track it.

## How I found it
Running `uv run vf-eval rlm-swe -a '{"task_type":"swerebench-v2"}' -n 5 -r 1 -s` against the new SWE-rebench-V2 TaskSet (PrimeIntellect-ai/verifiers#1187). 1/5 rollouts failed with `SandboxError: Agent install failed (exit=127)`; diagnosis in the linked PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the install script’s uv install/PATH wiring to avoid missing `uv` on images with differing `HOME`/`XDG_DATA_HOME`, with no runtime logic changes beyond tool setup.
> 
> **Overview**
> Fixes `install.sh` so `uv` is reliably on `PATH` even when `XDG_DATA_HOME` differs from `HOME`.
> 
> The script now exports `UV_INSTALL_DIR` (overrideable, defaulting to `$HOME/.local/bin`) before running the Astral installer and then sets `PATH` from that same variable, replacing the previous `$HOME`-based `env`/`PATH` one-liner that could point at the wrong directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c224978832986b647e2dbf58dcb84fb0367a4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->