### PR TITLE
kernel_shim: callable skill/rlm proxies + pre-import into globals

### DIFF
--- a/src/rlm/kernel_shim.py
+++ b/src/rlm/kernel_shim.py
@@ -1,8 +1,11 @@
 """Skill shims for external ipython kernels.
 
 Registers lightweight proxy modules so that ``import edit``,
-``edit.PARAMETERS``, and ``await edit.run(...)`` work in the ipython
-kernel — delegating to the skill CLIs on PATH via subprocess.
+``edit.PARAMETERS``, ``await edit(...)``, and ``await edit.run(...)``
+all work in the ipython kernel — delegating to the skill CLIs on PATH
+via subprocess. The callable form (``await edit(...)``) and the named
+form (``await edit.run(...)``) are equivalent; the former is the
+advertised style, the latter is kept as a back-compat alias.
 
 Shims are always installed regardless of whether a same-named module
 exists, guaranteeing the kernel uses the uploaded skills.
@@ -102,9 +105,23 @@ def _make_run(cli_name: str):
     return run
 
 
+class _CallableModule(types.ModuleType):
+    """Module subclass that forwards ``__call__`` to ``self.run``.
+
+    Python's implicit special-method lookup finds ``__call__`` on the
+    type, so putting it here (rather than as an attribute on the
+    instance) is what makes ``await edit(...)`` actually work.
+    ``edit.run(...)`` keeps working too — it's the same coroutine
+    function assigned in ``_make_proxy``.
+    """
+
+    async def __call__(self, *args, **kwargs):
+        return await self.run(*args, **kwargs)
+
+
 def _make_proxy(name: str, parameters: dict) -> types.ModuleType:
     """Create a proxy module for a skill."""
-    mod = types.ModuleType(name)
+    mod = _CallableModule(name)
     mod.__doc__ = f"Proxy for the {name} skill (delegates to CLI)."
     mod.__path__ = []  # make it look like a package
     mod.PARAMETERS = parameters
@@ -148,13 +165,16 @@ def install_shims(skills_dir: str) -> list[str]:
         sys.modules[name] = _make_proxy(name, parameters)
         shimmed.append(name)
 
-    # Also shim `rlm` itself for sub-agent recursion
+    # Also shim `rlm` itself for sub-agent recursion. Unlike the real
+    # Python API (which returns a structured RLMResult), the shim only
+    # sees CLI stdout — just the answer — so it returns a plain string.
+    # Callers who want session_dir / usage / turns can read meta.json.
     if shutil.which("rlm"):
-        mod = types.ModuleType("rlm")
+        mod = _CallableModule("rlm")
         mod.__doc__ = "Proxy for the rlm CLI (sub-agent recursion)."
         mod.__path__ = []
 
-        async def _rlm_run(prompt: str, **kwargs) -> types.SimpleNamespace:
+        async def _rlm_run(prompt: str, **kwargs) -> str:
             cmd = ["rlm", prompt]
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -162,7 +182,7 @@ def install_shims(skills_dir: str) -> list[str]:
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, _ = await proc.communicate()
-            return types.SimpleNamespace(answer=stdout.decode().strip())
+            return stdout.decode().strip()
 
         mod.run = _rlm_run
         sys.modules["rlm"] = mod

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -42,10 +42,10 @@ def build_system_prompt(
         )
     if installed_skills:
         installed = ", ".join(f"`{skill}`" for skill in installed_skills)
-        skill_lines.append(f"Installed skills: {installed}.")
+        skill_lines.append(f"Installed skills (pre-imported): {installed}.")
         skill_lines.append(
-            "Each skill is available as a Python module by the same name: `import <skill>`. "
-            "Inspect its schema via `<skill>.PARAMETERS`, and call its async entrypoint via `<skill>.run(...)`."
+            "Call each skill directly: `await <skill>(...)`. "
+            "Inspect its schema via `<skill>.PARAMETERS`."
         )
         skill_lines.append(
             "Each skill is also available as a shell command by the same name: `<skill> ...`. "
@@ -70,8 +70,8 @@ def build_system_prompt(
         parts.extend(
             [
                 "",
-                "The `rlm` module is pre-imported. Call `await rlm.run('sub-task')` to spawn a recursive sub-agent.",
-                "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm.run('task1'), rlm.run('task2'))`.",
+                "The `rlm` module is pre-imported. Call `answer = await rlm('sub-task')` to spawn a recursive sub-agent; returns the sub-agent's final answer as a string.",
+                "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
             ]
         )
 

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -44,7 +44,7 @@ def build_system_prompt(
         installed = ", ".join(f"`{skill}`" for skill in installed_skills)
         skill_lines.append(f"Installed skills (pre-imported): {installed}.")
         skill_lines.append(
-            "Call each skill directly: `await <skill>(...)`. "
+            "Each skill is an async function by the same name. "
             "Inspect its schema via `<skill>.PARAMETERS`."
         )
         skill_lines.append(
@@ -70,7 +70,7 @@ def build_system_prompt(
         parts.extend(
             [
                 "",
-                "The `rlm` module is pre-imported. Call `answer = await rlm('sub-task')` to spawn a recursive sub-agent; returns the sub-agent's final answer as a string.",
+                "The `rlm` module is pre-imported. `rlm` is an async function: give it a prompt (string), get back the sub-agent's final answer (string). Use it to spawn a recursive sub-agent.",
                 "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
             ]
         )

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -148,6 +148,8 @@ class IPythonREPL:
         """Set up kernel: cwd, nest_asyncio, env vars, skill shims."""
         session_dir = str(self.session.dir) if self.session else None
         depth = int(os.environ.get("RLM_DEPTH", "0"))
+        max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
+        allow_recursion = depth < max_depth
         shim_file = str(Path(__file__).resolve().parent.parent / "kernel_shim.py")
         skills_dir = str(TASK_SKILLS_DIR)
 
@@ -169,7 +171,18 @@ import importlib.util as _ilu
 _spec = _ilu.spec_from_file_location("kernel_shim", {shim_file!r})
 _shim = _ilu.module_from_spec(_spec)
 _spec.loader.exec_module(_shim)
-_shim.install_shims({skills_dir!r})
+_shimmed = _shim.install_shims({skills_dir!r})
+
+# Pre-import each shimmed name into the kernel's user namespace so the
+# model can call skills directly (`await edit(...)`) without writing
+# `import edit` every turn. `rlm` is gated on recursion being allowed;
+# without the gate it would appear in globals in non-recursive envs,
+# which is confusing (the prompt doesn't advertise it there).
+_allow_recursion = {allow_recursion!r}
+for _name in _shimmed:
+    if _name == "rlm" and not _allow_recursion:
+        continue
+    globals()[_name] = sys.modules[_name]
 """
         self._execute_silent(setup_code)
 


