### PR TITLE
Add builtin RLM tool metrics

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -223,6 +223,8 @@ class RLMEngine:
                     tool.execute, tool_args, self._tool_context(messages)
                 )
             duration = time.time() - t0
+            for event in tool_result.metric_events:
+                self._metrics.record(event)
 
             result = tool_result.content
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -72,10 +72,7 @@ class RLMEngine:
         self._last_prompt_tokens = 0
 
         # Metrics
-        self._metrics = RLMMetrics(
-            max_turns=self.max_turns,
-            max_tokens=self.max_tokens or 0,
-        )
+        self._metrics = RLMMetrics()
 
         self._tool_state = {"summarize": SummarizeState()}
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -21,6 +21,7 @@ from rlm.tools import (
     get_active_tools,
     get_builtin_tool,
     get_installed_skills,
+    summarize_drop_slice_bounds,
 )
 from rlm.types import RLMMetrics, RLMResult, TokenUsage
 
@@ -324,17 +325,7 @@ class RLMEngine:
 
     @staticmethod
     def _drop_turns(messages: list[dict], num_turns: int) -> None:
-        start = 0
-        while start < len(messages) and messages[start]["role"] != "assistant":
-            start += 1
-
-        end = start
-        for _ in range(num_turns):
-            if end >= len(messages) or messages[end]["role"] != "assistant":
-                break
-            end += 1
-            while end < len(messages) and messages[end]["role"] == "tool":
-                end += 1
+        start, end = summarize_drop_slice_bounds(messages, num_turns)
         del messages[start:end]
 
     @staticmethod

--- a/src/rlm/tools/__init__.py
+++ b/src/rlm/tools/__init__.py
@@ -4,13 +4,14 @@ from rlm.tools.base import BuiltinTool, ToolContext, ToolOutcome
 from rlm.tools.ipython import IPythonREPL
 from rlm.tools.registry import get_active_tools, get_builtin_tool
 from rlm.tools.skills import SKILLS_DIR, TASK_SKILLS_DIR, get_installed_skills
