### PR TITLE
skills: opt-in callable_module helper for `await <skill>(...)`

### DIFF
--- a/src/rlm/__init__.py
+++ b/src/rlm/__init__.py
@@ -2,6 +2,12 @@
 
 from rlm.api import run
 from rlm.engine import RLMEngine
+from rlm.skill import callable_module
 from rlm.types import RLMMetrics, RLMResult
 
-__all__ = ["run", "RLMEngine", "RLMMetrics", "RLMResult"]
+__all__ = ["callable_module", "run", "RLMEngine", "RLMMetrics", "RLMResult"]
+
+# Opt the rlm module itself into the callable-shorthand helper we ship
+# for skill authors, so `await rlm('sub-task')` works identically to
+# `await rlm.run('sub-task')` inside an IPython cell.
+callable_module(__name__)

--- a/src/rlm/skill.py
+++ b/src/rlm/skill.py
@@ -1,0 +1,28 @@
+"""Public helpers for building rlm skills."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def callable_module(name: str) -> None:
+    """Make a skill module directly awaitable.
+
+    Call from the skill package's ``__init__.py`` after ``run`` is bound
+    at module scope::
+
+        from .edit import PARAMETERS, main, run
+        from rlm.skill import callable_module
+        callable_module(__name__)
+
+    After this runs, ``await edit(...)`` is equivalent to
+    ``await edit.run(...)``; ``edit.run`` and ``edit.PARAMETERS`` stay
+    accessible unchanged.
+    """
+
+    class _CallableSkill(types.ModuleType):
+        async def __call__(self, *args, **kwargs):
+            return await self.run(*args, **kwargs)
+
+    sys.modules[name].__class__ = _CallableSkill

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -151,7 +151,7 @@ class IPythonREPL:
         installed_skills = get_installed_skills()
 
         setup_code = f"""\
-import os, sys, types
+import os
 os.chdir({self.cwd!r})
 os.environ['RLM_SESSION_DIR'] = {session_dir!r} or ''
 os.environ['RLM_DEPTH'] = str({depth!r} + 1)
@@ -159,27 +159,12 @@ os.environ['RLM_DEPTH'] = str({depth!r} + 1)
 import nest_asyncio
 nest_asyncio.apply()
 
-
-class _CallableModule(types.ModuleType):
-    # Make `await <skill>(...)` shorthand for `await <skill>.run(...)`.
-    # __call__ is looked up on the type, not the instance, so the
-    # override has to live on the class.
-    async def __call__(self, *args, **kwargs):
-        return await self.run(*args, **kwargs)
-
-
-def _wrap_callable(mod):
-    wrapped = _CallableModule(mod.__name__)
-    wrapped.__dict__.update(mod.__dict__)
-    sys.modules[mod.__name__] = wrapped
-    return wrapped
-
-
 for _name in {installed_skills!r}:
-    globals()[_name] = _wrap_callable(__import__(_name))
+    globals()[_name] = __import__(_name)
 
 if {allow_recursion!r}:
-    globals()['rlm'] = _wrap_callable(__import__('rlm'))
+    import rlm
+    globals()['rlm'] = rlm
 """
         self._execute_silent(setup_code)
 


### PR DESCRIPTION
## Summary

Move the `await <skill>(...)` → `await <skill>.run(...)` shorthand out of rlm's kernel-startup f-string and into a tiny public helper skill authors opt into.

- **`rlm.skill.callable_module(name)`** — sets the skill module's `__class__` to a `ModuleType` subclass whose async `__call__` forwards to `self.run`. Call it once from the skill package's `__init__.py` after `run` is bound at module scope.
- **`src/rlm/__init__.py`** opts in for `rlm` itself, so `await rlm('sub-task')` keeps returning `RLMResult` inside the kernel.
- **`src/rlm/tools/ipython.py`** drops the kernel-side `_CallableModule` wrap loop. Kernel startup now just does `__import__(name)` for each installed skill and `import rlm` if recursion is allowed. No ModuleType subclassing in the f-string.

## Skill author usage

```python
# skills/edit/src/edit/__init__.py
from .edit import PARAMETERS, main, run

__all__ = ["PARAMETERS", "main", "run"]

from rlm.skill import callable_module
callable_module(__name__)
```

After this, `await edit(...)` is equivalent to `await edit.run(...)`; `edit.run`, `edit.PARAMETERS` stay accessible unchanged.

## Coordination

The system prompt continues to advertise *"Each skill is an async function by the same name"*. That promise is only true for skills that have adopted the opt-in, so **this PR must merge together with the coordinated research-environments migration**:

**→ PrimeIntellect-ai/research-environments#329** (draft): opts in for all seven existing skills (`rlm_swe/edit`, `rlm_deepdive/websearch`, `rlm_deepdive/open_webpage`, `rlm_browsecomp/{exa,serper}/{websearch,open_webpage}`). Two-line addition per `__init__.py`, no logic changes.

Merge order: merge #55 first, then #329 once the skill packages can pick up a released `rlm` that exposes `rlm.skill.callable_module`. Skills that never opt in stay as plain modules — callers write `await <skill>.run(...)`.

## Test plan

- [x] `pytest` (2/2) and `ruff check` clean
- [x] Direct smoke test: with `rlm.skill.callable_module` applied to a fake module exposing an async `run`, `await mod(...)` and `await mod.run(...)` return the same value and `mod.PARAMETERS` is intact
- [x] `import rlm` makes `rlm` callable: `callable(rlm)` is True and `type(rlm).__call__` forwards to `rlm.run`
- [ ] Coordinated research-environments#329 merged, then re-run `vf-eval rlm-swe` to confirm `await edit(...)` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)