### PR TITLE
Session.__init__: resolve session dir to an absolute path

### DIFF
--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -17,7 +17,10 @@ class Session:
             sid = uuid.uuid4().hex[:12]
             rlm_home = Path(os.environ.get("RLM_HOME", ".rlm"))
             session_dir = rlm_home / "sessions" / sid
-        self.dir = Path(session_dir)
+        # Absolute path so later writes (meta.json.tmp, messages.jsonl) keep
+        # working if something changes cwd mid-rollout (a tool's os.chdir,
+        # REPL kernel restart in a different cwd, sandbox teardown, etc.).
+        self.dir = Path(session_dir).resolve()
         self.dir.mkdir(parents=True, exist_ok=True)
         self._msg_file = open(self.dir / "messages.jsonl", "a")
 


### PR DESCRIPTION
`self.dir` was stored as whatever `Path` the caller passed in, which defaults to a relative path `('.rlm/sessions/<id>'). mkdir` at `__init__` created the directory under the then-current cwd, but subsequent operations (write_meta, log) re-resolve the same relative Path against whatever cwd they run under. When anything between `__init__` and finalize changes cwd — a tool's `os.chdir`, a REPL kernel restart in a different cwd, a task harness, verifiers' sandbox teardown — the directory the writes target no longer exists, and finalize crashes with `FileNotFoundError` on `meta.json.tmp`.

Observed in training: cascaded with the 413 retry path to turn transient rollout failures into harder-to-debug secondary crashes.

Fix: `.resolve()` at `__init__` time so self.dir is absolute for the rest of the session's lifetime. No call-site impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to session path initialization, primarily affecting filesystem path resolution and preventing `FileNotFoundError` when `cwd` changes.
> 
> **Overview**
> **Fixes session logging/meta writes when `cwd` changes.** `Session.__init__` now stores `self.dir` as an absolute, resolved path rather than a potentially relative one, so later writes (e.g., `meta.json.tmp`, `messages.jsonl`) consistently target the original session directory even if something calls `os.chdir` or the runtime restarts in a different working directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1c83903fb790ea53e4ae4a679f7a41197235b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->