### PR TITLE
feat: decode JSON skill output in kernel_shim

### DIFF
--- a/src/rlm/kernel_shim.py
+++ b/src/rlm/kernel_shim.py
@@ -17,11 +17,13 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import json
 import os
 import shutil
 import sys
 import types
 from pathlib import Path
+from typing import Any
 
 
 def _read_parameters(skill_src: Path) -> dict:
@@ -45,10 +47,32 @@ def _read_parameters(skill_src: Path) -> dict:
     return {}
 
 
+def _maybe_decode(out: str) -> Any:
+    """Decode structured skill output transparently.
+
+    Skills communicate via subprocess stdout, so their return values
+    always arrive as strings. When a skill prints a valid JSON value
+    (list, dict, number, bool, null, or a quoted string), decode it so
+    callers get the native Python object — avoids the
+    ``if events:`` footgun where ``"[]"`` (a non-empty string) is truthy
+    even though the underlying list is empty.
+
+    Plain text output (anything that isn't valid JSON) is returned
+    as-is, preserving existing behaviour for skills that return
+    free-form strings.
+    """
+    if not out:
+        return out
+    try:
+        return json.loads(out)
+    except (json.JSONDecodeError, ValueError):
+        return out
+
+
 def _make_run(cli_name: str):
     """Create an async run() that delegates to the skill CLI."""
 
-    async def run(**kwargs) -> str:
+    async def run(**kwargs) -> Any:
         cmd = [cli_name]
         for key, value in kwargs.items():
             flag = f"--{key.replace('_', '-')}"
@@ -73,7 +97,7 @@ def _make_run(cli_name: str):
         if proc.returncode != 0:
             err = stderr.decode().strip()
             return err or out or f"{cli_name} exited with code {proc.returncode}"
-        return out
+        return _maybe_decode(out)
 
     return run
 


### PR DESCRIPTION
## Summary

Skills return values through subprocess stdout, so callers always receive strings. A skill that returns an empty list surfaces as the string `"[]"` — which is truthy in Python, so the obvious idiom

```python
events = await list_events.run(date="2025-07-14")
if events:
    ...  # fires even when the underlying list is empty
```

fires when it shouldn't. Same trap for `"{}"`, `"null"`, `"0"`, `"false"`.

## Change

`kernel_shim._make_run` now runs the subprocess stdout through a new `_maybe_decode`:

```python
def _maybe_decode(out: str) -> Any:
    if not out:
        return out
    try:
        return json.loads(out)
    except (json.JSONDecodeError, ValueError):
        return out
```

- Valid JSON (`[]`, `{}`, `[…]`, `"some string"`, numbers, `true`/`false`/`null`) → native Python object.
- Anything else (free-form text) → unchanged string.

Return annotation on the synthesised `run()` widens from `str` to `Any`.

## Backwards compatibility

- Skills emitting plain text are unaffected — `json.loads("hello")` raises, we fall through to returning the raw string.
- Skills that previously emitted JSON and relied on receiving a *string* are affected. I'd expect that to be a very small surface (the natural agent idiom is already to call `json.loads()` on the return when it matters). If we want to be strict, the decode can be gated on an opt-in env var or a skill-level flag — happy to do either.

## Motivation

Observed in a `research-environments/general-agent` run: the RLM agent called `list_events(date=…)` (returning `[]`), then correctly emitted `if existing: ... else: create_event(...)`, but `existing = "[]"` was truthy so it never hit the else branch. With this change the agent receives `[]` → `if existing:` is False → the create_event call fires.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the return type/semantics of shimmed skill `run()` calls by auto-decoding JSON, which may break callers that relied on JSON being returned as a string. Scope is limited to `kernel_shim` subprocess output handling.
> 
> **Overview**
> Proxy skill `run()` calls in `kernel_shim` now **attempt to `json.loads()` stdout** on success, returning native Python values for valid JSON (`[]`, `{}`, numbers, booleans, `null`, quoted strings) and falling back to the original string for non-JSON output.
> 
> This adds `_maybe_decode()` and widens the synthesized `run()` return annotation from `str` to `Any`, while leaving error-path output unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de664317b2eee3fc26a4d350f2b184b6a2ef3c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->