-from rlm.tools.summarize import SummarizeState
+from rlm.tools.summarize import SummarizeState, summarize_drop_slice_bounds
 
 __all__ = [
     "BuiltinTool",
     "IPythonREPL",
     "SKILLS_DIR",
     "SummarizeState",
+    "summarize_drop_slice_bounds",
     "TASK_SKILLS_DIR",
     "ToolContext",
     "ToolOutcome",

--- a/src/rlm/tools/base.py
+++ b/src/rlm/tools/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from rlm.types import RLMMetrics, TokenUsage
+from rlm.types import BuiltinMetricEvent, RLMMetrics, TokenUsage
 
 
 @dataclass
@@ -15,6 +15,7 @@ class ToolOutcome:
     content: str
     drop_turns: int = 0
     flush_repl_state: bool = False
+    metric_events: list[BuiltinMetricEvent] = field(default_factory=list)
 
 
 @dataclass

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
 from rlm.tools.skills import TASK_SKILLS_DIR
+from rlm.types import BuiltinToolCalled, IpythonExecuted
 
 if TYPE_CHECKING:
     from rlm.session import Session
@@ -71,6 +72,12 @@ class IpythonTool:
         code = args.get("code", "")
         if not isinstance(code, str):
             code = str(code)
+        input_chars = len(code)
+        input_loc = self._count_nonempty_lines(code)
+        metric_events = [
+            BuiltinToolCalled(self.name),
+            IpythonExecuted(input_chars=input_chars, input_loc=input_loc),
+        ]
 
         timeout = args.get("timeout")
         if timeout is None:
@@ -83,9 +90,19 @@ class IpythonTool:
         timeout = min(timeout, IPYTHON_TIMEOUT_MAX_SECONDS)
 
         if context.repl is None:
-            return ToolOutcome(content="Error: IPython REPL is not available")
+            return ToolOutcome(
+                content="Error: IPython REPL is not available",
+                metric_events=metric_events,
+            )
 
-        return ToolOutcome(content=context.repl.execute(code, timeout=timeout))
+        return ToolOutcome(
+            content=context.repl.execute(code, timeout=timeout),
+            metric_events=metric_events,
+        )
+
+    @staticmethod
+    def _count_nonempty_lines(code: str) -> int:
+        return sum(1 for line in code.splitlines() if line.strip())
 
 
 class IPythonREPL:

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
 from rlm.tools.skills import TASK_SKILLS_DIR
-from rlm.types import BuiltinToolCalled, IpythonExecuted
+from rlm.types import IpythonExecuted
 
 if TYPE_CHECKING:
     from rlm.session import Session
@@ -74,10 +74,7 @@ class IpythonTool:
             code = str(code)
         input_chars = len(code)
         input_loc = self._count_nonempty_lines(code)
-        metric_events = [
-            BuiltinToolCalled(self.name),
-            IpythonExecuted(input_chars=input_chars, input_loc=input_loc),
-        ]
+        metric_events = [IpythonExecuted(input_chars=input_chars, input_loc=input_loc)]
 
         timeout = args.get("timeout")
         if timeout is None:

--- a/src/rlm/tools/summarize.py
+++ b/src/rlm/tools/summarize.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
+from rlm.types import BuiltinToolCalled, SummarizeApplied, SummarizeRejected
 
 
 SUMMARIZE_SCHEMA = {
@@ -70,48 +71,31 @@ class SummarizeTool:
         summary = self._as_text(args.get("summary", ""))
         flush_repl_state = bool(args.get("flush_repl_state", False))
         droppable = self._count_droppable_turns(context.messages)
+        builtin_call = BuiltinToolCalled(self.name)
 
         if not isinstance(num_turns, int) or num_turns <= 0:
-            context.metrics.summarize_rejected_count += 1
             return ToolOutcome(
                 content=(
                     "[no-op] num_turns is required and must be > 0 "
                     f"(got {num_turns}). No context was dropped."
-                )
+                ),
+                metric_events=[builtin_call, SummarizeRejected()],
             )
         if num_turns > droppable:
-            context.metrics.summarize_rejected_count += 1
             return ToolOutcome(
                 content=(
                     f"[no-op] num_turns={num_turns} exceeds droppable turns "
                     f"({droppable}). No context was dropped."
-                )
+                ),
+                metric_events=[builtin_call, SummarizeRejected()],
             )
 
-        context.metrics.summarize_count += 1
-        context.metrics.summarize_prompt_tokens_before.append(
-            context.last_prompt_tokens
+        summary_chars = len(summary)
+        dropped_messages = self._dropped_message_slice(context.messages, num_turns)
+        dropped_chars = self._count_content_chars(dropped_messages)
+        prompt_tokens_dropped, completion_tokens_dropped = self._estimate_tokens_dropped(
+            context, num_turns
         )
-        context.metrics.summarize_completion_tokens_before.append(
-            context.total_usage.completion_tokens
-        )
-        context.metrics.turns_between_summarizes.append(
-            context.metrics.turns_since_last_summarize
-        )
-        context.metrics.summarize_summary_lengths.append(len(summary))
-        context.metrics.summarize_total_turns_dropped += num_turns
-
-        if context.metrics.turns > 0:
-            prompt_per_turn = context.last_prompt_tokens / context.metrics.turns
-            completion_per_turn = (
-                context.total_usage.completion_tokens / context.metrics.turns
-            )
-            context.metrics.summarize_prompt_tokens_dropped.append(
-                int(prompt_per_turn * num_turns)
-            )
-            context.metrics.summarize_completion_tokens_dropped.append(
-                int(completion_per_turn * num_turns)
-            )
 
         state.turn_at_last_summarize = context.metrics.turns
         start = state.dropped_turn_count
@@ -123,6 +107,19 @@ class SummarizeTool:
             content="\n\n".join(state.summaries),
             drop_turns=num_turns,
             flush_repl_state=flush_repl_state,
+            metric_events=[
+                builtin_call,
+                SummarizeApplied(
+                    num_turns=num_turns,
+                    summary_chars=summary_chars,
+                    dropped_chars=dropped_chars,
+                    prompt_tokens_before=context.last_prompt_tokens,
+                    completion_tokens_before=context.total_usage.completion_tokens,
+                    prompt_tokens_dropped=prompt_tokens_dropped,
+                    completion_tokens_dropped=completion_tokens_dropped,
+                    turns_since_last_summarize=context.metrics.turns_since_last_summarize,
+                ),
+            ],
         )
 
     @staticmethod
