### PR TITLE
simplify prompt construction, remove duplicates, no mention of git

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -61,6 +61,10 @@ def build_system_prompt(
                 f"The current context may contain at most {max_turns_in_context} assistant turns.",
             ]
         )
+        if any(tool.name == "summarize" for tool in active_tools):
+            parts.append(
+                "Use `summarize` to drop older turns and stay within this limit."
+            )
 
     if allow_recursion:
         parts.extend(
@@ -73,9 +77,5 @@ def build_system_prompt(
 
     if active_tools:
         parts.extend(["", "Call at most one built-in tool per turn."])
-        for tool in active_tools:
-            tool_lines = tool.prompt_lines(max_turns_in_context=max_turns_in_context)
-            if tool_lines:
-                parts.extend(["", *tool_lines])
 
     return "\n".join(parts)

--- a/src/rlm/tools/base.py
+++ b/src/rlm/tools/base.py
@@ -42,11 +42,3 @@ class BuiltinTool(Protocol):
 
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         """Execute the tool and return a string tool result plus side effects."""
-
-    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        """Return the lines this tool contributes to the system prompt.
-
-        May return an empty list when the tool has nothing to describe given
-        the current configuration (e.g. summarize only adds a line when a
-        context-turn limit is in effect).
-        """

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -61,10 +61,6 @@ class BashTool:
         )
         return schema
 
-    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        # Static tool — usage info lives in the OpenAI tool description.
-        return []
-
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         command = args.get("command", "")
         if not isinstance(command, str):

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -62,7 +62,8 @@ class BashTool:
         return schema
 
     def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        return ["Use `bash` to run shell commands. Each call is stateless."]
+        # Static tool — usage info lives in the OpenAI tool description.
+        return []
 
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         command = args.get("command", "")

--- a/src/rlm/tools/edit.py
+++ b/src/rlm/tools/edit.py
@@ -52,10 +52,6 @@ class EditTool:
     def schema(self) -> dict[str, Any]:
         return copy.deepcopy(EDIT_SCHEMA)
 
-    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        # Static tool — usage info lives in the OpenAI tool description.
-        return []
-
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         path = args.get("path")
         old_str = args.get("old_str")

--- a/src/rlm/tools/edit.py
+++ b/src/rlm/tools/edit.py
@@ -53,9 +53,8 @@ class EditTool:
         return copy.deepcopy(EDIT_SCHEMA)
 
     def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        return [
-            "Use `edit` to replace a unique string in a file (old_str must match exactly once)."
-        ]
+        # Static tool — usage info lives in the OpenAI tool description.
+        return []
 
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         path = args.get("path")

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -70,12 +70,6 @@ class IpythonTool:
         )
         return schema
 
-    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        # Static tool — all usage info lives in the OpenAI tool description
-        # (IPYTHON_SCHEMA), which the model already receives via the tools
-        # parameter. No system-prompt duplication.
-        return []
-
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         code = args.get("code", "")
         if not isinstance(code, str):

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -25,9 +25,11 @@ IPYTHON_SCHEMA = {
     "function": {
         "name": "ipython",
         "description": (
-            "Execute code in a persistent IPython session. "
-            "Variables, imports, and definitions persist across calls. "
-            "Use !command for shell commands (e.g. !git diff, !ls -la). "
+            "Execute code in a persistent IPython session. Variables, imports, "
+            "and function definitions persist across calls. "
+            "Use !command for shell commands (e.g. !ls -la, !cat file.py, !pip install foo). "
+            "Use !python3 to run code with the project's own packages "
+            "(e.g. !python3 -m pytest, !python3 -c 'import numpy'). "
             "Use %%bash for multi-line shell scripts."
         ),
         "parameters": {
@@ -69,12 +71,10 @@ class IpythonTool:
         return schema
 
     def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        return [
-            "You have a persistent IPython session. Variables, imports, and function definitions persist across calls.",
-            "Use !command for shell commands (e.g. !git status, !ls -la, !pip install foo).",
-            "Use !python3 to run code with the project's own packages (e.g. !python3 -m pytest, !python3 -c 'import numpy').",
-            "Use %%bash for multi-line shell scripts.",
-        ]
+        # Static tool — all usage info lives in the OpenAI tool description
+        # (IPYTHON_SCHEMA), which the model already receives via the tools
+        # parameter. No system-prompt duplication.
+        return []
 
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         code = args.get("code", "")

--- a/src/rlm/tools/summarize.py
+++ b/src/rlm/tools/summarize.py
@@ -93,13 +93,6 @@ class SummarizeTool:
             schema["function"]["description"] = _SUMMARIZE_DESCRIPTION_BASE
         return schema
 
-    def prompt_lines(self, *, max_turns_in_context: int | None) -> list[str]:
-        # Only mention summarize when there's a concrete limit to stay within;
-        # otherwise the tool is present but unmotivated.
-        if max_turns_in_context is None:
-            return []
-        return ["Use `summarize` to drop older turns and stay within this limit."]
-
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         state = context.state.setdefault("summarize", SummarizeState())
         if not isinstance(state, SummarizeState):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes system prompt content and removes `prompt_lines` from the builtin tool interface, which could subtly affect agent behavior and any downstream code expecting those prompt contributions.
> 
> **Overview**
> Simplifies system prompt construction by **dropping per-tool prompt text injection** and instead adding a single global tool constraint plus a conditional hint to use `summarize` when a turns-in-context limit is set.
> 
> Removes the `prompt_lines` API from `BuiltinTool` and deletes the now-redundant prompt-line implementations in `bash`, `edit`, `ipython`, and `summarize`, while updating the `ipython` tool schema description to avoid `git` examples and clarify `!command`/`!python3` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309df1a069f1991bf5cbca09d833faae0671517d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->