### PR DESCRIPTION
Three related cleanups that make skill invocation from the model's ipython session both shorter and more intuitive:

1. `await edit(...)` as the canonical call form alongside `await edit.run(...)`. Implemented via a `ModuleType` subclass (`_CallableModule`) whose `__call__` forwards to `self.run`. `run` stays as a back-compat alias so cached prompts / existing code keep working.

2. Pre-import of shimmed names into the kernel's user namespace during startup, so the agent no longer has to write `import edit` every turn. `rlm` is gated on `allow_recursion` (same gate that guards the prompt's rlm section) — non-recursive envs don't get a confusing global.

3. rlm shim returns `str` instead of `SimpleNamespace(answer=...)`. The shim can only observe CLI stdout (which is just the answer), so the namespace wrapper held a single field and cost an unnecessary `.answer` access at every call site. The real Python API (`rlm.run` in `src/rlm/api.py`, returning `RLMResult`) is unchanged — this only affects how the model calls rlm from inside ipython.

Prompt wording updated to match: skills advertised as pre-imported and callable directly; rlm sub-agent call documented as `answer = await rlm('sub-task')` returning the sub-agent's final answer as a string.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes IPython kernel startup behavior and the skill/`rlm` invocation interface, which could break existing prompt assumptions or introduce name collisions in the kernel namespace.
> 
> **Overview**
> Updates IPython skill shims so each shimmed module is **directly awaitable** (e.g. `await edit(...)`) by introducing a callable `ModuleType` proxy while keeping `.<run(...)>` as a back-compat alias.
> 
> During kernel startup, automatically **pre-imports all shimmed skills into the user namespace** to avoid repeated `import <skill>` calls, and gates pre-import of `rlm` on recursion allowance derived from `RLM_DEPTH`/`RLM_MAX_DEPTH`.
> 
> Adjusts the `rlm` shim to return the CLI stdout as a plain `str` (instead of a namespace wrapper), and updates system-prompt wording to reflect pre-imported, callable skills and the new `rlm('sub-task')` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3228b27527ec713b51ee191576cef127587a3720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->