@@ -134,3 +131,84 @@ class SummarizeTool:
     @staticmethod
     def _as_text(value: Any) -> str:
         return value if isinstance(value, str) else str(value)
+
+    @classmethod
+    def _dropped_message_slice(
+        cls, messages: list[dict[str, Any]], num_turns: int
+    ) -> list[dict[str, Any]]:
+        start = 0
+        while start < len(messages) and messages[start]["role"] != "assistant":
+            start += 1
+
+        end = start
+        for _ in range(num_turns):
+            if end >= len(messages) or messages[end]["role"] != "assistant":
+                break
+            end += 1
+            while end < len(messages) and messages[end]["role"] == "tool":
+                end += 1
+        return messages[start:end]
+
+    @classmethod
+    def _count_content_chars(cls, messages: list[dict[str, Any]]) -> int:
+        return sum(cls._message_chars(message) for message in messages)
+
+    @classmethod
+    def _message_chars(cls, message: dict[str, Any]) -> int:
+        total = cls._content_chars(message.get("content"))
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list):
+            total += sum(cls._tool_call_chars(tool_call) for tool_call in tool_calls)
+        return total
+
+    @classmethod
+    def _content_chars(cls, content: Any) -> int:
+        if isinstance(content, str):
+            return len(content)
+        if isinstance(content, list):
+            return sum(cls._content_chars(item) for item in content)
+        if isinstance(content, dict):
+            total = 0
+            for field in ("text", "input_text", "output_text"):
+                value = content.get(field)
+                if isinstance(value, str):
+                    total += len(value)
+            nested_content = content.get("content")
+            if nested_content is not None:
+                total += cls._content_chars(nested_content)
+            return total
+        return 0
+
+    @classmethod
+    def _tool_call_chars(cls, tool_call: Any) -> int:
+        if isinstance(tool_call, dict):
+            function = tool_call.get("function")
+        else:
+            function = getattr(tool_call, "function", None)
+        if function is None:
+            return 0
+        if isinstance(function, dict):
+            name = function.get("name")
+            arguments = function.get("arguments")
+        else:
+            name = getattr(function, "name", None)
+            arguments = getattr(function, "arguments", None)
+        total = 0
+        if name is not None:
+            total += len(cls._as_text(name))
+        if arguments is not None:
+            total += len(cls._as_text(arguments))
+        return total
+
+    @staticmethod
+    def _estimate_tokens_dropped(
+        context: ToolContext, num_turns: int
+    ) -> tuple[int, int]:
+        if context.metrics.turns <= 0:
+            return 0, 0
+        prompt_per_turn = context.last_prompt_tokens / context.metrics.turns
+        completion_per_turn = context.total_usage.completion_tokens / context.metrics.turns
+        return (
+            int(prompt_per_turn * num_turns),
+            int(completion_per_turn * num_turns),
+        )

--- a/src/rlm/tools/summarize.py
+++ b/src/rlm/tools/summarize.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
-from rlm.types import BuiltinToolCalled, SummarizeApplied, SummarizeRejected
+from rlm.types import SummarizeApplied, SummarizeRejected
 
 
 SUMMARIZE_SCHEMA = {
@@ -71,7 +71,6 @@ class SummarizeTool:
         summary = self._as_text(args.get("summary", ""))
         flush_repl_state = bool(args.get("flush_repl_state", False))
         droppable = self._count_droppable_turns(context.messages)
-        builtin_call = BuiltinToolCalled(self.name)
 
         if not isinstance(num_turns, int) or num_turns <= 0:
             return ToolOutcome(
@@ -79,7 +78,7 @@ class SummarizeTool:
                     "[no-op] num_turns is required and must be > 0 "
                     f"(got {num_turns}). No context was dropped."
                 ),
-                metric_events=[builtin_call, SummarizeRejected()],
+                metric_events=[SummarizeRejected()],
             )
         if num_turns > droppable:
             return ToolOutcome(
@@ -87,15 +86,12 @@ class SummarizeTool:
                     f"[no-op] num_turns={num_turns} exceeds droppable turns "
                     f"({droppable}). No context was dropped."
                 ),
