### PR TITLE
feat(kernel_shim): prefer in-process import over subprocess CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rlm"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/rlm/kernel_shim.py
+++ b/src/rlm/kernel_shim.py
@@ -1,11 +1,22 @@
 """Skill shims for external ipython kernels.
 
-Registers lightweight proxy modules so that ``import edit``,
-``edit.PARAMETERS``, and ``await edit.run(...)`` work in the ipython
-kernel — delegating to the skill CLIs on PATH via subprocess.
+Registers modules so that ``import edit``, ``edit.PARAMETERS``, and
+``await edit.run(...)`` work in the ipython kernel. Two dispatch paths:
 
-Shims are always installed regardless of whether a same-named module
-exists, guaranteeing the kernel uses the uploaded skills.
+* **In-process** — preferred. If the skill is importable from the
+  kernel's Python (i.e. it lives in the same venv as rlm, which is the
+  default layout produced by ``install.sh``), the real module is
+  registered directly. ``await edit.run(**kwargs)`` then calls the
+  skill's Python function with no process boundary: kwargs stay typed,
+  exceptions surface as native Python exceptions with real tracebacks,
+  and return values travel as native objects.
+* **Subprocess** — fallback for skills installed in an isolated venv
+  (not importable from the kernel). A proxy module shells out to the
+  skill's CLI on PATH, translating kwargs to ``--flag value`` pairs.
+
+The in-process path only wins when the importable module resolves to a
+file under the skill's own ``src/`` directory — that guards against a
+same-named PyPI package on ``sys.path`` shadowing the skill.
 
 Usage (called from _inject_startup)::
 
@@ -17,6 +28,8 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import importlib
+import importlib.util
 import os
 import shutil
 import sys
@@ -79,7 +92,7 @@ def _make_run(cli_name: str):
 
 
 def _make_proxy(name: str, parameters: dict) -> types.ModuleType:
-    """Create a proxy module for a skill."""
+    """Create a subprocess-dispatched proxy module for a skill."""
     mod = types.ModuleType(name)
     mod.__doc__ = f"Proxy for the {name} skill (delegates to CLI)."
     mod.__path__ = []  # make it look like a package
@@ -88,14 +101,43 @@ def _make_proxy(name: str, parameters: dict) -> types.ModuleType:
     return mod
 
 
+def _import_skill_module(skill_dir: Path, name: str) -> types.ModuleType | None:
+    """Import *name* only if it resolves to a file under ``skill_dir/src``.
+
+    Guards against a same-named PyPI package on ``sys.path`` shadowing
+    the skill: if the importable module lives somewhere else, we refuse
+    and let the caller fall back to the subprocess proxy.
+    """
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, ValueError):
+        return None
+    if spec is None or spec.origin is None:
+        return None
+    try:
+        origin = Path(spec.origin).resolve()
+        src_root = (skill_dir / "src").resolve()
+    except OSError:
+        return None
+    if not origin.is_relative_to(src_root):
+        return None
+    try:
+        return importlib.import_module(name)
+    except Exception:
+        return None
+
+
 def install_shims(skills_dir: str) -> list[str]:
-    """Register proxy modules for all skills found in *skills_dir*.
+    """Register modules for all skills found in *skills_dir*.
 
-    Always installs shims regardless of whether a same-named module is
-    already importable — this guarantees the kernel uses the rlm
-    checkout's version of each skill, not an unrelated package.
+    Prefers in-process import when the skill resolves to a file under
+    its own ``src/`` directory — this gives the kernel native Python
+    semantics (typed kwargs, real exceptions, native return values)
+    instead of the subprocess/CLI boundary. Falls back to the
+    subprocess CLI proxy when the skill isn't importable from the
+    kernel's Python (e.g. it's in an isolated venv).
 
-    Returns the list of skill names that were shimmed.
+    Returns the list of skill names that were registered.
     """
     skills_path = Path(skills_dir)
     if not skills_path.is_dir():
@@ -116,7 +158,13 @@ def install_shims(skills_dir: str) -> list[str]:
         else:
             continue
 
-        # Skip if the CLI isn't on PATH
+        real_mod = _import_skill_module(skill_dir, name)
+        if real_mod is not None and callable(getattr(real_mod, "run", None)):
+            sys.modules[name] = real_mod
+            shimmed.append(name)
+            continue
+
+        # Subprocess fallback — skill is not importable from the kernel.
         if not shutil.which(name):
             continue
 

