### PR TITLE
Add RLM_TOOLS env var for per-tool opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ All configuration is via environment variables:
 | `RLM_MAX_TOKENS` | `0` | Optional completion-token budget (`0` disables) |
 | `RLM_APPEND_TO_SYSTEM_PROMPT` | — | Extra instructions appended to the generated system prompt |
 | `RLM_SYSTEM_PROMPT_PATH` | — | Path to a file whose contents fully replace the generated system prompt |
+| `RLM_TOOLS` | `ipython,summarize` | Comma-separated subset of builtin tools to enable. Empty string = no tools. Unknown names raise. |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 
 `RLM_SYSTEM_PROMPT_PATH` takes precedence over `RLM_APPEND_TO_SYSTEM_PROMPT`. CLI flags override env vars: `rlm --model gpt-5-mini --max-turns 50 --append-to-system-prompt "..." --system-prompt-path /tmp/system.txt "prompt"`.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 A minimal CLI coding agent with a persistent IPython execution environment and optional recursive sub-agents.
 
-The model gets three built-in tools (opt in / out via `RLM_TOOLS`):
+The model gets four built-in tools (opt in / out via `RLM_TOOLS`):
 
 - `ipython` for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash` (on by default)
 - `summarize` for dropping old turns from context and optionally resetting REPL state (on by default)
 - `bash` for stateless shell command execution (off by default)
+- `edit` for single-occurrence string replacement in a file (off by default)
 
 Inside the IPython session, the `rlm` module is pre-imported. When recursion is allowed, the model can call `await rlm.run(...)` to spawn sub-agents. Skills supplied by the host environment (see [Skills](#skills)) are importable directly by name, e.g. `import websearch`.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A minimal CLI coding agent with a persistent IPython execution environment and optional recursive sub-agents.
 
-The model gets two built-in tools:
+The model gets three built-in tools (opt in / out via `RLM_TOOLS`):
 
-- `ipython` for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash`
-- `summarize` for dropping old turns from context and optionally resetting REPL state
+- `ipython` for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash` (on by default)
+- `summarize` for dropping old turns from context and optionally resetting REPL state (on by default)
+- `bash` for stateless shell command execution (off by default)
 
 Inside the IPython session, the `rlm` module is pre-imported. When recursion is allowed, the model can call `await rlm.run(...)` to spawn sub-agents. Skills supplied by the host environment (see [Skills](#skills)) are importable directly by name, e.g. `import websearch`.
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -142,15 +142,19 @@ class RLMEngine:
             cwd=self.cwd,
         )
 
-        # Start IPython kernel
-        self._repl = IPythonREPL(cwd=self.cwd, session=self.session)
-        self._repl.start()
+        # Start IPython kernel only when the ipython tool is active —
+        # otherwise the model can't see or dispatch it, so the kernel
+        # startup (subprocess + injection) is pure waste.
+        if any(tool.name == "ipython" for tool in get_active_builtin_tools()):
+            self._repl = IPythonREPL(cwd=self.cwd, session=self.session)
+            self._repl.start()
         self._known_children = {p.name for p in self.session.dir.glob("sub-*")}
 
         try:
             return await self._run_loop(prompt)
         finally:
-            self._repl.shutdown()
+            if self._repl is not None:
+                self._repl.shutdown()
 
     async def _run_loop(self, prompt: str) -> RLMResult:
         active_builtin_tools = get_active_builtin_tools()
@@ -279,7 +283,7 @@ class RLMEngine:
 
             if self.max_output > 0 and len(result) > self.max_output:
                 result = result[: self.max_output] + "\n... [output truncated]"
-            if tool_result.flush_repl_state:
+            if tool_result.flush_repl_state and self._repl is not None:
                 result += "\n[repl state flushed]"
             if tool_name == "ipython" and self.max_turns_in_context is not None:
                 turns_in_context = self._count_turns_in_context(messages)
@@ -302,7 +306,7 @@ class RLMEngine:
             # Drop old turn-groups after summarize
             if tool_result.drop_turns > 0:
                 self._drop_turns(messages, tool_result.drop_turns)
-            if tool_result.flush_repl_state:
+            if tool_result.flush_repl_state and self._repl is not None:
                 self._repl.restart_kernel()
 
             if self.max_turns_in_context is not None:

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -370,6 +370,7 @@ class RLMEngine:
             exec_timeout=self.exec_timeout,
             repl=self._repl,
             state=self._tool_state,
+            cwd=self.cwd,
         )
 
     @staticmethod

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -15,11 +15,12 @@ from rlm.prompt import build_system_prompt
 from rlm.session import Session
 from rlm.tools import (
     SKILLS_DIR,
+    BuiltinTool,
     IPythonREPL,
     SummarizeState,
     ToolContext,
     ToolOutcome,
-    get_active_tools,
+    get_active_builtin_tools,
     get_builtin_tool,
     get_installed_skills,
     summarize_drop_slice_bounds,
@@ -152,12 +153,10 @@ class RLMEngine:
             self._repl.shutdown()
 
     async def _run_loop(self, prompt: str) -> RLMResult:
-        active_tools = get_active_tools()
-        summarize_enabled = any(
-            tool["function"]["name"] == "summarize" for tool in active_tools
-        )
+        active_builtin_tools = get_active_builtin_tools()
+        active_tools = [tool.schema() for tool in active_builtin_tools]
         messages_path = str(self.session.dir / "messages.jsonl")
-        system_prompt = self._load_system_prompt(messages_path, summarize_enabled)
+        system_prompt = self._load_system_prompt(messages_path, active_builtin_tools)
 
         messages = [
             {"role": "system", "content": system_prompt},
@@ -334,7 +333,9 @@ class RLMEngine:
         )
         return result
 
-    def _load_system_prompt(self, messages_path: str, summarize_enabled: bool) -> str:
+    def _load_system_prompt(
+        self, messages_path: str, active_tools: list[BuiltinTool]
+    ) -> str:
         if self.system_prompt_path:
             return Path(self.system_prompt_path).read_text()
         system_prompt = build_system_prompt(
@@ -344,7 +345,7 @@ class RLMEngine:
             messages_path,
             allow_recursion=self.depth < self.max_depth,
             max_turns_in_context=self.max_turns_in_context,
-            summarize_enabled=summarize_enabled,
+            active_tools=active_tools,
         )
         if self.append_to_system_prompt:
             system_prompt += "\n\n" + self.append_to_system_prompt

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rlm.tools.base import BuiltinTool
+
 
 def build_system_prompt(
     cwd: str,
@@ -11,17 +16,17 @@ def build_system_prompt(
     *,
     allow_recursion: bool,
     max_turns_in_context: int | None,
-    summarize_enabled: bool,
+    active_tools: list[BuiltinTool],
 ) -> str:
-    """Build the system prompt."""
-    parts = [
+    """Build the system prompt.
+
+    Layout: role → work instructions → environment (cwd, log path, skills) →
+    constraints (max turns) → capabilities (recursion) → tool API. Tools come
+    last so the model has already seen any constraints that motivate them
+    (e.g. summarize makes sense only once the turns-in-context limit is known).
+    """
+    parts: list[str] = [
         "You are a coding agent. You solve tasks by writing and executing code, observing results, and iterating.",
-        "Call at most one built-in tool per turn.",
-        "",
-        "You have a persistent IPython session. Variables, imports, and function definitions persist across calls.",
-        "Use !command for shell commands (e.g. !git status, !ls -la, !pip install foo).",
-        "Use !python3 to run code with the project's own packages (e.g. !python3 -m pytest, !python3 -c 'import numpy').",
-        "Use %%bash for multi-line shell scripts.",
         "",
         "Work one step at a time: execute code, read the output, then decide your next step.",
         "When you are done, stop calling tools and state your final answer.",
@@ -47,26 +52,30 @@ def build_system_prompt(
             "Discover its CLI usage with `<skill> --help`."
         )
     if skill_lines:
-        parts[10:10] = [*skill_lines, ""]
+        parts.extend(["", *skill_lines])
 
     if max_turns_in_context is not None:
         parts.extend(
             [
                 "",
-                "The current context may contain at most "
-                f"{max_turns_in_context} assistant turns.",
+                f"The current context may contain at most {max_turns_in_context} assistant turns.",
             ]
         )
-        if summarize_enabled:
-            parts.append(
-                "Use `summarize` to drop older turns and stay within this limit."
-            )
 
     if allow_recursion:
-        parts[6:6] = [
-            "The `rlm` module is pre-imported. Call `await rlm.run('sub-task')` to spawn a recursive sub-agent.",
-            "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm.run('task1'), rlm.run('task2'))`.",
-            "",
-        ]
+        parts.extend(
+            [
+                "",
+                "The `rlm` module is pre-imported. Call `await rlm.run('sub-task')` to spawn a recursive sub-agent.",
+                "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm.run('task1'), rlm.run('task2'))`.",
+            ]
+        )
+
+    if active_tools:
+        parts.extend(["", "Call at most one built-in tool per turn."])
+        for tool in active_tools:
+            tool_lines = tool.prompt_lines(max_turns_in_context=max_turns_in_context)
+            if tool_lines:
+                parts.extend(["", *tool_lines])
 
     return "\n".join(parts)