-                metric_events=[builtin_call, SummarizeRejected()],
+                metric_events=[SummarizeRejected()],
             )
 
         summary_chars = len(summary)
         dropped_messages = self._dropped_message_slice(context.messages, num_turns)
         dropped_chars = self._count_content_chars(dropped_messages)
-        prompt_tokens_dropped, completion_tokens_dropped = self._estimate_tokens_dropped(
-            context, num_turns
-        )
 
         state.turn_at_last_summarize = context.metrics.turns
         start = state.dropped_turn_count
@@ -108,15 +104,10 @@ class SummarizeTool:
             drop_turns=num_turns,
             flush_repl_state=flush_repl_state,
             metric_events=[
-                builtin_call,
                 SummarizeApplied(
                     num_turns=num_turns,
                     summary_chars=summary_chars,
                     dropped_chars=dropped_chars,
-                    prompt_tokens_before=context.last_prompt_tokens,
-                    completion_tokens_before=context.total_usage.completion_tokens,
-                    prompt_tokens_dropped=prompt_tokens_dropped,
-                    completion_tokens_dropped=completion_tokens_dropped,
                     turns_since_last_summarize=context.metrics.turns_since_last_summarize,
                 ),
             ],
@@ -199,16 +190,3 @@ class SummarizeTool:
         if arguments is not None:
             total += len(cls._as_text(arguments))
         return total
-
-    @staticmethod
-    def _estimate_tokens_dropped(
-        context: ToolContext, num_turns: int
-    ) -> tuple[int, int]:
-        if context.metrics.turns <= 0:
-            return 0, 0
-        prompt_per_turn = context.last_prompt_tokens / context.metrics.turns
-        completion_per_turn = context.total_usage.completion_tokens / context.metrics.turns
-        return (
-            int(prompt_per_turn * num_turns),
-            int(completion_per_turn * num_turns),
-        )

--- a/src/rlm/tools/summarize.py
+++ b/src/rlm/tools/summarize.py
@@ -53,6 +53,24 @@ class SummarizeState:
     turn_at_last_summarize: int = 0
 
 
+def summarize_drop_slice_bounds(
+    messages: list[dict[str, Any]], num_turns: int
+) -> tuple[int, int]:
+    """Return the message slice that would be dropped for ``num_turns``."""
+    start = 0
+    while start < len(messages) and messages[start]["role"] != "assistant":
+        start += 1
+
+    end = start
+    for _ in range(num_turns):
+        if end >= len(messages) or messages[end]["role"] != "assistant":
+            break
+        end += 1
+        while end < len(messages) and messages[end]["role"] == "tool":
+            end += 1
+    return start, end
+
+
 class SummarizeTool:
     """Builtin tool handler for context summarization."""
 
@@ -127,17 +145,7 @@ class SummarizeTool:
     def _dropped_message_slice(
         cls, messages: list[dict[str, Any]], num_turns: int
     ) -> list[dict[str, Any]]:
-        start = 0
-        while start < len(messages) and messages[start]["role"] != "assistant":
-            start += 1
-
-        end = start
-        for _ in range(num_turns):
-            if end >= len(messages) or messages[end]["role"] != "assistant":
-                break
-            end += 1
-            while end < len(messages) and messages[end]["role"] == "tool":
-                end += 1
+        start, end = summarize_drop_slice_bounds(messages, num_turns)
         return messages[start:end]
 
     @classmethod

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -45,24 +45,28 @@ class RLMMetrics:
 
     # Turn metrics
     turns_since_last_summarize: int = 0
-    turns_between_summarizes: list[int] = field(default_factory=list)
+    turns_between_summarizes_mean: float = 0.0
 
     # Summarize metrics
     summarize_rejected_count: int = 0