--- a/tests/test_kernel_shim.py
+++ b/tests/test_kernel_shim.py
@@ -1,0 +1,231 @@
+"""Tests for in-process vs subprocess dispatch in kernel_shim.install_shims."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from rlm.kernel_shim import install_shims
+
+PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "date": {"type": "string"},
+    },
+    "required": ["title", "date"],
+}
+
+
+def _write_skill_package(skills_dir: Path, name: str, run_src: str) -> Path:
+    """Write a minimal skill package under *skills_dir*/name/."""
+    skill = skills_dir / name
+    src = skill / "src" / name
+    src.mkdir(parents=True, exist_ok=True)
+    (skill / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""
+            [project]
+            name = "rlm-skill-{name}"
+            version = "0.1.0"
+            requires-python = ">=3.10"
+
+            [project.scripts]
+            {name} = "{name}:main"
+            """
+        ).strip()
+        + "\n"
+    )
+    (src / "__init__.py").write_text(run_src)
+    return skill
+
+
+def _write_cli_on_path(bin_dir: Path, name: str, required: list[str]) -> Path:
+    """Write an executable argparse CLI to *bin_dir*/name and return its path."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / name
+    lines = [
+        f"#!{sys.executable}",
+        "import argparse, json",
+        "p = argparse.ArgumentParser(prog=" + repr(name) + ")",
+    ]
+    for f in required:
+        lines.append(f"p.add_argument('--{f.replace('_','-')}', required=True)")
+    lines.append("args = p.parse_args()")
+    lines.append("print(json.dumps(vars(args)))")
+    script.write_text("\n".join(lines) + "\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+@pytest.fixture
+def clean_modules():
+    """Snapshot sys.modules; restore after test so skill names don't leak."""
+    before = dict(sys.modules)
+    yield
+    for name in list(sys.modules):
+        if name not in before:
+            del sys.modules[name]
+        else:
+            sys.modules[name] = before[name]
+
+
+@pytest.fixture
+def cli_path(tmp_path, monkeypatch):
+    """Fresh bin dir prepended to PATH; returns the dir path."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH','')}")
+    return bin_dir
+
+
+# ---------- in-process path ----------
+
+_IN_PROCESS_SKILL_SRC = textwrap.dedent(
+    """
+    PARAMETERS = {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "date": {"type": "string"},
+        },
+        "required": ["title", "date"],
+    }
+
+    async def run(title: str, date: str) -> dict:
+        if date.count("-") != 2:
+            raise ValueError(f"bad date format: {date!r} (expected YYYY-MM-DD)")
+        return {"title": title, "date": date}
+    """
+).lstrip()
+
+
+def test_in_process_valid_call_returns_native_value(
+    tmp_path, monkeypatch, clean_modules, cli_path
+):
+    """A valid Python call returns the skill's real return value (dict, not str)."""
+    skills = tmp_path / "skills"
+    skill = _write_skill_package(skills, "in_proc_tool", _IN_PROCESS_SKILL_SRC)
+    monkeypatch.syspath_prepend(str(skill / "src"))
+    # CLI must be resolvable for parity with subprocess path; it's irrelevant
+    # here because in-process should win.
+    _write_cli_on_path(cli_path, "in_proc_tool", ["title", "date"])
+
+    shimmed = install_shims(str(skills))
+    assert "in_proc_tool" in shimmed
+
+    mod = sys.modules["in_proc_tool"]
+    assert getattr(mod, "__file__", None) and "in_proc_tool" in mod.__file__
+    result = asyncio.run(mod.run(title="Standup", date="2025-07-14"))
+    assert result == {"title": "Standup", "date": "2025-07-14"}
+
+
+def test_in_process_missing_kwarg_raises_native_typeerror(
+    tmp_path, monkeypatch, clean_modules, cli_path
+):
+    """Missing required kwarg surfaces as a native Python TypeError."""
+    skills = tmp_path / "skills"
+    skill = _write_skill_package(skills, "in_proc_tool", _IN_PROCESS_SKILL_SRC)
+    monkeypatch.syspath_prepend(str(skill / "src"))
+    _write_cli_on_path(cli_path, "in_proc_tool", ["title", "date"])
+
+    install_shims(str(skills))
+    mod = sys.modules["in_proc_tool"]
+    with pytest.raises(TypeError, match="date"):
+        asyncio.run(mod.run(title="Standup"))
+
+
+def test_in_process_skill_raised_exception_propagates(
+    tmp_path, monkeypatch, clean_modules, cli_path
+):
+    """An exception raised inside the skill reaches the caller unchanged."""
+    skills = tmp_path / "skills"
+    skill = _write_skill_package(skills, "in_proc_tool", _IN_PROCESS_SKILL_SRC)
+    monkeypatch.syspath_prepend(str(skill / "src"))
+    _write_cli_on_path(cli_path, "in_proc_tool", ["title", "date"])
+
+    install_shims(str(skills))
+    mod = sys.modules["in_proc_tool"]
+    with pytest.raises(ValueError, match="bad date format"):
+        asyncio.run(mod.run(title="Standup", date="2025/07/14"))
+
+
+# ---------- subprocess fallback path ----------
+
+def test_subprocess_fallback_missing_flag_returns_argparse_text(
+    tmp_path, clean_modules, cli_path
+):
+    """When the skill isn't importable, the shim uses subprocess and
+    argparse's stderr comes back as a string (matching the shell-call
+    experience, since the Python call translates kwargs to CLI flags)."""
+    skills = tmp_path / "skills"
+    # Skill package exists on disk but its src/ is NOT on sys.path, so the
+    # in-process import path refuses.
+    _write_skill_package(skills, "sub_tool", "PARAMETERS = {}\n")
+    _write_cli_on_path(cli_path, "sub_tool", ["title", "date"])
+
+    shimmed = install_shims(str(skills))
+    assert "sub_tool" in shimmed
+
+    mod = sys.modules["sub_tool"]
+    # Proxy module — no __file__ pointing into the skill.
+    assert getattr(mod, "__file__", None) is None
+
+    result = asyncio.run(mod.run())  # no kwargs -> CLI gets no flags
+    assert isinstance(result, str)
+    # argparse-style stderr message from our tiny CLI.
+    assert "required" in result.lower() and "--title" in result
+
+
+def test_subprocess_bash_call_gets_argparse_directly(cli_path):
+    """Independently confirm the CLI itself emits argparse text on stderr
+    for the bash/shell call site. No shim involved."""
+    _write_cli_on_path(cli_path, "bash_tool", ["title", "date"])
+    cli = cli_path / "bash_tool"
+
+    proc = subprocess.run([str(cli)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "required" in proc.stderr.lower()
+    assert "--title" in proc.stderr
+
+
+# ---------- shadow guard ----------
+
+def test_same_name_pypi_does_not_hijack_in_process_path(
+    tmp_path, monkeypatch, clean_modules, cli_path
+):
+    """If `<name>` is importable but resolves outside the skill's src/,
+    the shim refuses in-process and falls back to subprocess."""
+    # 1. A decoy module with the same name, importable from a DIFFERENT path.
+    decoy_dir = tmp_path / "decoy"
+    decoy_dir.mkdir()
+    (decoy_dir / "shadow_tool.py").write_text(
+        "async def run(**kwargs):\n    return 'HIJACKED'\n"
+    )
+    monkeypatch.syspath_prepend(str(decoy_dir))
+
+    # 2. A legitimate skill dir whose src/ is NOT on sys.path.
+    skills = tmp_path / "skills"
+    _write_skill_package(skills, "shadow_tool", "PARAMETERS = {}\n")
+    _write_cli_on_path(cli_path, "shadow_tool", ["title", "date"])
+
+    shimmed = install_shims(str(skills))
+    assert "shadow_tool" in shimmed
+
+    # The shim must NOT register the decoy — it falls back to subprocess.
+    mod = sys.modules["shadow_tool"]
+    assert getattr(mod, "__file__", None) is None  # proxy, not the decoy
+    assert "decoy" not in str(mod)
+
+    result = asyncio.run(mod.run())
+    assert isinstance(result, str)
+    assert "HIJACKED" not in result
+    assert "required" in result.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -272,6 +272,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipykernel"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -601,6 +610,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -810,6 +828,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -905,6 +941,11 @@ dependencies = [
     { name = "openai" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "ipykernel" },
@@ -912,6 +953,9 @@ requires-dist = [
     { name = "nest-asyncio" },
     { name = "openai", specifier = ">=1.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "six"
@@ -943,6 +987,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Skills installed into the same venv as the kernel's Python (the default layout from `install.sh`, which installs rlm and every `rlm-skill-*` into a single `uv tool install` venv) are now imported directly. `await <tool>.run(**kwargs)` in the IPython kernel calls the skill's async function with no process boundary.
- Falls back to the existing subprocess CLI proxy for skills that aren't importable from the kernel (e.g. in an isolated venv).
- Guardrail: a same-named PyPI package on `sys.path` cannot hijack the in-process path — we only use it when the module's file resolves under the skill's own `src/` directory.

## Why
The current shim always shells out to the skill CLI and translates kwargs into `--flag value` pairs. When the model called a skill from Python and got an arg wrong, the failure path was: argparse error on stderr → subprocess exits non-zero → shim returns stderr as a string. So a Python call surfaced as an argparse/bash-flavored error string, with no traceback and no exception object — easy for the agent to miss or misread.

With in-process dispatch:
- Kwargs stay typed (no string round-trip), so missing/unknown args raise native `TypeError` instead of argparse text.
- Skill-internal exceptions (`ValueError`, `ValidationError`, etc.) propagate with their real type and traceback.
- Return values travel as native Python objects rather than stringified stdout.

## Behavior preservation
- Subprocess fallback still covers third-party skills in isolated venvs and skills whose CLI is on PATH but module isn't importable.
- The `rlm`-itself sub-agent shim is unchanged — it still uses subprocess.
- `PARAMETERS`, `run`, and module docstring are taken from the real module when imported, matching what the proxy previously synthesized.