### PR TITLE
ci: add ci workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,21 @@
+name: Style
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Lint
+        uses: astral-sh/ruff-action@v3
+      - name: Format
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Lint
         uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.11"
       - name: Format
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.11"
           args: "format --check"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   ruff:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,14 +11,12 @@ jobs:
     name: Ruff
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install dependencies
+        run: uv sync
       - name: Lint
-        uses: astral-sh/ruff-action@v3
-        with:
-          version: "0.15.11"
+        run: uv run ruff check .
       - name: Format
-        uses: astral-sh/ruff-action@v3
-        with:
-          version: "0.15.11"
-          args: "format --check"
+        run: uv run ruff format --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Tests
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: RLM
+    name: Pytest
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,7 @@ name: Test
 on:
   push:
     branches: [main]
-    paths:
-      - "**.py"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/test.yml"
   pull_request:
-    branches: [main]
-    paths:
-      - "**.py"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/test.yml"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Pytest
+    name: RLM
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/test.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/test.yml"
+
+jobs:
+  test:
+    name: Pytest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install dependencies
+        run: uv sync
+      - name: Run tests
+        run: uv run pytest tests/


### PR DESCRIPTION
## Summary
Two GitHub Actions workflows, inspired by verifiers and prime-rl:

- `.github/workflows/style.yml` — runs `ruff check` and `ruff format --check` via `astral-sh/ruff-action@v3` on push/PR.
- `.github/workflows/test.yml` — runs `uv run pytest tests/` on a Python 3.12/3.13 matrix; gated on Python / `pyproject.toml` / `uv.lock` / the workflow itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds CI-only GitHub Actions workflows for lint/format and test execution without changing runtime code. Main risk is CI failures due to environment/dependency/matrix differences (Python 3.10–3.13).
> 
> **Overview**
> Adds two new GitHub Actions workflows to run on pushes to `main` and on pull requests.
> 
> `Style` installs dependencies via `uv` and enforces `ruff check` plus `ruff format --check`. `Test` runs `pytest` via `uv` across a Python version matrix (`3.10`–`3.13`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59547bfbd316ed1034ad55432de345a4a4d5e354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->