-    summarize_turns_dropped_total: int = 0
-    summarize_summary_lengths: list[int] = field(default_factory=list)
-    summarize_chars_dropped_total: int = 0
-    summarize_summary_chars_total: int = 0
+    summarize_turns_dropped_mean: float = 0.0
+    summarize_chars_dropped_mean: float = 0.0
+    summarize_summary_chars_mean: float = 0.0
 
     # IPython input size metrics
-    ipython_input_chars_total: int = 0
     ipython_input_chars_mean: float = 0.0
-    ipython_input_loc_total: int = 0
     ipython_input_loc_mean: float = 0.0
 
     # Internal counters for derived metrics
     _turns: int = field(default=0, repr=False)
     _ipython_call_count: int = field(default=0, repr=False)
+    _ipython_input_chars_total: int = field(default=0, repr=False)
+    _ipython_input_loc_total: int = field(default=0, repr=False)
+    _summarize_applied_count: int = field(default=0, repr=False)
+    _turns_between_summarizes_total: int = field(default=0, repr=False)
+    _summarize_turns_dropped_total: int = field(default=0, repr=False)
+    _summarize_chars_dropped_total: int = field(default=0, repr=False)
+    _summarize_summary_chars_total: int = field(default=0, repr=False)
 
     # This agent's token usage
     prompt_tokens: int = 0
@@ -91,32 +95,42 @@ class RLMMetrics:
     def record(self, event: BuiltinMetricEvent) -> None:
         if isinstance(event, IpythonExecuted):
             self._ipython_call_count += 1
-            self.ipython_input_chars_total += event.input_chars
-            self.ipython_input_loc_total += event.input_loc
+            self._ipython_input_chars_total += event.input_chars
+            self._ipython_input_loc_total += event.input_loc
         elif isinstance(event, SummarizeRejected):
             self.summarize_rejected_count += 1
         elif isinstance(event, SummarizeApplied):
-            self.turns_between_summarizes.append(event.turns_since_last_summarize)
-            self.summarize_turns_dropped_total += event.num_turns
-            self.summarize_summary_lengths.append(event.summary_chars)
-            self.summarize_chars_dropped_total += event.dropped_chars
-            self.summarize_summary_chars_total += event.summary_chars
+            self._summarize_applied_count += 1
+            self._turns_between_summarizes_total += event.turns_since_last_summarize
+            self._summarize_turns_dropped_total += event.num_turns
+            self._summarize_chars_dropped_total += event.dropped_chars
+            self._summarize_summary_chars_total += event.summary_chars
         else:
             raise TypeError(f"Unsupported builtin metric event: {type(event)!r}")
 
         self._refresh_derived_metrics()
 
     def _refresh_derived_metrics(self) -> None:
-        self.ipython_input_chars_mean = (
-            self.ipython_input_chars_total / self._ipython_call_count
-            if self._ipython_call_count
-            else 0.0
-        )
-        self.ipython_input_loc_mean = (
-            self.ipython_input_loc_total / self._ipython_call_count
-            if self._ipython_call_count
-            else 0.0
-        )
+        if self._ipython_call_count:
+            self.ipython_input_chars_mean = (
+                self._ipython_input_chars_total / self._ipython_call_count
+            )
+            self.ipython_input_loc_mean = (
+                self._ipython_input_loc_total / self._ipython_call_count
+            )
+        if self._summarize_applied_count:
+            self.turns_between_summarizes_mean = (
+                self._turns_between_summarizes_total / self._summarize_applied_count
+            )
+            self.summarize_turns_dropped_mean = (
+                self._summarize_turns_dropped_total / self._summarize_applied_count
+            )
+            self.summarize_chars_dropped_mean = (
+                self._summarize_chars_dropped_total / self._summarize_applied_count
+            )
+            self.summarize_summary_chars_mean = (
+                self._summarize_summary_chars_total / self._summarize_applied_count
+            )
 
     def to_dict(self) -> dict[str, Any]:
         self._refresh_derived_metrics()

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -144,10 +144,7 @@ class RLMMetrics:
 
     def to_dict(self) -> dict[str, Any]:
         self._refresh_derived_metrics()
