### PR TITLE
install.sh: pin UV_TOOL_BIN_DIR so uv tool shims land on PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,15 @@ set -eo pipefail
 command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl; }
 
 # Always install latest uv (sandbox images may have stale versions). Pin
-# UV_INSTALL_DIR so the PATH export below agrees with where the installer
-# actually writes — on images that set XDG_DATA_HOME independent of HOME
-# (e.g. SWE-rebench-V2 python images with HOME=/root, XDG_DATA_HOME=
-# /workspace/.local/share), the astral installer resolves its target via
-# $XDG_DATA_HOME/../bin and lands uv there, while a $HOME-based PATH
-# export points at an empty dir and leaves uv off PATH.
+# UV_INSTALL_DIR (uv installer target) and UV_TOOL_BIN_DIR (`uv tool install`
+# shim target) to the same directory, and make the PATH export agree — on
+# images that set XDG_DATA_HOME independent of HOME (e.g. SWE-rebench-V2
+# python images with HOME=/root, XDG_DATA_HOME=/workspace/.local/share),
+# both uv and its tool shims otherwise resolve via $XDG_DATA_HOME/../bin
+# while a $HOME-based PATH export points at an empty dir — leaving `uv`
+# and any `uv tool install`-ed executables (e.g. `rlm`) off PATH.
 export UV_INSTALL_DIR="${UV_INSTALL_DIR:-$HOME/.local/bin}"
+export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$UV_INSTALL_DIR}"
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$UV_INSTALL_DIR:$PATH"
 


### PR DESCRIPTION
## Summary
Follow-up to #33. Resolving the uv-installer target location fixed `uv: command not found`, but the next stage of the script — `uv tool install --editable "$RLM_CHECKOUT" ...` — writes its *tool shims* using the same XDG-first resolution that the base installer used.

So on images where `XDG_DATA_HOME` diverges from `HOME` (e.g. SWE-rebench-V2 python images: `HOME=/root`, `XDG_DATA_HOME=/workspace/.local/share`), the `rlm` shim lands at `/workspace/.local/bin/rlm`, while `PATH` was exported from `$UV_INSTALL_DIR` (= `$HOME/.local/bin`). The agent launcher then crashes:

```
AgentError: Agent crashed before any LLM call (exit_code=127):
  bash: line 22: rlm: command not found
```

Verified empirically: `UV_TOOL_BIN_DIR` deterministically controls where `uv tool install` places executables:

```console
$ UV_TOOL_BIN_DIR=/tmp/uvtools uv tool install --python 3.10 ruff
Installed 1 executable: ruff
warning: `/tmp/uvtools` is not on your PATH.
$ ls /tmp/uvtools
ruff
```

## Fix
Pin `UV_TOOL_BIN_DIR` alongside `UV_INSTALL_DIR` to the same directory, so uv tool shims land where PATH already points. `${UV_TOOL_BIN_DIR:-$UV_INSTALL_DIR}` preserves caller override.

## Regression risk
Zero. On working images, `$UV_INSTALL_DIR=$HOME/.local/bin` and the default shim dir was already `$HOME/.local/bin` — so the shim path is unchanged. The only change is on images where the old fallback missed PATH; there the shim now lands on PATH.

## How I found it
Re-ran `uv run vf-eval rlm-swe -a '{"task_type":"swerebench-v2"}' -n 5 -r 1 -s` after #33 landed and the rlm-checkout cache was cleared. The old `SandboxError: uv: command not found` is gone; 4/5 rollouts are now clean `agent_completed` (reward=0, weak model). The remaining 1/5 (python wtforms image, the same row that hit #33) fails one step later with `AgentError: bash: line 22: rlm: command not found` — same class of bug applied to the tool-shim location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small install-script environment variable change that only affects where `uv tool install` writes shims, reducing PATH-related failures on some images.
> 
> **Overview**
> Ensures `uv tool install`-generated shims (e.g. `rlm`) are placed on `PATH` by default by exporting `UV_TOOL_BIN_DIR` to match `UV_INSTALL_DIR` in `install.sh`.
> 
> This avoids failures on environments where `XDG_DATA_HOME` causes uv to target a different bin directory than the `$HOME`-based `PATH` export, while still allowing callers to override either variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198bae594aaafa11d034a0dca2968df632a6cd8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->