### PR TITLE
Add token metrics

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -153,12 +153,15 @@ class RLMEngine:
             self._total_usage.completion_tokens += usage.completion_tokens
             self._last_prompt_tokens = usage.prompt_tokens
 
-            # Record per-turn token counts
-            # TODO: verify tool_result token accounting with a self-hosted model + vLLM,
-            # where we can inspect the tokenizer directly (OpenAI encodes tool schemas as
-            # TypeScript internally, making tiktoken-based reconstruction imprecise).
-            self._metrics.prompt_tokens_per_turn.append(usage.prompt_tokens)
-            self._metrics.completion_tokens_per_turn.append(usage.completion_tokens)
+            # Record root usage and assistant-visible context for this turn.
+            self._metrics.note_root_usage(
+                self._total_usage.prompt_tokens,
+                self._total_usage.completion_tokens,
+            )
+            self._metrics.note_assistant_turn(
+                usage.prompt_tokens,
+                usage.completion_tokens,
+            )
 
             # Update metrics
             self._metrics.turns = turn + 1
@@ -166,8 +169,6 @@ class RLMEngine:
             self._metrics.turns_since_last_summarize = (
                 turn + 1
             ) - summarize_state.turn_at_last_summarize
-            self._metrics.prompt_tokens = self._total_usage.prompt_tokens
-            self._metrics.completion_tokens = self._total_usage.completion_tokens
 
             msg = response.choices[0].message
             msg_dict = msg.model_dump(exclude_none=True)

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -62,34 +62,52 @@ class Session:
     def log_sub_spawn(self, child_name: str, command: str):
         self.log({"type": "sub_spawn", "child_dir": child_name, "command": command})
 
-    def aggregate_child_metrics(self) -> tuple[int, int, int]:
-        """Read all sub-*/meta.json and sum their token usage.
-
-        Returns (sub_prompt_tokens, sub_completion_tokens, sub_count).
-        """
-        sub_prompt = 0
-        sub_completion = 0
-        sub_count = 0
+    def aggregate_child_metrics(self) -> dict[str, int]:
+        """Read all sub-*/meta.json and aggregate recursive session totals."""
+        totals = {
+            "session_count": 0,
+            "input_tokens_total": 0,
+            "output_tokens_total": 0,
+            "final_input_tokens_total": 0,
+            "final_output_tokens_total": 0,
+            "branch_count": 0,
+            "branch_input_tokens_sum": 0,
+            "branch_input_tokens_max": 0,
+            "branch_output_tokens_sum": 0,
+            "branch_output_tokens_max": 0,
+        }
 
         for child_dir in self.dir.glob("sub-*"):
             meta_path = child_dir / "meta.json"
             if meta_path.exists():
                 with open(meta_path) as f:
                     meta = json.load(f)
-                usage = meta.get("usage", {})
-                metrics = meta.get("metrics", {})
+                stats = meta.get("context_token_stats")
+                if not isinstance(stats, dict):
+                    raise RuntimeError(
+                        f"Missing context_token_stats in child session meta: {meta_path}"
+                    )
+                for key in (
+                    "session_count",
+                    "input_tokens_total",
+                    "output_tokens_total",
+                    "final_input_tokens_total",
+                    "final_output_tokens_total",
+                    "branch_count",
+                    "branch_input_tokens_sum",
+                    "branch_output_tokens_sum",
+                ):
+                    totals[key] += int(stats.get(key, 0))
+                totals["branch_input_tokens_max"] = max(
+                    totals["branch_input_tokens_max"],
+                    int(stats.get("branch_input_tokens_max", 0)),
+                )
+                totals["branch_output_tokens_max"] = max(
+                    totals["branch_output_tokens_max"],
+                    int(stats.get("branch_output_tokens_max", 0)),
+                )
 