--- a/src/rlm/tools/__init__.py
+++ b/src/rlm/tools/__init__.py
@@ -2,7 +2,11 @@
 
 from rlm.tools.base import BuiltinTool, ToolContext, ToolOutcome
 from rlm.tools.ipython import IPythonREPL
-from rlm.tools.registry import get_active_tools, get_builtin_tool
+from rlm.tools.registry import (
+    get_active_builtin_tools,
+    get_active_tools,
+    get_builtin_tool,
+)
 from rlm.tools.skills import SKILLS_DIR, TASK_SKILLS_DIR, get_installed_skills
 from rlm.tools.summarize import SummarizeState, summarize_drop_slice_bounds
 
@@ -15,6 +19,7 @@ __all__ = [
     "TASK_SKILLS_DIR",
     "ToolContext",
     "ToolOutcome",
+    "get_active_builtin_tools",
     "get_active_tools",
     "get_builtin_tool",
     "get_installed_skills",

--- a/src/rlm/tools/base.py
+++ b/src/rlm/tools/base.py
@@ -29,6 +29,7 @@ class ToolContext:
     exec_timeout: int
     repl: Any | None = None
     state: dict[str, Any] = field(default_factory=dict)
+    cwd: str = ""
 
 
 class BuiltinTool(Protocol):

--- a/src/rlm/tools/base.py
+++ b/src/rlm/tools/base.py
@@ -41,3 +41,11 @@ class BuiltinTool(Protocol):
 
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         """Execute the tool and return a string tool result plus side effects."""
+
+    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
+        """Return the lines this tool contributes to the system prompt.
+
+        May return an empty list when the tool has nothing to describe given
+        the current configuration (e.g. summarize only adds a line when a
+        context-turn limit is in effect).
+        """

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -1,0 +1,100 @@
+"""Builtin bash tool — stateless shell command execution.
+
+Each call spawns a fresh ``bash -c`` subprocess. No state is shared across
+calls (no cwd changes, no exports, no background processes). For stateful
+shell work, the ipython tool's ``!command`` / ``%%bash`` are still available.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import subprocess
+from typing import Any
+
+from rlm.tools.base import ToolContext, ToolOutcome
+
+
+BASH_TIMEOUT_MAX_SECONDS = 600
+
+
+BASH_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "bash",
+        "description": (
+            "Execute a bash command. Stateless: each call runs in a fresh "
+            "shell, so cd / exports / background processes don't persist."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Bash command to execute.",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": None,  # filled by schema()
+                },
+            },
+            "required": ["command"],
+        },
+    },
+}
+
+
+class BashTool:
+    """Builtin tool handler for stateless bash command execution."""
+
+    name = "bash"
+
+    def schema(self) -> dict[str, Any]:
+        timeout = min(
+            int(os.environ.get("RLM_EXEC_TIMEOUT", "300")),
+            BASH_TIMEOUT_MAX_SECONDS,
+        )
+        schema = copy.deepcopy(BASH_SCHEMA)
+        schema["function"]["parameters"]["properties"]["timeout"]["description"] = (
+            f"Optional timeout in seconds. Default: {timeout}s. "
+            f"Maximum: {BASH_TIMEOUT_MAX_SECONDS}s."
+        )
+        return schema
+
+    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
+        return ["Use `bash` to run shell commands. Each call is stateless."]
+
+    def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
+        command = args.get("command", "")
+        if not isinstance(command, str):
+            command = str(command)
+
+        timeout = args.get("timeout")
+        if timeout is None:
+            timeout = context.exec_timeout
+        else:
+            try:
+                timeout = int(timeout)
+            except (TypeError, ValueError):
+                timeout = context.exec_timeout
+        timeout = min(timeout, BASH_TIMEOUT_MAX_SECONDS)
+
+        try:
+            proc = subprocess.run(
+                ["bash", "-c", command],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=context.cwd or None,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolOutcome(content=f"[command timed out after {timeout}s]")
+
+        parts: list[str] = []
+        if proc.stdout:
+            parts.append(proc.stdout)
+        if proc.stderr:
+            parts.append(proc.stderr)
+        if proc.returncode != 0:
+            parts.append(f"[exit code: {proc.returncode}]")
+        return ToolOutcome(content="\n".join(parts) if parts else "")

--- a/src/rlm/tools/edit.py
+++ b/src/rlm/tools/edit.py
@@ -1,0 +1,93 @@
+"""Builtin edit tool — safe single-occurrence string replacement.
+
+Ported from the ``edit`` skill in research-environments/rlm_swe. Kept as a
+builtin so it's available to any env that opts in via RLM_TOOLS, not just
+envs that ship the skill.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from rlm.tools.base import ToolContext, ToolOutcome
+
+
+EDIT_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "edit",
+        "description": (
+            "Replace a unique string in a file. old_str must appear exactly "
+            "once in the file."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path (relative to cwd or absolute).",
+                },
+                "old_str": {
+                    "type": "string",
+                    "description": "Exact string to find (must appear exactly once).",
+                },
+                "new_str": {
+                    "type": "string",
+                    "description": "Replacement string.",
+                },
+            },
+            "required": ["path", "old_str", "new_str"],
+        },
+    },
+}
+
+
+class EditTool:
+    """Builtin tool handler for single-occurrence file edits."""
+
+    name = "edit"
+
+    def schema(self) -> dict[str, Any]:
+        return copy.deepcopy(EDIT_SCHEMA)
+
+    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
+        return [
+            "Use `edit` to replace a unique string in a file (old_str must match exactly once)."
+        ]
+
+    def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
+        path = args.get("path")
+        old_str = args.get("old_str")
+        new_str = args.get("new_str")
+
+        if not isinstance(path, str) or not path:
+            return ToolOutcome(content="Error: 'path' is required")
+        if not isinstance(old_str, str):
+            return ToolOutcome(content="Error: 'old_str' must be a string")
+        if not isinstance(new_str, str):
+            return ToolOutcome(content="Error: 'new_str' must be a string")
+
+        base_dir = Path(context.cwd) if context.cwd else Path.cwd()
+        filepath = base_dir / path
+        if not filepath.exists():
+            return ToolOutcome(content=f"Error: {path} not found")
+        try:
+            content = filepath.read_text()
+        except Exception as exc:
+            return ToolOutcome(content=f"Error reading {path}: {exc}")
+
+        count = content.count(old_str)
+        if count == 0:
+            return ToolOutcome(content=f"Error: string not found in {path}")
+        if count > 1:
+            return ToolOutcome(
+                content=f"Error: found {count} occurrences, need exactly 1"
+            )
+
+        try:
+            filepath.write_text(content.replace(old_str, new_str, 1))
+        except Exception as exc:
+            return ToolOutcome(content=f"Error writing {path}: {exc}")
+        return ToolOutcome(content=f"Edited {path}")

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -68,6 +68,14 @@ class IpythonTool:
         )
         return schema
 