-        data = asdict(self)
-        data["ipython_input_chars_mean"] = self.ipython_input_chars_mean
-        data["ipython_input_loc_mean"] = self.ipython_input_loc_mean
-        return data
+        return asdict(self)
 
 
 @dataclass

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -1,7 +1,10 @@
 """Core data types."""
 
+from __future__ import annotations
+
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Any
 
 
 @dataclass
@@ -12,6 +15,39 @@ class TokenUsage:
     @property
     def total(self) -> int:
         return self.prompt_tokens + self.completion_tokens
+
+
+@dataclass(frozen=True)
+class BuiltinToolCalled:
+    name: str
+
+
+@dataclass(frozen=True)
+class IpythonExecuted:
+    input_chars: int
+    input_loc: int
+
+
+@dataclass(frozen=True)
+class SummarizeRejected:
+    pass
+
+
+@dataclass(frozen=True)
+class SummarizeApplied:
+    num_turns: int
+    summary_chars: int
+    dropped_chars: int
+    prompt_tokens_before: int
+    completion_tokens_before: int
+    prompt_tokens_dropped: int
+    completion_tokens_dropped: int
+    turns_since_last_summarize: int
+
+
+BuiltinMetricEvent = (
+    BuiltinToolCalled | IpythonExecuted | SummarizeRejected | SummarizeApplied
+)
 
 
 @dataclass
@@ -26,8 +62,19 @@ class RLMMetrics:
     # Summarize metrics
     summarize_count: int = 0
     summarize_rejected_count: int = 0
+    summarize_calls: int = 0
     summarize_total_turns_dropped: int = 0
     summarize_summary_lengths: list[int] = field(default_factory=list)
+    summarize_chars_dropped_total: int = 0
+    summarize_summary_chars_total: int = 0
+
+    # Builtin tool metrics
+    builtin_tool_calls_total: int = 0
+    ipython_calls: int = 0
+    ipython_input_chars_total: int = 0
+    ipython_input_chars_mean: float = 0.0
+    ipython_input_loc_total: int = 0
+    ipython_input_loc_mean: float = 0.0
 
     # Token metrics before/dropped per summarize
     summarize_prompt_tokens_before: list[int] = field(default_factory=list)
@@ -54,8 +101,56 @@ class RLMMetrics:
     max_tokens: int = 0
     stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "context_limit", "depth_limit"
 
