### PR TITLE
Update install script to allow for other libs in the ipython REPL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,4 +52,14 @@ if [ -d /task/rlm-skills ]; then
         SKILL_ARGS="$SKILL_ARGS --with-editable $skill_dir --with-executables-from $skill_name"
     done
 fi
-uv tool install --python 3.10 --editable "$RLM_CHECKOUT" $SKILL_ARGS
+
+# Forward caller-supplied `uv tool install` extras (e.g. "--with numpy
+# --with sympy") when set, so environments can inject extra pip deps into
+# the rlm tool venv without patching this script. Tokens are word-split by
+# the shell, so avoid shell metacharacters (e.g. `>=`) inside package specs.
+EXTRA_UV_ARGS=""
+if [ -n "${RLM_EXTRA_UV_ARGS:-}" ]; then
+    EXTRA_UV_ARGS="$RLM_EXTRA_UV_ARGS"
+fi
+
+uv tool install --python 3.10 --editable "$RLM_CHECKOUT" $SKILL_ARGS $EXTRA_UV_ARGS


### PR DESCRIPTION
This adds an extra `RLM_EXTRA_UV_ARGS` env variable that looks for extra dependencies to install in the REPL. Generally shouldn't need to be used, and is environment specific.

Revert if needed; this is primarily for environments where we want certain Python libraries available. It generally shouldn't be used, unless otherwise specified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the install-time command line by forwarding an env var into `uv tool install`, which can alter dependency resolution and could be abused if the environment variable is not trusted.
> 
> **Overview**
> `install.sh` now supports an optional `RLM_EXTRA_UV_ARGS` environment variable that is appended to the final `uv tool install` invocation, enabling environments to install additional Python packages into the `rlm` tool venv (alongside any discovered skills) without modifying the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 235946b1991d44d2aba3628a71b98b61e56c99b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->