+    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
+        return [
+            "You have a persistent IPython session. Variables, imports, and function definitions persist across calls.",
+            "Use !command for shell commands (e.g. !git status, !ls -la, !pip install foo).",
+            "Use !python3 to run code with the project's own packages (e.g. !python3 -m pytest, !python3 -c 'import numpy').",
+            "Use %%bash for multi-line shell scripts.",
+        ]
+
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         code = args.get("code", "")
         if not isinstance(code, str):

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -2,20 +2,62 @@
 
 from __future__ import annotations
 
+import os
+
 from rlm.tools.base import BuiltinTool
 from rlm.tools.ipython import IpythonTool
 from rlm.tools.summarize import SummarizeTool
 
 
 _BUILTIN_TOOLS: tuple[BuiltinTool, ...] = (IpythonTool(), SummarizeTool())
-_TOOLS_BY_NAME = {tool.name: tool for tool in _BUILTIN_TOOLS}
+_TOOLS_BY_NAME: dict[str, BuiltinTool] = {tool.name: tool for tool in _BUILTIN_TOOLS}
+
+
+def _active_tool_names() -> list[str]:
+    """Resolve the active builtin-tool names from the ``RLM_TOOLS`` env var.
+
+    Unset → ``["ipython", "summarize"]`` (convenience default for direct CLI
+    use; all other callers — notably the verifiers rlm_harness — are
+    expected to set ``RLM_TOOLS`` explicitly so the tool set is a single
+    source of truth).
+    Comma-separated list → that subset, preserving user-specified order.
+    Empty string → no tools (pure chat mode).
+    Unknown names → ``ValueError``.
+    Duplicates and surrounding whitespace are tolerated (deduped / stripped).
+    """
+    raw = os.environ.get("RLM_TOOLS")
+    if raw is None:
+        return ["ipython", "summarize"]
+    names: list[str] = []
+    for token in raw.split(","):
+        name = token.strip()
+        if name and name not in names:
+            names.append(name)
+    unknown = [n for n in names if n not in _TOOLS_BY_NAME]
+    if unknown:
+        raise ValueError(
+            f"RLM_TOOLS contains unknown tool(s): {unknown}. "
+            f"Available: {sorted(_TOOLS_BY_NAME)}"
+        )
+    return names
+
+
+def get_active_builtin_tools() -> list[BuiltinTool]:
+    """Return active builtin-tool instances (respects ``RLM_TOOLS``)."""
+    return [_TOOLS_BY_NAME[name] for name in _active_tool_names()]
 
 
 def get_active_tools() -> list[dict]:
-    """Return OpenAI tool schemas with runtime defaults baked in."""
-    return [tool.schema() for tool in _BUILTIN_TOOLS]
+    """Return OpenAI tool schemas for active builtins."""
+    return [tool.schema() for tool in get_active_builtin_tools()]
 
 
 def get_builtin_tool(name: str) -> BuiltinTool | None:
-    """Look up a builtin tool handler by name."""
+    """Look up an active builtin tool handler by name.
+
+    Returns None for unknown names or tools excluded by ``RLM_TOOLS``, so
+    the engine's unknown-tool error path catches both cases identically.
+    """
+    if name not in _active_tool_names():
+        return None
     return _TOOLS_BY_NAME.get(name)

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -6,11 +6,17 @@ import os
 
 from rlm.tools.base import BuiltinTool
 from rlm.tools.bash import BashTool
+from rlm.tools.edit import EditTool
 from rlm.tools.ipython import IpythonTool
 from rlm.tools.summarize import SummarizeTool
 
 
-_BUILTIN_TOOLS: tuple[BuiltinTool, ...] = (IpythonTool(), SummarizeTool(), BashTool())
+_BUILTIN_TOOLS: tuple[BuiltinTool, ...] = (
+    IpythonTool(),
+    SummarizeTool(),
+    BashTool(),
+    EditTool(),
+)
 _TOOLS_BY_NAME: dict[str, BuiltinTool] = {tool.name: tool for tool in _BUILTIN_TOOLS}
 
 

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -54,6 +54,11 @@ def get_active_builtin_tools() -> list[BuiltinTool]:
     return [_TOOLS_BY_NAME[name] for name in _active_tool_names()]
 
 