-    def to_dict(self) -> dict:
-        return asdict(self)
+    def record(self, event: BuiltinMetricEvent) -> None:
+        if isinstance(event, BuiltinToolCalled):
+            self.builtin_tool_calls_total += 1
+            if event.name == "ipython":
+                self.ipython_calls += 1
+            elif event.name == "summarize":
+                self.summarize_calls += 1
+                self.summarize_count += 1
+        elif isinstance(event, IpythonExecuted):
+            self.ipython_input_chars_total += event.input_chars
+            self.ipython_input_loc_total += event.input_loc
+        elif isinstance(event, SummarizeRejected):
+            self.summarize_rejected_count += 1
+        elif isinstance(event, SummarizeApplied):
+            self.turns_between_summarizes.append(event.turns_since_last_summarize)
+            self.summarize_total_turns_dropped += event.num_turns
+            self.summarize_summary_lengths.append(event.summary_chars)
+            self.summarize_chars_dropped_total += event.dropped_chars
+            self.summarize_summary_chars_total += event.summary_chars
+            self.summarize_prompt_tokens_before.append(event.prompt_tokens_before)
+            self.summarize_completion_tokens_before.append(
+                event.completion_tokens_before
+            )
+            self.summarize_prompt_tokens_dropped.append(event.prompt_tokens_dropped)
+            self.summarize_completion_tokens_dropped.append(
+                event.completion_tokens_dropped
+            )
+        else:
+            raise TypeError(f"Unsupported builtin metric event: {type(event)!r}")
+
+        self._refresh_derived_metrics()
+
+    def _refresh_derived_metrics(self) -> None:
+        self.ipython_input_chars_mean = (
+            self.ipython_input_chars_total / self.ipython_calls
+            if self.ipython_calls
+            else 0.0
+        )
+        self.ipython_input_loc_mean = (
+            self.ipython_input_loc_total / self.ipython_calls
+            if self.ipython_calls
+            else 0.0
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        self._refresh_derived_metrics()
+        data = asdict(self)
+        data["ipython_input_chars_mean"] = self.ipython_input_chars_mean
+        data["ipython_input_loc_mean"] = self.ipython_input_loc_mean
+        return data
 
 
 @dataclass

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -18,11 +18,6 @@ class TokenUsage:
 
 
 @dataclass(frozen=True)
-class BuiltinToolCalled:
-    name: str
-
-
-@dataclass(frozen=True)
 class IpythonExecuted:
     input_chars: int
     input_loc: int
@@ -38,16 +33,10 @@ class SummarizeApplied:
     num_turns: int
     summary_chars: int
     dropped_chars: int
-    prompt_tokens_before: int
-    completion_tokens_before: int
-    prompt_tokens_dropped: int
-    completion_tokens_dropped: int
     turns_since_last_summarize: int
 
 
-BuiltinMetricEvent = (
-    BuiltinToolCalled | IpythonExecuted | SummarizeRejected | SummarizeApplied
-)
+BuiltinMetricEvent = IpythonExecuted | SummarizeRejected | SummarizeApplied
 
 
 @dataclass
@@ -60,26 +49,20 @@ class RLMMetrics:
     turns_between_summarizes: list[int] = field(default_factory=list)
 
     # Summarize metrics
-    summarize_count: int = 0
     summarize_rejected_count: int = 0
-    summarize_total_turns_dropped: int = 0
+    summarize_turns_dropped_total: int = 0
     summarize_summary_lengths: list[int] = field(default_factory=list)
     summarize_chars_dropped_total: int = 0
     summarize_summary_chars_total: int = 0
 
-    # Builtin tool metrics
-    builtin_tool_calls_total: int = 0
-    ipython_calls: int = 0
+    # IPython input size metrics
     ipython_input_chars_total: int = 0
     ipython_input_chars_mean: float = 0.0
     ipython_input_loc_total: int = 0
     ipython_input_loc_mean: float = 0.0
 
-    # Token metrics before/dropped per summarize
-    summarize_prompt_tokens_before: list[int] = field(default_factory=list)
-    summarize_completion_tokens_before: list[int] = field(default_factory=list)
-    summarize_prompt_tokens_dropped: list[int] = field(default_factory=list)
-    summarize_completion_tokens_dropped: list[int] = field(default_factory=list)
+    # Internal counters for derived metrics
+    _ipython_call_count: int = field(default=0, repr=False)
 
     # This agent's token usage
     prompt_tokens: int = 0
@@ -95,36 +78,21 @@ class RLMMetrics:
     sub_rlm_completion_tokens: int = 0
     sub_rlm_count: int = 0
 
-    # Budget tracking
-    max_turns: int = 0
-    max_tokens: int = 0
     stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "context_limit", "depth_limit"
 
     def record(self, event: BuiltinMetricEvent) -> None:
-        if isinstance(event, BuiltinToolCalled):
-            self.builtin_tool_calls_total += 1
-            if event.name == "ipython":
-                self.ipython_calls += 1
-        elif isinstance(event, IpythonExecuted):
+        if isinstance(event, IpythonExecuted):
+            self._ipython_call_count += 1
             self.ipython_input_chars_total += event.input_chars
             self.ipython_input_loc_total += event.input_loc
         elif isinstance(event, SummarizeRejected):
             self.summarize_rejected_count += 1
         elif isinstance(event, SummarizeApplied):
-            self.summarize_count += 1
             self.turns_between_summarizes.append(event.turns_since_last_summarize)
-            self.summarize_total_turns_dropped += event.num_turns
+            self.summarize_turns_dropped_total += event.num_turns
             self.summarize_summary_lengths.append(event.summary_chars)
             self.summarize_chars_dropped_total += event.dropped_chars
             self.summarize_summary_chars_total += event.summary_chars
-            self.summarize_prompt_tokens_before.append(event.prompt_tokens_before)
-            self.summarize_completion_tokens_before.append(
-                event.completion_tokens_before
-            )
-            self.summarize_prompt_tokens_dropped.append(event.prompt_tokens_dropped)
-            self.summarize_completion_tokens_dropped.append(
-                event.completion_tokens_dropped
-            )
         else:
             raise TypeError(f"Unsupported builtin metric event: {type(event)!r}")
 
@@ -132,19 +100,21 @@ class RLMMetrics:
 
     def _refresh_derived_metrics(self) -> None:
         self.ipython_input_chars_mean = (
-            self.ipython_input_chars_total / self.ipython_calls
-            if self.ipython_calls
+            self.ipython_input_chars_total / self._ipython_call_count
+            if self._ipython_call_count
             else 0.0
         )
         self.ipython_input_loc_mean = (
-            self.ipython_input_loc_total / self.ipython_calls
-            if self.ipython_calls
+            self.ipython_input_loc_total / self._ipython_call_count
+            if self._ipython_call_count
             else 0.0
         )
 
     def to_dict(self) -> dict[str, Any]:
         self._refresh_derived_metrics()
-        return asdict(self)
+        return {
+            key: value for key, value in asdict(self).items() if not key.startswith("_")
+        }
 
 
 @dataclass

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -62,7 +62,6 @@ class RLMMetrics:
     # Summarize metrics
     summarize_count: int = 0
     summarize_rejected_count: int = 0
-    summarize_calls: int = 0
     summarize_total_turns_dropped: int = 0
     summarize_summary_lengths: list[int] = field(default_factory=list)
     summarize_chars_dropped_total: int = 0
@@ -106,15 +105,13 @@ class RLMMetrics:
             self.builtin_tool_calls_total += 1
             if event.name == "ipython":
                 self.ipython_calls += 1
-            elif event.name == "summarize":
-                self.summarize_calls += 1
-                self.summarize_count += 1
         elif isinstance(event, IpythonExecuted):
             self.ipython_input_chars_total += event.input_chars
             self.ipython_input_loc_total += event.input_loc
         elif isinstance(event, SummarizeRejected):
             self.summarize_rejected_count += 1
         elif isinstance(event, SummarizeApplied):
+            self.summarize_count += 1
             self.turns_between_summarizes.append(event.turns_since_last_summarize)
             self.summarize_total_turns_dropped += event.num_turns
             self.summarize_summary_lengths.append(event.summary_chars)

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -44,7 +44,6 @@ class RLMMetrics:
     """Metrics tracked during an rlm session."""
 
     # Turn metrics
-    turns: int = 0
     turns_since_last_summarize: int = 0
     turns_between_summarizes: list[int] = field(default_factory=list)
 
@@ -62,6 +61,7 @@ class RLMMetrics:
     ipython_input_loc_mean: float = 0.0
 
     # Internal counters for derived metrics
+    _turns: int = field(default=0, repr=False)
     _ipython_call_count: int = field(default=0, repr=False)
 
     # This agent's token usage
@@ -79,6 +79,14 @@ class RLMMetrics:
     sub_rlm_count: int = 0
 
     stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "context_limit", "depth_limit"
+
+    @property
+    def turns(self) -> int:
+        return self._turns
+
+    @turns.setter
+    def turns(self, value: int) -> None:
+        self._turns = value
 
     def record(self, event: BuiltinMetricEvent) -> None:
         if isinstance(event, IpythonExecuted):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `RLMMetrics` is computed/serialized and wires tool execution to emit metric events, which could affect downstream consumers of session `meta.json` metrics and summarize-turn dropping behavior.
> 
> **Overview**
> Adds an event-based builtin tool metrics pipeline: tools now return `ToolOutcome.metric_events`, `RLMEngine` records them via `RLMMetrics.record()`, and `RLMMetrics` is refactored to store internal counters and expose derived mean stats in `to_dict()`.
> 
> Enhances builtin tools to emit metrics: `ipython` reports input size (chars/LOC) per call, and `summarize` reports applied/rejected outcomes plus estimated dropped/summary character counts; summarize’s drop-slice calculation is centralized as `summarize_drop_slice_bounds()` and reused by the engine when pruning context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8524279f7d5220f7fa8496d2201fc0b9295b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->