### PR TITLE
Add RLM_MAX_TOOL_OUTPUT_CHARS to iPython, allows truncating iPython outputs (disabled by default)

### DIFF
--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -51,6 +51,26 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 IPYTHON_TIMEOUT_MAX_SECONDS = 600
 
 
+def _maybe_truncate_output(content: str) -> str:
+    """Cap ``content`` at ``RLM_MAX_TOOL_OUTPUT_CHARS`` if that env var is set.
+
+    Keeps the head and tail so tracebacks at the end survive. Off by default.
+    """
+    cap_env = os.environ.get("RLM_MAX_TOOL_OUTPUT_CHARS")
+    if not cap_env:
+        return content
+    try:
+        cap = int(cap_env)
+    except ValueError:
+        return content
+    if cap <= 0 or len(content) <= cap:
+        return content
+    head = cap // 2
+    tail = cap - head
+    dropped = len(content) - cap
+    return f"{content[:head]}\n...[{dropped} chars truncated]...\n{content[-tail:]}"
+
+
 class IpythonTool:
     """Builtin tool handler for the persistent IPython session."""
 
@@ -93,7 +113,7 @@ class IpythonTool:
             )
 
         return ToolOutcome(
-            content=context.repl.execute(code, timeout=timeout),
+            content=_maybe_truncate_output(context.repl.execute(code, timeout=timeout)),
             metric_events=metric_events,
         )
 

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -51,26 +51,6 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 IPYTHON_TIMEOUT_MAX_SECONDS = 600
 
 
-def _maybe_truncate_output(content: str) -> str:
-    """Cap ``content`` at ``RLM_MAX_TOOL_OUTPUT_CHARS`` if that env var is set.
-
-    Keeps the head and tail so tracebacks at the end survive. Off by default.
-    """
-    cap_env = os.environ.get("RLM_MAX_TOOL_OUTPUT_CHARS")
-    if not cap_env:
-        return content
-    try:
-        cap = int(cap_env)
-    except ValueError:
-        return content
-    if cap <= 0 or len(content) <= cap:
-        return content
-    head = cap // 2
-    tail = cap - head
-    dropped = len(content) - cap
-    return f"{content[:head]}\n...[{dropped} chars truncated]...\n{content[-tail:]}"
-
-
 class IpythonTool:
     """Builtin tool handler for the persistent IPython session."""
 
@@ -113,13 +93,22 @@ class IpythonTool:
             )
 
         return ToolOutcome(
-            content=_maybe_truncate_output(context.repl.execute(code, timeout=timeout)),
+            content=self._maybe_truncate_output(context.repl.execute(code, timeout=timeout)),
             metric_events=metric_events,
         )
 
     @staticmethod
     def _count_nonempty_lines(code: str) -> int:
         return sum(1 for line in code.splitlines() if line.strip())
+
+    @staticmethod
+    def _maybe_truncate_output(content: str) -> str:
+        """Truncate ``content`` to ``RLM_MAX_TOOL_OUTPUT_CHARS`` if set (off by default)."""
+        cap = int(os.environ.get("RLM_MAX_TOOL_OUTPUT_CHARS", "-1"))
+        if cap <= 0 or len(content) <= cap:
+            return content
+        head, tail = cap // 2, cap - cap // 2
+        return f"{content[:head]}\n...[{len(content) - cap} chars truncated]...\n{content[-tail:]}"
 
 
 class IPythonREPL:


### PR DESCRIPTION
In environments like `graphwalks`, `MRCR` etc. that contain huge strings, there are scenarios where the model decides to print the full context by accident. This will cause the agent to crash, so to prevent issues like these we limit what the model can print for now and return back.

This is off by default, but is useful for certain environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to `ipython` tool output formatting and is disabled by default. Main impact is potentially hiding full REPL output when `RLM_MAX_TOOL_OUTPUT_CHARS` is set.
> 
> **Overview**
> Adds optional output truncation for the `ipython` tool via `RLM_MAX_TOOL_OUTPUT_CHARS`, to prevent extremely large REPL outputs from overwhelming the agent.
> 
> When enabled, `IpythonTool.execute` wraps REPL results with `_maybe_truncate_output`, returning a head/tail preview with a truncation marker; behavior is unchanged when the env var is unset or non-positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587e70d2768db12489be6c833b073f763ce4489c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->