### PR TITLE
feat(edit): richer feedback, atomic writes

### DIFF
--- a/src/rlm/tools/edit.py
+++ b/src/rlm/tools/edit.py
@@ -1,17 +1,24 @@
 """Builtin edit tool — safe single-occurrence string replacement.
 
-Ported from the ``edit`` skill in research-environments/rlm_swe. Kept as a
-builtin so it's available to any env that opts in via RLM_TOOLS, not just
-envs that ship the skill.
+Ported from the ``edit_via_str_replace`` tool in mini-swe-agent-plus:
+on ambiguity the tool reports the line numbers of every match so the
+model can add surrounding context and retry; on success it echoes a
+context snippet with line numbers so the model can confirm the edit
+landed in the right spot without re-reading the file.
 """
 
 from __future__ import annotations
 
 import copy
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
+
+
+_CONTEXT_LINES = 3
 
 
 EDIT_SCHEMA = {
@@ -20,7 +27,8 @@ EDIT_SCHEMA = {
         "name": "edit",
         "description": (
             "Replace a unique string in a file. old_str must appear exactly "
-            "once in the file."
+            "once in the file; otherwise the tool reports the line numbers "
+            "of every match so you can add surrounding context and retry."
         ),
         "parameters": {
             "type": "object",
@@ -42,6 +50,43 @@ EDIT_SCHEMA = {
         },
     },
 }
+
+
+def _find_all(haystack: str, needle: str) -> list[int]:
+    if not needle:
+        return []
+    positions: list[int] = []
+    start = 0
+    while True:
+        idx = haystack.find(needle, start)
+        if idx == -1:
+            return positions
+        positions.append(idx)
+        start = idx + len(needle)
+
+
+def _line_number(text: str, char_index: int) -> int:
+    return text.count("\n", 0, char_index) + 1
+
+
+def _snippet(new_content: str, replacement_line: int, new_str: str) -> str:
+    lines = new_content.split("\n")
+    extra = new_str.count("\n")
+    start = max(1, replacement_line - _CONTEXT_LINES)
+    end = min(len(lines), replacement_line + _CONTEXT_LINES + extra)
+    width = len(str(end))
+    return "\n".join(f"{i:>{width}} | {lines[i - 1]}" for i in range(start, end + 1))
+
+
+def _atomic_write(path: Path, data: str) -> None:
+    with tempfile.NamedTemporaryFile(
+        "w", delete=False, dir=str(path.parent), encoding="utf-8"
+    ) as f:
+        tmp_path = Path(f.name)
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(str(tmp_path), str(path))
 
 
 class EditTool:
@@ -73,16 +118,37 @@ class EditTool:
         except Exception as exc:
             return ToolOutcome(content=f"Error reading {path}: {exc}")
 
-        count = content.count(old_str)
-        if count == 0:
-            return ToolOutcome(content=f"Error: string not found in {path}")
-        if count > 1:
+        positions = _find_all(content, old_str)
+        if not positions:
             return ToolOutcome(
-                content=f"Error: found {count} occurrences, need exactly 1"
+                content=f"Error: old_str did not appear verbatim in {path}."
+            )
+        if len(positions) > 1:
+            line_nums = [_line_number(content, i) for i in positions]
+            return ToolOutcome(
+                content=(
+                    f"Error: found {len(positions)} occurrences of old_str in "
+                    f"{path} at lines {line_nums}. Expand old_str with "
+                    f"surrounding context so it matches exactly once."
+                )
             )
 
+        replace_start = positions[0]
+        replacement_line = _line_number(content, replace_start)
+        new_content = (
+            content[:replace_start] + new_str + content[replace_start + len(old_str) :]
+        )
+
         try:
-            filepath.write_text(content.replace(old_str, new_str, 1))
+            _atomic_write(filepath, new_content)
         except Exception as exc:
             return ToolOutcome(content=f"Error writing {path}: {exc}")
-        return ToolOutcome(content=f"Edited {path}")
+
+        snippet = _snippet(new_content, replacement_line, new_str)
+        return ToolOutcome(
+            content=(
+                f"Edited {path} at line {replacement_line}.\n"
+                f"{snippet}\n"
+                f"Review the changes and make sure they are as expected."
+            )
+        )


### PR DESCRIPTION
## Summary

Align the builtin `edit` tool with mini-swe-agent-plus's `edit_via_str_replace` so the model can iterate in one turn where it previously needed two. Same schema and tool name (`edit`), only the output text and write path change.

- **Multi-match error** now lists the line numbers of every occurrence (e.g. `lines [2, 7]`) so the model can add surrounding context and retry in a single turn instead of blindly re-reading the file.
- **Success** echoes a numbered context snippet around the edit so the model can confirm it landed in the right spot without a follow-up `cat`/`grep` turn.
- **Atomic writes** via temp-file + `os.replace` + `fsync` — a crash mid-write can no longer leave a half-written source file behind.

## Motivation

In a recent SWE-Bench-Verified-Quick (468 tasks) comparison with `zai-org/GLM-5.1-FP8`:

| Scaffold | Tools | Solve rate |
|---|---|---|
| rlm-swe (edit + bash) | current `edit` | **29.2%** |
| mini-swe-agent-plus | `edit_via_str_replace` | **~79%** |

Agent loop, loop prompt and grading are separate levers, but porting the edit-tool feedback shape is the smallest isolated change that closes part of the gap.

## What is unchanged

Schema (`{path, old_str, new_str}`), tool name (`edit`), and the single-occurrence invariant. No new kwargs, no behaviour change for callers already happy with the tool.