+def is_tool_active(name: str) -> bool:
+    """Return whether ``name`` is in the active builtin-tool set."""
+    return name in _active_tool_names()
+
+
 def get_active_tools() -> list[dict]:
     """Return OpenAI tool schemas for active builtins."""
     return [tool.schema() for tool in get_active_builtin_tools()]

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import os
 
 from rlm.tools.base import BuiltinTool
+from rlm.tools.bash import BashTool
 from rlm.tools.ipython import IpythonTool
 from rlm.tools.summarize import SummarizeTool
 
 
-_BUILTIN_TOOLS: tuple[BuiltinTool, ...] = (IpythonTool(), SummarizeTool())
+_BUILTIN_TOOLS: tuple[BuiltinTool, ...] = (IpythonTool(), SummarizeTool(), BashTool())
 _TOOLS_BY_NAME: dict[str, BuiltinTool] = {tool.name: tool for tool in _BUILTIN_TOOLS}
 
 

--- a/src/rlm/tools/summarize.py
+++ b/src/rlm/tools/summarize.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -9,16 +10,22 @@ from rlm.tools.base import ToolContext, ToolOutcome
 from rlm.types import SummarizeApplied, SummarizeRejected
 
 
+_SUMMARIZE_DESCRIPTION_BASE = (
+    "Summarize and drop old turns from context to free up space. "
+    "A turn is one assistant response plus all its tool results. "
+    "Dropping num_turns removes the oldest complete turns from context."
+)
+_SUMMARIZE_DESCRIPTION_WITH_IPYTHON = (
+    f"{_SUMMARIZE_DESCRIPTION_BASE} "
+    "Optionally flush the persistent IPython state after summarization."
+)
+
+
 SUMMARIZE_SCHEMA = {
     "type": "function",
     "function": {
         "name": "summarize",
-        "description": (
-            "Summarize and drop old turns from context to free up space. "
-            "A turn is one assistant response plus all its tool results. "
-            "Dropping num_turns removes the oldest complete turns from context. "
-            "Optionally flush the persistent IPython state after summarization."
-        ),
+        "description": _SUMMARIZE_DESCRIPTION_WITH_IPYTHON,
         "parameters": {
             "type": "object",
             "properties": {
@@ -77,7 +84,14 @@ class SummarizeTool:
     name = "summarize"
 
     def schema(self) -> dict[str, Any]:
-        return SUMMARIZE_SCHEMA
+        # Lazy import to avoid a module-load cycle with registry.
+        from rlm.tools.registry import is_tool_active
+
+        schema = copy.deepcopy(SUMMARIZE_SCHEMA)
+        if not is_tool_active("ipython"):
+            schema["function"]["parameters"]["properties"].pop("flush_repl_state", None)
+            schema["function"]["description"] = _SUMMARIZE_DESCRIPTION_BASE
+        return schema
 
     def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
         # Only mention summarize when there's a concrete limit to stay within;

--- a/src/rlm/tools/summarize.py
+++ b/src/rlm/tools/summarize.py
@@ -79,6 +79,13 @@ class SummarizeTool:
     def schema(self) -> dict[str, Any]:
         return SUMMARIZE_SCHEMA
 
+    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
+        # Only mention summarize when there's a concrete limit to stay within;
+        # otherwise the tool is present but unmotivated.
+        if max_turns_in_context is None:
+            return []
+        return ["Use `summarize` to drop older turns and stay within this limit."]
+
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         state = context.state.setdefault("summarize", SummarizeState())
         if not isinstance(state, SummarizeState):


### PR DESCRIPTION
Adds RLM_TOOLS — a comma-separated list of builtin tool names — that controls which builtins are advertised to the LLM and dispatched.

Also adds the `bash` tool, which is off by default. It's stateless.

Also adds the `edit` tool, which is off by default. It's identical to the skill of the same name from rlm_swe.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new tool-dispatch paths for shell execution and file mutation, controlled by `RLM_TOOLS`; misconfiguration or unexpected enablement could expand agent capabilities in sensitive environments.
> 
> **Overview**
> Adds `RLM_TOOLS` to **explicitly control which builtin tools are advertised and dispatched**, supporting subsets, pure-chat mode (empty string), and validation of unknown tool names.
> 
> Introduces two new optional builtins: `bash` for *stateless* `bash -c` execution and `edit` for *single-occurrence* string replacement in files. The engine and system-prompt builder are updated to only initialize/describe enabled tools, including skipping IPython kernel startup when `ipython` is disabled and tailoring `summarize` to omit REPL-flush behavior when IPython isn’t active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a27c6f7cf2bcbc6ccd5959fde4a0a7d24e41c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->