### PR TITLE
docs: add AGENTS.md with CLAUDE.md pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Writing code
+
+- **Minimal try/except**: let errors propagate — silent failures hide bugs. Only catch for intentional fault tolerance (retries, robustness).
+- **Targeted comments**: don't explain your work process or reference old code. Use comments sparingly to clarify ambiguous logic or non-obvious constraints.
+
+## Running code
+
+- **Always use uv**: run code with `uv run`, never raw `python`.
+- **Adding dependencies**: add to `pyproject.toml` and run `uv sync` (or `uv sync --group dev` for dev-only) to install and lock.
+
+## Testing
+
+- Run the suite with `uv run pytest tests/`.
+- Write tests as plain functions; don't use class-based tests.
+- **Conservative test additions**: don't add new tests unless the user asks or it's clearly necessary. Editing existing tests is fine.
+- **Test what matters**: only test code with clear, isolated logic. If you need to patch everything to make it testable, it's probably not worth testing.
+
+## Git
+
+- **Branch prefixes**: use `feat/`, `fix/`, `chore/`, `docs/`, `tests/`.
+
+## GitHub
+
+- **Draft PRs**: always create PRs as drafts (`gh pr create --draft`) to avoid triggering CI unnecessarily.
+- **Pull requests**: do not include a "test plan" section unless you actually ran tests or the user explicitly asked for one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` distilled from `~/prime-rl/AGENTS.md` and `~/verifiers/AGENTS.md` — minimal rlm-relevant guidance: uv-only, minimal try/except, conservative test additions, draft PRs, branch prefixes.
- Add `CLAUDE.md` containing just `@AGENTS.md` so Claude Code reads the same source of truth (same pattern prime-rl uses).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds contributor/agent workflow guidance; no runtime code paths are affected.
> 
> **Overview**
> Adds a new `AGENTS.md` document capturing lightweight project conventions (error handling, `uv` usage, testing practices, git/PR hygiene).
> 
> Introduces `CLAUDE.md` as a single-line pointer to `@AGENTS.md` so Claude Code follows the same shared guidance source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 735e0d977bd0592c8ea9a2e526b13be398dacdb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->