-                # This child's direct usage
-                sub_prompt += usage.get("prompt_tokens", 0)
-                sub_completion += usage.get("completion_tokens", 0)
-                sub_count += 1
-
-                # Plus its children's usage (recursive aggregation)
-                sub_prompt += metrics.get("sub_rlm_prompt_tokens", 0)
-                sub_completion += metrics.get("sub_rlm_completion_tokens", 0)
-                sub_count += metrics.get("sub_rlm_count", 0)
-
-        return sub_prompt, sub_completion, sub_count
+        return totals
 
     def finalize(
         self, answer: str, usage: dict | None = None, turns: int = 0, metrics=None
@@ -103,16 +121,15 @@ class Session:
 
         # Aggregate child sub-RLM metrics
         if metrics is not None:
-            sub_prompt, sub_completion, sub_count = self.aggregate_child_metrics()
-            metrics.sub_rlm_prompt_tokens = sub_prompt
-            metrics.sub_rlm_completion_tokens = sub_completion
-            metrics.sub_rlm_count = sub_count
+            metrics.finalize_current_branch()
+            metrics.apply_child_aggregates(self.aggregate_child_metrics())
 
         meta_update = {"status": "done", "answer_preview": answer[:200], "turns": turns}
         if usage:
             meta_update["usage"] = usage
         if metrics is not None:
             meta_update["metrics"] = metrics.to_dict()
+            meta_update["context_token_stats"] = metrics.context_token_stats()
         self.write_meta(**meta_update)
         self._msg_file.close()
 

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -70,8 +70,6 @@ class RLMMetrics:
     _summarize_summary_chars_total: int = field(default=0, repr=False)
 
     # Public work/cost token metrics
-    input_tokens: int = 0
-    output_tokens: int = 0
     sub_rlm_input_tokens: int = 0
     sub_rlm_output_tokens: int = 0
 
@@ -177,8 +175,9 @@ class RLMMetrics:
         self._refresh_derived_metrics()
         return {
             "session_count": 1 + self._sub_rlm_count,
-            "input_tokens_total": self.input_tokens,
-            "output_tokens_total": self.output_tokens,
+            "input_tokens_total": self._root_input_tokens + self.sub_rlm_input_tokens,
+            "output_tokens_total": self._root_output_tokens
+            + self.sub_rlm_output_tokens,
             "final_input_tokens_total": self.final_input_tokens
             + self._sub_rlm_final_input_tokens,
             "final_output_tokens_total": self.final_output_tokens
@@ -222,9 +221,6 @@ class RLMMetrics:
         self._refresh_derived_metrics()
 
     def _refresh_derived_metrics(self) -> None:
-        self.input_tokens = self._root_input_tokens + self.sub_rlm_input_tokens
-        self.output_tokens = self._root_output_tokens + self.sub_rlm_output_tokens
-
         if self._ipython_call_count:
             self.ipython_input_chars_mean = (
                 self._ipython_input_chars_total / self._ipython_call_count

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -80,6 +80,8 @@ class RLMMetrics:
     # Root branch context exposure
     branch_input_tokens_mean: float = 0.0
     branch_input_tokens_max: int = 0
+    branch_output_tokens_mean: float = 0.0
+    branch_output_tokens_max: int = 0
 
     stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "context_limit", "depth_limit"
 
@@ -247,6 +249,10 @@ class RLMMetrics:
                 self._branch_input_tokens_sum / self._branch_count
             )
             self.branch_input_tokens_max = self._branch_input_tokens_max
+            self.branch_output_tokens_mean = (
+                self._branch_output_tokens_sum / self._branch_count
+            )
+            self.branch_output_tokens_max = self._branch_output_tokens_max
 
     def to_dict(self) -> dict[str, Any]:
         self._refresh_derived_metrics()

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -70,12 +70,10 @@ class RLMMetrics:
     _summarize_summary_chars_total: int = field(default=0, repr=False)
 
     # Public work/cost token metrics
-    root_input_tokens: int = 0
-    root_output_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
     sub_rlm_input_tokens: int = 0
     sub_rlm_output_tokens: int = 0
-    input_tokens_total: int = 0
-    output_tokens_total: int = 0
 
     # Root terminal branch context
     final_input_tokens: int = 0
@@ -84,24 +82,6 @@ class RLMMetrics:
     # Root branch context exposure
     branch_input_tokens_mean: float = 0.0
     branch_input_tokens_max: int = 0
-    branch_output_tokens_mean: float = 0.0
-    branch_output_tokens_max: int = 0
-
-    # Aggregated from children
-    sub_rlm_count: int = 0
-    sub_rlm_final_input_tokens: int = 0
-    sub_rlm_final_output_tokens: int = 0
-    sub_rlm_branch_count: int = 0
-    sub_rlm_branch_input_tokens_sum: int = 0
-    sub_rlm_branch_input_tokens_max: int = 0
-    sub_rlm_branch_output_tokens_sum: int = 0
-    sub_rlm_branch_output_tokens_max: int = 0
-
-    # All-agent branch context exposure
-    all_agents_branch_input_tokens_mean: float = 0.0
-    all_agents_branch_input_tokens_max: int = 0
-    all_agents_branch_output_tokens_mean: float = 0.0
-    all_agents_branch_output_tokens_max: int = 0
 
     stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "context_limit", "depth_limit"
 
@@ -125,6 +105,14 @@ class RLMMetrics:
     _branch_output_tokens_max: int = field(default=0, repr=False)
     _root_input_tokens: int = field(default=0, repr=False)
     _root_output_tokens: int = field(default=0, repr=False)
+    _sub_rlm_count: int = field(default=0, repr=False)
+    _sub_rlm_final_input_tokens: int = field(default=0, repr=False)
+    _sub_rlm_final_output_tokens: int = field(default=0, repr=False)
+    _sub_rlm_branch_count: int = field(default=0, repr=False)
+    _sub_rlm_branch_input_tokens_sum: int = field(default=0, repr=False)
+    _sub_rlm_branch_input_tokens_max: int = field(default=0, repr=False)
+    _sub_rlm_branch_output_tokens_sum: int = field(default=0, repr=False)
+    _sub_rlm_branch_output_tokens_max: int = field(default=0, repr=False)
 
     def note_root_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
         self._root_input_tokens = prompt_tokens
@@ -169,40 +157,44 @@ class RLMMetrics:
         self._refresh_derived_metrics()
 
     def apply_child_aggregates(self, stats: dict[str, int]) -> None:
-        self.sub_rlm_count = stats.get("session_count", 0)
+        self._sub_rlm_count = stats.get("session_count", 0)
         self.sub_rlm_input_tokens = stats.get("input_tokens_total", 0)
         self.sub_rlm_output_tokens = stats.get("output_tokens_total", 0)
-        self.sub_rlm_final_input_tokens = stats.get("final_input_tokens_total", 0)
-        self.sub_rlm_final_output_tokens = stats.get("final_output_tokens_total", 0)
-        self.sub_rlm_branch_count = stats.get("branch_count", 0)
-        self.sub_rlm_branch_input_tokens_sum = stats.get("branch_input_tokens_sum", 0)
-        self.sub_rlm_branch_input_tokens_max = stats.get("branch_input_tokens_max", 0)
-        self.sub_rlm_branch_output_tokens_sum = stats.get("branch_output_tokens_sum", 0)
-        self.sub_rlm_branch_output_tokens_max = stats.get("branch_output_tokens_max", 0)
+        self._sub_rlm_final_input_tokens = stats.get("final_input_tokens_total", 0)
+        self._sub_rlm_final_output_tokens = stats.get("final_output_tokens_total", 0)
+        self._sub_rlm_branch_count = stats.get("branch_count", 0)
+        self._sub_rlm_branch_input_tokens_sum = stats.get("branch_input_tokens_sum", 0)
+        self._sub_rlm_branch_input_tokens_max = stats.get("branch_input_tokens_max", 0)
+        self._sub_rlm_branch_output_tokens_sum = stats.get(
+            "branch_output_tokens_sum", 0
+        )
+        self._sub_rlm_branch_output_tokens_max = stats.get(
+            "branch_output_tokens_max", 0
+        )
         self._refresh_derived_metrics()
 
     def context_token_stats(self) -> dict[str, int]:
         self._refresh_derived_metrics()
         return {
-            "session_count": 1 + self.sub_rlm_count,
-            "input_tokens_total": self.input_tokens_total,
-            "output_tokens_total": self.output_tokens_total,
+            "session_count": 1 + self._sub_rlm_count,
+            "input_tokens_total": self.input_tokens,
+            "output_tokens_total": self.output_tokens,
             "final_input_tokens_total": self.final_input_tokens
-            + self.sub_rlm_final_input_tokens,
+            + self._sub_rlm_final_input_tokens,
             "final_output_tokens_total": self.final_output_tokens
-            + self.sub_rlm_final_output_tokens,
-            "branch_count": self._branch_count + self.sub_rlm_branch_count,
+            + self._sub_rlm_final_output_tokens,
+            "branch_count": self._branch_count + self._sub_rlm_branch_count,
             "branch_input_tokens_sum": self._branch_input_tokens_sum
-            + self.sub_rlm_branch_input_tokens_sum,
+            + self._sub_rlm_branch_input_tokens_sum,
             "branch_input_tokens_max": max(
                 self._branch_input_tokens_max,
-                self.sub_rlm_branch_input_tokens_max,
+                self._sub_rlm_branch_input_tokens_max,
             ),
             "branch_output_tokens_sum": self._branch_output_tokens_sum
-            + self.sub_rlm_branch_output_tokens_sum,
+            + self._sub_rlm_branch_output_tokens_sum,
             "branch_output_tokens_max": max(
                 self._branch_output_tokens_max,
-                self.sub_rlm_branch_output_tokens_max,
+                self._sub_rlm_branch_output_tokens_max,
             ),
         }
 
@@ -230,10 +222,8 @@ class RLMMetrics:
         self._refresh_derived_metrics()
 
     def _refresh_derived_metrics(self) -> None:
-        self.root_input_tokens = self._root_input_tokens
-        self.root_output_tokens = self._root_output_tokens
-        self.input_tokens_total = self.root_input_tokens + self.sub_rlm_input_tokens
-        self.output_tokens_total = self.root_output_tokens + self.sub_rlm_output_tokens
+        self.input_tokens = self._root_input_tokens + self.sub_rlm_input_tokens
+        self.output_tokens = self._root_output_tokens + self.sub_rlm_output_tokens
 
         if self._ipython_call_count:
             self.ipython_input_chars_mean = (
@@ -261,33 +251,6 @@ class RLMMetrics:
                 self._branch_input_tokens_sum / self._branch_count
             )
             self.branch_input_tokens_max = self._branch_input_tokens_max
-            self.branch_output_tokens_mean = (
-                self._branch_output_tokens_sum / self._branch_count
-            )
-            self.branch_output_tokens_max = self._branch_output_tokens_max
-
-        all_branch_count = self._branch_count + self.sub_rlm_branch_count
-        if all_branch_count:
-            all_branch_input_sum = (
-                self._branch_input_tokens_sum + self.sub_rlm_branch_input_tokens_sum
-            )
-            all_branch_output_sum = (
-                self._branch_output_tokens_sum + self.sub_rlm_branch_output_tokens_sum
-            )
-            self.all_agents_branch_input_tokens_mean = (
-                all_branch_input_sum / all_branch_count
-            )
-            self.all_agents_branch_output_tokens_mean = (
-                all_branch_output_sum / all_branch_count
-            )
-            self.all_agents_branch_input_tokens_max = max(
-                self._branch_input_tokens_max,
-                self.sub_rlm_branch_input_tokens_max,
-            )
-            self.all_agents_branch_output_tokens_max = max(
-                self._branch_output_tokens_max,
-                self.sub_rlm_branch_output_tokens_max,
-            )
 
     def to_dict(self) -> dict[str, Any]:
         self._refresh_derived_metrics()

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -68,19 +69,39 @@ class RLMMetrics:
     _summarize_chars_dropped_total: int = field(default=0, repr=False)
     _summarize_summary_chars_total: int = field(default=0, repr=False)
 
-    # This agent's token usage
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
+    # Public work/cost token metrics
+    root_input_tokens: int = 0
+    root_output_tokens: int = 0
+    sub_rlm_input_tokens: int = 0
+    sub_rlm_output_tokens: int = 0
+    input_tokens_total: int = 0
+    output_tokens_total: int = 0
 
-    # Per-turn token counts from the API (for computing tool result tokens etc.)
-    # tool_result_tokens[i] ≈ prompt_tokens_per_turn[i+1] - prompt_tokens_per_turn[i] - completion_tokens_per_turn[i]
-    prompt_tokens_per_turn: list[int] = field(default_factory=list)
-    completion_tokens_per_turn: list[int] = field(default_factory=list)
+    # Root terminal branch context
+    final_input_tokens: int = 0
+    final_output_tokens: int = 0
+
+    # Root branch context exposure
+    branch_input_tokens_mean: float = 0.0
+    branch_input_tokens_max: int = 0
+    branch_output_tokens_mean: float = 0.0
+    branch_output_tokens_max: int = 0
 
     # Aggregated from children
-    sub_rlm_prompt_tokens: int = 0
-    sub_rlm_completion_tokens: int = 0
     sub_rlm_count: int = 0
+    sub_rlm_final_input_tokens: int = 0
+    sub_rlm_final_output_tokens: int = 0
+    sub_rlm_branch_count: int = 0
+    sub_rlm_branch_input_tokens_sum: int = 0
+    sub_rlm_branch_input_tokens_max: int = 0
+    sub_rlm_branch_output_tokens_sum: int = 0
+    sub_rlm_branch_output_tokens_max: int = 0
+
+    # All-agent branch context exposure
+    all_agents_branch_input_tokens_mean: float = 0.0
+    all_agents_branch_input_tokens_max: int = 0
+    all_agents_branch_output_tokens_mean: float = 0.0
+    all_agents_branch_output_tokens_max: int = 0
 
     stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "context_limit", "depth_limit"
 
@@ -91,6 +112,99 @@ class RLMMetrics:
     @turns.setter
     def turns(self, value: int) -> None:
         self._turns = value
+
+    # Internal context-token tracker state
+    _retained_completion_tokens: deque[int] = field(default_factory=deque, repr=False)
+    _retained_completion_tokens_total: int = field(default=0, repr=False)
+    _current_branch_input_tokens: int | None = field(default=None, repr=False)
+    _current_branch_output_tokens: int | None = field(default=None, repr=False)
+    _branch_count: int = field(default=0, repr=False)
+    _branch_input_tokens_sum: int = field(default=0, repr=False)
+    _branch_input_tokens_max: int = field(default=0, repr=False)
+    _branch_output_tokens_sum: int = field(default=0, repr=False)
+    _branch_output_tokens_max: int = field(default=0, repr=False)
+    _root_input_tokens: int = field(default=0, repr=False)
+    _root_output_tokens: int = field(default=0, repr=False)
+
+    def note_root_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
+        self._root_input_tokens = prompt_tokens
+        self._root_output_tokens = completion_tokens
+        self._refresh_derived_metrics()
+
+    def note_assistant_turn(self, prompt_tokens: int, completion_tokens: int) -> None:
+        self._retained_completion_tokens.append(completion_tokens)
+        self._retained_completion_tokens_total += completion_tokens
+
+        turn_total_tokens = prompt_tokens + completion_tokens
+        visible_output_tokens = self._retained_completion_tokens_total
+        visible_input_tokens = max(0, turn_total_tokens - visible_output_tokens)
+
+        self._current_branch_input_tokens = visible_input_tokens
+        self._current_branch_output_tokens = visible_output_tokens
+        self._refresh_derived_metrics()
+
+    def finalize_current_branch(self) -> None:
+        if (
+            self._current_branch_input_tokens is None
+            or self._current_branch_output_tokens is None
+        ):
+            return
+
+        self._branch_count += 1
+        self._branch_input_tokens_sum += self._current_branch_input_tokens
+        self._branch_output_tokens_sum += self._current_branch_output_tokens
+        self._branch_input_tokens_max = max(
+            self._branch_input_tokens_max,
+            self._current_branch_input_tokens,
+        )
+        self._branch_output_tokens_max = max(
+            self._branch_output_tokens_max,
+            self._current_branch_output_tokens,
+        )
+
+        self.final_input_tokens = self._current_branch_input_tokens
+        self.final_output_tokens = self._current_branch_output_tokens
+        self._current_branch_input_tokens = None
+        self._current_branch_output_tokens = None
+        self._refresh_derived_metrics()
+
+    def apply_child_aggregates(self, stats: dict[str, int]) -> None:
+        self.sub_rlm_count = stats.get("session_count", 0)
+        self.sub_rlm_input_tokens = stats.get("input_tokens_total", 0)
+        self.sub_rlm_output_tokens = stats.get("output_tokens_total", 0)
+        self.sub_rlm_final_input_tokens = stats.get("final_input_tokens_total", 0)
+        self.sub_rlm_final_output_tokens = stats.get("final_output_tokens_total", 0)
+        self.sub_rlm_branch_count = stats.get("branch_count", 0)
+        self.sub_rlm_branch_input_tokens_sum = stats.get("branch_input_tokens_sum", 0)
+        self.sub_rlm_branch_input_tokens_max = stats.get("branch_input_tokens_max", 0)
+        self.sub_rlm_branch_output_tokens_sum = stats.get("branch_output_tokens_sum", 0)
+        self.sub_rlm_branch_output_tokens_max = stats.get("branch_output_tokens_max", 0)
+        self._refresh_derived_metrics()
+
+    def context_token_stats(self) -> dict[str, int]:
+        self._refresh_derived_metrics()
+        return {
+            "session_count": 1 + self.sub_rlm_count,
+            "input_tokens_total": self.input_tokens_total,
+            "output_tokens_total": self.output_tokens_total,
+            "final_input_tokens_total": self.final_input_tokens
+            + self.sub_rlm_final_input_tokens,
+            "final_output_tokens_total": self.final_output_tokens
+            + self.sub_rlm_final_output_tokens,
+            "branch_count": self._branch_count + self.sub_rlm_branch_count,
+            "branch_input_tokens_sum": self._branch_input_tokens_sum
+            + self.sub_rlm_branch_input_tokens_sum,
+            "branch_input_tokens_max": max(
+                self._branch_input_tokens_max,
+                self.sub_rlm_branch_input_tokens_max,
+            ),
+            "branch_output_tokens_sum": self._branch_output_tokens_sum
+            + self.sub_rlm_branch_output_tokens_sum,
+            "branch_output_tokens_max": max(
+                self._branch_output_tokens_max,
+                self.sub_rlm_branch_output_tokens_max,
+            ),
+        }
 
     def record(self, event: BuiltinMetricEvent) -> None:
         if isinstance(event, IpythonExecuted):
@@ -105,12 +219,22 @@ class RLMMetrics:
             self._summarize_turns_dropped_total += event.num_turns
             self._summarize_chars_dropped_total += event.dropped_chars
             self._summarize_summary_chars_total += event.summary_chars
+            self.finalize_current_branch()
+            for _ in range(min(event.num_turns, len(self._retained_completion_tokens))):
+                self._retained_completion_tokens_total -= (
+                    self._retained_completion_tokens.popleft()
+                )
         else:
             raise TypeError(f"Unsupported builtin metric event: {type(event)!r}")
 
         self._refresh_derived_metrics()
 
     def _refresh_derived_metrics(self) -> None:
+        self.root_input_tokens = self._root_input_tokens
+        self.root_output_tokens = self._root_output_tokens
+        self.input_tokens_total = self.root_input_tokens + self.sub_rlm_input_tokens
+        self.output_tokens_total = self.root_output_tokens + self.sub_rlm_output_tokens
+
         if self._ipython_call_count:
             self.ipython_input_chars_mean = (
                 self._ipython_input_chars_total / self._ipython_call_count
@@ -130,6 +254,39 @@ class RLMMetrics:
             )
             self.summarize_summary_chars_mean = (
                 self._summarize_summary_chars_total / self._summarize_applied_count
+            )
+
+        if self._branch_count:
+            self.branch_input_tokens_mean = (
+                self._branch_input_tokens_sum / self._branch_count
+            )
+            self.branch_input_tokens_max = self._branch_input_tokens_max
+            self.branch_output_tokens_mean = (
+                self._branch_output_tokens_sum / self._branch_count
+            )
+            self.branch_output_tokens_max = self._branch_output_tokens_max
+
+        all_branch_count = self._branch_count + self.sub_rlm_branch_count
+        if all_branch_count:
+            all_branch_input_sum = (
+                self._branch_input_tokens_sum + self.sub_rlm_branch_input_tokens_sum
+            )
+            all_branch_output_sum = (
+                self._branch_output_tokens_sum + self.sub_rlm_branch_output_tokens_sum
+            )
+            self.all_agents_branch_input_tokens_mean = (
+                all_branch_input_sum / all_branch_count
+            )
+            self.all_agents_branch_output_tokens_mean = (
+                all_branch_output_sum / all_branch_count
+            )
+            self.all_agents_branch_input_tokens_max = max(
+                self._branch_input_tokens_max,
+                self.sub_rlm_branch_input_tokens_max,
+            )
+            self.all_agents_branch_output_tokens_max = max(
+                self._branch_output_tokens_max,
+                self.sub_rlm_branch_output_tokens_max,
             )
 
     def to_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Add summarize-aware RLM context-token metrics that distinguish billing-relevant sub-agent work from the model-visible context the root agent actually sees
- Keep these as `rlm_*` harness metrics only for now; core `verifiers` `token_usage` is unchanged

## Added Metrics

### Sub-agent work / cost tokens
- `rlm_sub_rlm_input_tokens`: Recursive sum of sub-RLM prompt/prefill tokens
- `rlm_sub_rlm_output_tokens`: Recursive sum of sub-RLM completion/decode tokens

### Root terminal-branch context

- `rlm_final_input_tokens`: Non-model tokens in the root agent’s terminal branch context
- `rlm_final_output_tokens`: Model-generated tokens retained in the root agent’s terminal branch context

### Root branch context exposure

Successful summarization ends the current root-context branch and starts a new one with a reduced retained context. The branch metrics summarize the model-visible context at the terminal assistant turn of each such branch.

- `rlm_branch_input_tokens_mean`: Mean visible non-model context tokens across root branches
- `rlm_branch_input_tokens_max`: Max visible non-model context tokens across root branches
- `rlm_branch_output_tokens_mean`: Mean visible retained model-output tokens across root branches
- `rlm_branch_output_tokens_max`: Max visible retained model-output tokens across root branches

## Removed Metrics

- `rlm_prompt_tokens`: Removed because total rollout billing tokens already come from `verifiers` `input_tokens`
- `rlm_completion_tokens`: Removed because total rollout billing tokens already come from `verifiers` `output_tokens`
- `rlm_sub_rlm_prompt_tokens`: Removed because `rlm_sub_rlm_input_tokens` is the clearer non-redundant name
- `rlm_sub_rlm_completion_tokens`: Removed because `rlm_sub_rlm_output_tokens` is the clearer non-redundant name

## Notes

- Summarization affects the context-style metrics by splitting the root rollout into branches and dropping retained assistant-output tokens from later branch contexts
- Total rollout billing tokens remain the built-in `verifiers` `input_tokens` / `output_tokens`
- These RLM metrics now focus on:
  - sub-agent token work that is not attributable from the flattened intercepted trajectory
  - summarize-aware root-context exposure from the model’s perspective

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates RLM metrics accounting and the `meta.json` schema for child-session aggregation, which could break downstream consumers or misreport token usage if assumptions about context accounting are wrong.
> 
> **Overview**
> Adds new summarize-aware *context token* tracking to RLM runs, distinguishing total token work (root + sub-sessions) from the assistant-visible context within each root branch.
> 
> Replaces per-turn prompt/completion arrays and legacy `sub_rlm_*prompt/completion*` fields with derived branch/terminal-context metrics, and persists a new `context_token_stats` block in `meta.json` for recursive aggregation across `sub-*` sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a4154f89bf17789decff3647f1f7a94b8ad8e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->