### PR TITLE
Accept git worktrees in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq 
 RLM_REPO_URL="${RLM_REPO_URL:-github.com/PrimeIntellect-ai/rlm.git}"
 RLM_REPO_BRANCH="${RLM_REPO_BRANCH:-main}"
 RLM_CHECKOUT="${RLM_CHECKOUT_PATH:-/tmp/rlm-checkout}"
-if ! git -C "$RLM_CHECKOUT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [ ! -f "$RLM_CHECKOUT/install.sh" ] || [ ! -f "$RLM_CHECKOUT/pyproject.toml" ]; then
     case "$RLM_REPO_URL" in
         https://*|http://*)
             CLONE_URL="$RLM_REPO_URL"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ command -v rg >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq 
 RLM_REPO_URL="${RLM_REPO_URL:-github.com/PrimeIntellect-ai/rlm.git}"
 RLM_REPO_BRANCH="${RLM_REPO_BRANCH:-main}"
 RLM_CHECKOUT="${RLM_CHECKOUT_PATH:-/tmp/rlm-checkout}"
-if [ ! -d "$RLM_CHECKOUT/.git" ]; then
+if ! git -C "$RLM_CHECKOUT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     case "$RLM_REPO_URL" in
         https://*|http://*)
             CLONE_URL="$RLM_REPO_URL"


### PR DESCRIPTION
## Summary

- Make `rlm`'s install script accept uploaded git worktrees as valid checkouts
- Reason: [verifiers PR#1202](https://github.com/PrimeIntellect-ai/verifiers/pull/1202) uses git worktrees to cache the resolved commit for a given `rlm_ref` (branch/tag/full SHA) and upload that checkout to sandboxes, while allowing newer runs to pick up newer branch commits without affecting ongoing rollouts

## Changes

- replace the `.git` directory check with `git rev-parse --is-inside-work-tree`
- keep the existing fallback clone behavior for missing or invalid checkouts
- fix sandbox installs when the uploaded host cache checkout is a git worktree

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to install-time checkout validation logic; main risk is false positives/negatives when non-repo directories coincidentally contain those files.
> 
> **Overview**
> Updates `install.sh` to treat an existing checkout as valid when it contains the expected project files (`install.sh` and `pyproject.toml`), instead of requiring a `.git` directory.
> 
> This allows installs to reuse uploaded/cached git worktree checkouts while preserving the current behavior of recloning into `RLM_CHECKOUT` when the checkout is missing or invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e44c7761c70b6a15c6d7c8d8e6693f349192b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->