### PR TITLE
add max_context_tokens ceiling with overshoot rollback

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -539,8 +539,14 @@ class RLMEngine:
             # Detect new child sessions spawned via rlm()
             self._detect_new_children()
         else:
+            # Max turns hit. Don't surface msg.content here: after a
+            # hard-overshoot `continue` on the final iteration, `msg`
+            # is stale (or unassigned if max_turns == 1). And
+            # semantically, we only reach this branch when every turn
+            # had a tool_call — so msg.content is the model's
+            # intermediate reasoning, not an answer.
             self._metrics.stop_reason = "max_turns"
-            final_text = msg.content or "[max turns reached]"
+            final_text = "[max turns reached]"
 
         result = RLMResult(
             answer=final_text,

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -133,9 +133,7 @@ def _parse_positive_int(name: str, value: int | str | None) -> int | None:
     elif isinstance(value, int):
         parsed = value
     else:
-        raise ValueError(
-            f"{name} must be int or None (got {type(value).__name__})"
-        )
+        raise ValueError(f"{name} must be int or None (got {type(value).__name__})")
 
     if parsed <= 0:
         raise ValueError(f"{name} must be positive (got {parsed})")
@@ -256,9 +254,7 @@ class RLMEngine:
         if self.max_context_tokens is None:
             return {}
         remaining = (
-            self.max_context_tokens
-            - self._last_prompt_tokens
-            - _BUDGET_MARGIN_TOKENS
+            self.max_context_tokens - self._last_prompt_tokens - _BUDGET_MARGIN_TOKENS
         )
         if remaining <= 0:
             return {}

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -82,6 +82,12 @@ OVERSHOT_TOOL_RESULT_STUB = (
 # between our prompt_tokens accounting and whatever the server measures.
 _BUDGET_MARGIN_TOKENS = 128
 
+# Max times _compact_branch will roll back a fat tool result and retry
+# its own call when the compaction prompt overshoots max_context_tokens.
+# In practice one rollback suffices; the cap is a safety valve for
+# pathological shapes.
+_MAX_COMPACTION_ROLLBACK_RETRIES = 3
+
 
 def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:
     """Parse a tool-call arguments blob. Returns (args, error_info).
@@ -540,52 +546,92 @@ class RLMEngine:
         not a work turn — but its tokens land in ``_total_usage`` for
         cost accounting.
 
+        When the compaction call itself overshoots ``max_context_tokens``
+        — usually because soft compaction fires off the previous turn's
+        stale ``prompt_tokens`` just after a fat tool result was
+        appended — the most recent non-stub tool result is rolled back
+        to the stub and the call is retried. This mirrors the
+        normal-turn overshoot path, so soft compaction no longer
+        preempts the rollback-based recovery flow.
+
         Returns ``True`` on success. Returns ``False`` (and sets
-        ``stop_reason = "context_budget_exceeded"``) if the compaction
-        call itself overshot ``max_context_tokens`` — i.e. the
-        post-rollback messages are still larger than the ceiling and
-        there's nothing further to recover. Caller should break out of
-        the run loop.
+        ``stop_reason = "context_budget_exceeded"``) when the call
+        still overshoots after every available tool result has been
+        rolled back, or when the retry budget is exhausted. Caller
+        should break out of the run loop.
         """
-        # Measure what's about to be dropped BEFORE appending the
-        # checkpoint prompt — otherwise the prompt's own chars get
-        # counted as "dropped conversation content", inflating the
-        # metric and the session log's dropped_chars field.
-        dropped_chars = _count_messages_chars(messages[2:])
         turns_since_last = turn + 1 - self._branch_start_turn
 
-        # Append the checkpoint prompt and ask the model for a summary
-        # turn with NO tools available so it can only respond with text.
-        # Warn about the REPL restart only when a kernel is actually running.
+        # Build the checkpoint prompt once; appended fresh on each retry.
+        # Warn about REPL restart only when a kernel is actually running.
         checkpoint_prompt = CHECKPOINT_COMPACTION_PROMPT
         if self._repl is not None:
             checkpoint_prompt += REPL_RESTART_NOTE
-        messages.append({"role": "user", "content": checkpoint_prompt})
-        response = await self.client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            **self._completion_budget_kwargs(),
-        )
-        usage = extract_usage(response)
-        self._total_usage.prompt_tokens += usage.prompt_tokens
-        self._total_usage.completion_tokens += usage.completion_tokens
-        self._last_prompt_tokens = usage.prompt_tokens
 
-        # If the compaction call itself overshot, we can't recover: the
-        # rollback already happened (or nothing was left to roll back),
-        # and summarising an oversized prompt won't fit either. Fail the
-        # rollout cleanly.
-        if self._is_overshoot(usage.prompt_tokens):
-            self._metrics.stop_reason = "context_budget_exceeded"
+        # Try the compaction call; on overshoot, roll back a fat tool
+        # result and retry on the smaller messages list.
+        response = None
+        usage = None
+        for _ in range(_MAX_COMPACTION_ROLLBACK_RETRIES + 1):
+            messages.append({"role": "user", "content": checkpoint_prompt})
+            response = await self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                **self._completion_budget_kwargs(),
+            )
+            usage = extract_usage(response)
+            self._total_usage.prompt_tokens += usage.prompt_tokens
+            self._total_usage.completion_tokens += usage.completion_tokens
+            self._last_prompt_tokens = usage.prompt_tokens
+
+            if not self._is_overshoot(usage.prompt_tokens):
+                break
+
+            # Overshot. Pop the checkpoint we just appended, try to roll
+            # back a fat tool result, then retry. The assert guards
+            # against future edits that might append something else in
+            # this loop body.
+            assert messages[-1].get("content") == checkpoint_prompt
+            messages.pop()
+            rolled_back = self._rollback_last_tool_result(messages)
+            if not rolled_back:
+                self._metrics.stop_reason = "context_budget_exceeded"
+                self.session.log(
+                    {
+                        "type": "compaction_overshot",
+                        "turn": turn,
+                        "prompt_tokens": usage.prompt_tokens,
+                        "max_context_tokens": self.max_context_tokens,
+                    }
+                )
+                return False
+            self._metrics.note_overshoot_rollback()
             self.session.log(
                 {
-                    "type": "compaction_overshot",
+                    "type": "overshoot_rollback",
                     "turn": turn,
                     "prompt_tokens": usage.prompt_tokens,
                     "max_context_tokens": self.max_context_tokens,
                 }
             )
+        else:
+            # Retries exhausted without ever fitting under the ceiling.
+            self._metrics.stop_reason = "context_budget_exceeded"
+            self.session.log(
+                {
+                    "type": "compaction_overshot",
+                    "turn": turn,
+                    "prompt_tokens": usage.prompt_tokens if usage else None,
+                    "max_context_tokens": self.max_context_tokens,
+                }
+            )
             return False
+
+        # Measure what's about to be dropped AFTER retries: rollbacks
+        # already consumed whatever fat tool results triggered them
+        # (they're stubs now). The checkpoint at messages[-1] is
+        # infrastructure, not conversation content — exclude it.
+        dropped_chars = _count_messages_chars(messages[2:-1])
 
         summary_text = response.choices[0].message.content or ""
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -628,6 +628,16 @@ class RLMEngine:
             {"role": "user", "content": compacted_user_content},
         ]
 
+        # Reset the prompt-tokens tracker: the compaction call's
+        # prompt_tokens reflected the pre-compaction bloated messages,
+        # but we've just replaced them with [system, user(summary)].
+        # Leaving the old value would under-cap max_completion_tokens
+        # on the next turn (remaining budget = max_context - stale_big
+        # - margin → tiny). Resetting to 0 gives the next turn the
+        # full budget; the response comes back with an honest
+        # prompt_tokens that fixes the tracker for turns after.
+        self._last_prompt_tokens = 0
+
         # Log the compaction for traceability.
         self.session.log(
             {

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -67,6 +67,21 @@ POST_COMPACTION_FRAMING = (
     "information in this summary to assist with your own analysis:"
 )
 
+# Replaces a tool result whose presence in context pushed prompt_tokens
+# past max_context_tokens. Stays intentionally short so the rolled-back
+# conversation fits in whatever budget remains; the tool_call that
+# produced it stays intact on the assistant message above, so the model
+# can see what it intended to do.
+OVERSHOT_TOOL_RESULT_STUB = (
+    "[tool output dropped: the result would have pushed the conversation "
+    "past the context-token budget. The tool call above was not applied.]"
+)
+
+# Safety cushion subtracted from remaining-budget when computing
+# max_completion_tokens. Accounts for small provider bookkeeping drift
+# between our prompt_tokens accounting and whatever the server measures.
+_BUDGET_MARGIN_TOKENS = 128
+
 
 def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:
     """Parse a tool-call arguments blob. Returns (args, error_info).
@@ -99,35 +114,42 @@ def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:
     return args, None
 
 
-def _parse_summarize_at_tokens(value: int | str | None) -> int | None:
-    """Normalize ``summarize_at_tokens`` to a positive int or ``None``.
+def _parse_positive_int(name: str, value: int | str | None) -> int | None:
+    """Normalize a positive-int config value to ``int`` or ``None``.
 
-    Accepts:
-      - ``None`` / empty string → disabled.
-      - ``int`` → fixed threshold.
-      - ``str`` (from env var) → "N".
+    Accepts ``None`` / empty string → disabled, ``int`` → direct, ``str``
+    (from env var) → parsed. ``bool`` is rejected (``True`` is technically
+    an int, but passing it here is almost certainly a bug).
     """
     if value is None or value == "":
         return None
     if isinstance(value, bool):
-        raise ValueError("summarize_at_tokens must be an int")
+        raise ValueError(f"{name} must be an int")
     if isinstance(value, str):
         try:
             parsed = int(value.strip())
         except ValueError as exc:
-            raise ValueError(
-                f"summarize_at_tokens must be an int (got {value!r})"
-            ) from exc
+            raise ValueError(f"{name} must be an int (got {value!r})") from exc
     elif isinstance(value, int):
         parsed = value
     else:
         raise ValueError(
-            f"summarize_at_tokens must be int or None (got {type(value).__name__})"
+            f"{name} must be int or None (got {type(value).__name__})"
         )
 
     if parsed <= 0:
-        raise ValueError(f"summarize_at_tokens must be positive (got {parsed})")
+        raise ValueError(f"{name} must be positive (got {parsed})")
     return parsed
+
+
+def _parse_summarize_at_tokens(value: int | str | None) -> int | None:
+    """Normalize ``summarize_at_tokens`` to a positive int or ``None``."""
+    return _parse_positive_int("summarize_at_tokens", value)
+
+
+def _parse_max_context_tokens(value: int | str | None) -> int | None:
+    """Normalize ``max_context_tokens`` to a positive int or ``None``."""
+    return _parse_positive_int("max_context_tokens", value)
 
 
 class RLMEngine:
@@ -136,6 +158,7 @@ class RLMEngine:
         model: str | None = None,
         max_turns: int | None = None,
         summarize_at_tokens: int | None = None,
+        max_context_tokens: int | None = None,
         system_prompt_path: str | None = None,
         append_to_system_prompt: str | None = None,
         cwd: str | None = None,
@@ -159,6 +182,28 @@ class RLMEngine:
         else:
             env_value = summarize_at_tokens
         self.summarize_at_tokens = _parse_summarize_at_tokens(env_value)
+
+        # Hard context ceiling: caps per-call max_completion_tokens and
+        # triggers tool-result rollback when a response's prompt_tokens
+        # overshoots it. User kwarg wins; otherwise parse env var.
+        if max_context_tokens is None:
+            env_value = os.environ.get("RLM_MAX_CONTEXT_TOKENS")
+        else:
+            env_value = max_context_tokens
+        self.max_context_tokens = _parse_max_context_tokens(env_value)
+
+        # Invariant: the soft compaction trigger must be strictly below
+        # the hard ceiling, or compaction would fire at the ceiling with
+        # no room to generate a summary.
+        if (
+            self.summarize_at_tokens is not None
+            and self.max_context_tokens is not None
+            and self.summarize_at_tokens >= self.max_context_tokens
+        ):
+            raise ValueError(
+                f"summarize_at_tokens ({self.summarize_at_tokens}) must be "
+                f"< max_context_tokens ({self.max_context_tokens})"
+            )
 
         self.system_prompt_path = system_prompt_path or os.environ.get(
             "RLM_SYSTEM_PROMPT_PATH"
@@ -197,6 +242,52 @@ class RLMEngine:
             return
         session_dir = os.environ.get("RLM_SESSION_DIR")
         self.session = Session(session_dir)
+
+    def _completion_budget_kwargs(self) -> dict:
+        """Extra kwargs for ``chat.completions.create`` to cap generation.
+
+        When ``max_context_tokens`` is set, passes ``max_completion_tokens``
+        computed from the remaining budget so the provider enforces the
+        cap server-side. The floor is the provider's default (we just
+        don't pass the kwarg when the remaining budget goes non-positive);
+        the post-response overshoot check is responsible for recovery if
+        the model or a tool result still overflows.
+        """
+        if self.max_context_tokens is None:
+            return {}
+        remaining = (
+            self.max_context_tokens
+            - self._last_prompt_tokens
+            - _BUDGET_MARGIN_TOKENS
+        )
+        if remaining <= 0:
+            return {}
+        return {"max_completion_tokens": remaining}
+
+    def _is_overshoot(self, prompt_tokens: int) -> bool:
+        if self.max_context_tokens is None:
+            return False
+        return prompt_tokens > self.max_context_tokens
+
+    @staticmethod
+    def _rollback_last_tool_result(messages: list[dict]) -> bool:
+        """Replace the most recent non-stub tool result with the overshoot stub.
+
+        Returns True if a rollback was performed, False if no eligible
+        ``role="tool"`` message was found — in which case the caller
+        should treat the situation as unrecoverable (system + initial
+        user prompt alone overflowed the ceiling, or we've already
+        rolled back every tool result to the stub).
+        """
+        for i in range(len(messages) - 1, -1, -1):
+            msg = messages[i]
+            if (
+                msg.get("role") == "tool"
+                and msg.get("content") != OVERSHOT_TOOL_RESULT_STUB
+            ):
+                messages[i] = {**msg, "content": OVERSHOT_TOOL_RESULT_STUB}
+                return True
+        return False
 
     async def run(self, prompt: str) -> RLMResult:
         """Run a single agent loop to completion."""
@@ -252,6 +343,7 @@ class RLMEngine:
             request_kwargs = {
                 "model": self.model,
                 "messages": messages,
+                **self._completion_budget_kwargs(),
             }
             if active_tools:
                 request_kwargs["tools"] = active_tools
@@ -264,6 +356,41 @@ class RLMEngine:
             self._total_usage.prompt_tokens += usage.prompt_tokens
             self._total_usage.completion_tokens += usage.completion_tokens
             self._last_prompt_tokens = usage.prompt_tokens
+
+            # Overshoot: the request we just sent exceeded max_context_tokens.
+            # The usual culprit is a fat tool result that landed in messages
+            # between the previous turn and this one. Roll it back to a short
+            # stub, fire compaction on the cleaned messages, and discard this
+            # turn's response (its reasoning references the tool_result we
+            # just replaced, and its tool_call — if any — would dangle).
+            if self._is_overshoot(usage.prompt_tokens):
+                rolled_back = self._rollback_last_tool_result(messages)
+                if not rolled_back:
+                    self._metrics.stop_reason = "context_budget_exceeded"
+                    final_text = (
+                        f"[context budget exceeded "
+                        f"({usage.prompt_tokens} > {self.max_context_tokens}) "
+                        f"with no tool result to roll back]"
+                    )
+                    break
+                self._metrics.note_overshoot_rollback()
+                self.session.log(
+                    {
+                        "type": "overshoot_rollback",
+                        "turn": turn,
+                        "prompt_tokens": usage.prompt_tokens,
+                        "max_context_tokens": self.max_context_tokens,
+                    }
+                )
+                compact_ok = await self._compact_branch(messages, turn)
+                if not compact_ok:
+                    final_text = (
+                        f"[compaction call exceeded max_context_tokens "
+                        f"({self.max_context_tokens}); "
+                        f"initial prompt may be too large]"
+                    )
+                    break
+                continue
 
             # Record root usage and assistant-visible context for this turn.
             self._metrics.note_root_usage(
@@ -380,7 +507,13 @@ class RLMEngine:
                 self.summarize_at_tokens is not None
                 and usage.prompt_tokens >= self.summarize_at_tokens
             ):
-                await self._compact_branch(messages, turn)
+                compact_ok = await self._compact_branch(messages, turn)
+                if not compact_ok:
+                    final_text = (
+                        f"[compaction call exceeded max_context_tokens "
+                        f"({self.max_context_tokens})]"
+                    )
+                    break
         else:
             self._metrics.stop_reason = "max_turns"
             final_text = msg.content or "[max turns reached]"
@@ -402,7 +535,7 @@ class RLMEngine:
         )
         return result
 
-    async def _compact_branch(self, messages: list[dict], turn: int) -> None:
+    async def _compact_branch(self, messages: list[dict], turn: int) -> bool:
         """Ask the model for a handoff summary and rebuild ``messages``.
 
         Called in-place: mutates ``messages`` to ``[system, user(framing +
@@ -410,6 +543,13 @@ class RLMEngine:
         summary doesn't count toward ``max_turns`` — it's housekeeping,
         not a work turn — but its tokens land in ``_total_usage`` for
         cost accounting.
+
+        Returns ``True`` on success. Returns ``False`` (and sets
+        ``stop_reason = "context_budget_exceeded"``) if the compaction
+        call itself overshot ``max_context_tokens`` — i.e. the
+        post-rollback messages are still larger than the ceiling and
+        there's nothing further to recover. Caller should break out of
+        the run loop.
         """
         # Measure what's about to be dropped BEFORE appending the
         # checkpoint prompt — otherwise the prompt's own chars get
@@ -428,10 +568,28 @@ class RLMEngine:
         response = await self.client.chat.completions.create(
             model=self.model,
             messages=messages,
+            **self._completion_budget_kwargs(),
         )
         usage = extract_usage(response)
         self._total_usage.prompt_tokens += usage.prompt_tokens
         self._total_usage.completion_tokens += usage.completion_tokens
+        self._last_prompt_tokens = usage.prompt_tokens
+
+        # If the compaction call itself overshot, we can't recover: the
+        # rollback already happened (or nothing was left to roll back),
+        # and summarising an oversized prompt won't fit either. Fail the
+        # rollout cleanly.
+        if self._is_overshoot(usage.prompt_tokens):
+            self._metrics.stop_reason = "context_budget_exceeded"
+            self.session.log(
+                {
+                    "type": "compaction_overshot",
+                    "turn": turn,
+                    "prompt_tokens": usage.prompt_tokens,
+                    "max_context_tokens": self.max_context_tokens,
+                }
+            )
+            return False
 
         summary_text = response.choices[0].message.content or ""
 
@@ -474,6 +632,7 @@ class RLMEngine:
         )
         self._branch_start_turn = turn + 1
         self._metrics.turns_since_last_compaction = 0
+        return True
 
     def _load_system_prompt(
         self, messages_path: str, active_tools: list[BuiltinTool]

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -68,25 +68,29 @@ POST_COMPACTION_FRAMING = (
 )
 
 # Replaces a tool result whose presence in context pushed prompt_tokens
-# past max_context_tokens. Stays intentionally short so the rolled-back
-# conversation fits in whatever budget remains; the tool_call that
-# produced it stays intact on the assistant message above, so the model
-# can see what it intended to do.
+# past max_context_tokens. The tool WAS executed — real-world side
+# effects (filesystem writes, web calls) already happened — but its
+# output is being dropped so the rolled-back conversation fits in the
+# remaining budget.
 OVERSHOT_TOOL_RESULT_STUB = (
     "[tool output dropped: the result would have pushed the conversation "
-    "past the context-token budget. The tool call above was not applied.]"
+    "past the context-token budget. The tool ran but its output is not "
+    "visible.]"
+)
+
+# Written in place of a real tool result when soft compaction fires on
+# a turn whose assistant response had a tool_call. The tool was NOT
+# executed; we're compacting before running it. Preserves the model's
+# intent in the summary ("I was about to call X; my call was deferred").
+SOFT_COMPACT_SKIPPED_STUB = (
+    "[tool call skipped: the context-compaction threshold was reached "
+    "before this tool ran. It was not executed.]"
 )
 
 # Safety cushion subtracted from remaining-budget when computing
 # max_completion_tokens. Accounts for small provider bookkeeping drift
 # between our prompt_tokens accounting and whatever the server measures.
 _BUDGET_MARGIN_TOKENS = 128
-
-# Max times _compact_branch will roll back a fat tool result and retry
-# its own call when the compaction prompt overshoots max_context_tokens.
-# In practice one rollback suffices; the cap is a safety valve for
-# pathological shapes.
-_MAX_COMPACTION_ROLLBACK_RETRIES = 3
 
 
 def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:
@@ -466,6 +470,40 @@ class RLMEngine:
                 final_text = msg.content or ""
                 break
 
+            # Soft compaction: the model wants to continue (it has a
+            # tool_call) but this turn's prompt_tokens reached the
+            # threshold. Don't execute the tool; instead append a skip
+            # stub as the tool result so the model's intent is
+            # preserved in what compaction summarizes, then compact.
+            # Checks here — before tool execution — so the compaction
+            # call runs on messages that are still ≈ prompt_tokens + a
+            # small stub, guaranteeing it fits under the ceiling. Done
+            # responses (above) skip this path, so a final-answer turn
+            # is never wasted by soft compaction.
+            if (
+                self.summarize_at_tokens is not None
+                and usage.prompt_tokens >= self.summarize_at_tokens
+            ):
+                tc = msg.tool_calls[0]
+                self.session.log_tool_result(
+                    turn, tc.function.name, SOFT_COMPACT_SKIPPED_STUB, 0.0
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": SOFT_COMPACT_SKIPPED_STUB,
+                    }
+                )
+                compact_ok = await self._compact_branch(messages, turn)
+                if not compact_ok:
+                    final_text = (
+                        f"[compaction call exceeded max_context_tokens "
+                        f"({self.max_context_tokens})]"
+                    )
+                    break
+                continue
+
             # Execute the single allowed tool call (reuse parsed args from above;
             # parse failures have already broken the loop, so parsed_args[0] is
             # guaranteed to be a dict here).
@@ -500,22 +538,6 @@ class RLMEngine:
 
             # Detect new child sessions spawned via rlm()
             self._detect_new_children()
-
-            # Auto-compaction: if this turn's prompt_tokens reached the
-            # configured threshold, ask the model for a handoff summary and
-            # rebuild the branch around it. Fires at most once per loop
-            # iteration; the compaction op takes its own LLM call.
-            if (
-                self.summarize_at_tokens is not None
-                and usage.prompt_tokens >= self.summarize_at_tokens
-            ):
-                compact_ok = await self._compact_branch(messages, turn)
-                if not compact_ok:
-                    final_text = (
-                        f"[compaction call exceeded max_context_tokens "
-                        f"({self.max_context_tokens})]"
-                    )
-                    break
         else:
             self._metrics.stop_reason = "max_turns"
             final_text = msg.content or "[max turns reached]"
@@ -546,92 +568,56 @@ class RLMEngine:
         not a work turn — but its tokens land in ``_total_usage`` for
         cost accounting.
 
-        When the compaction call itself overshoots ``max_context_tokens``
-        — usually because soft compaction fires off the previous turn's
-        stale ``prompt_tokens`` just after a fat tool result was
-        appended — the most recent non-stub tool result is rolled back
-        to the stub and the call is retried. This mirrors the
-        normal-turn overshoot path, so soft compaction no longer
-        preempts the rollback-based recovery flow.
+        Callers run this on ``messages`` that should already fit under
+        the ceiling:
 
-        Returns ``True`` on success. Returns ``False`` (and sets
-        ``stop_reason = "context_budget_exceeded"``) when the call
-        still overshoots after every available tool result has been
-        rolled back, or when the retry budget is exhausted. Caller
-        should break out of the run loop.
+        - Hard path: the triggering response was discarded and the
+          fat tool result is already rolled back to the overshot stub.
+        - Soft path: the check fires on pre-append ``usage.prompt_tokens``
+          that's below the ceiling; the just-appended assistant + skip
+          stub add only a couple hundred tokens.
+
+        So the compaction call normally fits. Returns ``False`` (and
+        sets ``stop_reason = "context_budget_exceeded"``) only in the
+        pathological case where it overshoots anyway — e.g. system +
+        initial user prompt alone exceed the ceiling. Caller should
+        break out of the run loop.
         """
+        # Measure what's about to be dropped BEFORE appending the
+        # checkpoint prompt — otherwise the prompt's own chars get
+        # counted as "dropped conversation content", inflating the
+        # metric and the session log's dropped_chars field.
+        dropped_chars = _count_messages_chars(messages[2:])
         turns_since_last = turn + 1 - self._branch_start_turn
 
-        # Build the checkpoint prompt once; appended fresh on each retry.
-        # Warn about REPL restart only when a kernel is actually running.
+        # Append the checkpoint prompt and ask the model for a summary
+        # turn with NO tools available so it can only respond with text.
+        # Warn about the REPL restart only when a kernel is actually running.
         checkpoint_prompt = CHECKPOINT_COMPACTION_PROMPT
         if self._repl is not None:
             checkpoint_prompt += REPL_RESTART_NOTE
+        messages.append({"role": "user", "content": checkpoint_prompt})
+        response = await self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            **self._completion_budget_kwargs(),
+        )
+        usage = extract_usage(response)
+        self._total_usage.prompt_tokens += usage.prompt_tokens
+        self._total_usage.completion_tokens += usage.completion_tokens
+        self._last_prompt_tokens = usage.prompt_tokens
 
-        # Try the compaction call; on overshoot, roll back a fat tool
-        # result and retry on the smaller messages list.
-        response = None
-        usage = None
-        for _ in range(_MAX_COMPACTION_ROLLBACK_RETRIES + 1):
-            messages.append({"role": "user", "content": checkpoint_prompt})
-            response = await self.client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                **self._completion_budget_kwargs(),
-            )
-            usage = extract_usage(response)
-            self._total_usage.prompt_tokens += usage.prompt_tokens
-            self._total_usage.completion_tokens += usage.completion_tokens
-            self._last_prompt_tokens = usage.prompt_tokens
-
-            if not self._is_overshoot(usage.prompt_tokens):
-                break
-
-            # Overshot. Pop the checkpoint we just appended, try to roll
-            # back a fat tool result, then retry. The assert guards
-            # against future edits that might append something else in
-            # this loop body.
-            assert messages[-1].get("content") == checkpoint_prompt
-            messages.pop()
-            rolled_back = self._rollback_last_tool_result(messages)
-            if not rolled_back:
-                self._metrics.stop_reason = "context_budget_exceeded"
-                self.session.log(
-                    {
-                        "type": "compaction_overshot",
-                        "turn": turn,
-                        "prompt_tokens": usage.prompt_tokens,
-                        "max_context_tokens": self.max_context_tokens,
-                    }
-                )
-                return False
-            self._metrics.note_overshoot_rollback()
-            self.session.log(
-                {
-                    "type": "overshoot_rollback",
-                    "turn": turn,
-                    "prompt_tokens": usage.prompt_tokens,
-                    "max_context_tokens": self.max_context_tokens,
-                }
-            )
-        else:
-            # Retries exhausted without ever fitting under the ceiling.
+        if self._is_overshoot(usage.prompt_tokens):
             self._metrics.stop_reason = "context_budget_exceeded"
             self.session.log(
                 {
                     "type": "compaction_overshot",
                     "turn": turn,
-                    "prompt_tokens": usage.prompt_tokens if usage else None,
+                    "prompt_tokens": usage.prompt_tokens,
                     "max_context_tokens": self.max_context_tokens,
                 }
             )
             return False
-
-        # Measure what's about to be dropped AFTER retries: rollbacks
-        # already consumed whatever fat tool results triggered them
-        # (they're stubs now). The checkpoint at messages[-1] is
-        # infrastructure, not conversation content — exclude it.
-        dropped_chars = _count_messages_chars(messages[2:-1])
 
         summary_text = response.choices[0].message.content or ""
 

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -178,6 +178,9 @@ class RLMMetrics:
     compaction_chars_dropped_mean: float = 0.0
     compaction_summary_chars_mean: float = 0.0
 
+    # Number of tool-result rollbacks triggered by max_context_tokens overshoots.
+    overshoot_rollbacks: int = 0
+
     # IPython input size metrics
     ipython_input_chars_mean: float = 0.0
     ipython_input_loc_mean: float = 0.0
@@ -212,7 +215,7 @@ class RLMMetrics:
     sub_rlm_programmatic_tool_calls_python: int = 0
     sub_rlm_programmatic_tool_calls_bash: int = 0
 
-    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "invalid_tool_args", "depth_limit"
+    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "invalid_tool_args", "depth_limit", "context_budget_exceeded"
 
     @property
     def turns(self) -> int:
@@ -259,6 +262,10 @@ class RLMMetrics:
         self._current_branch_input_tokens = visible_input_tokens
         self._current_branch_output_tokens = visible_output_tokens
         self._refresh_derived_metrics()
+
+    def note_overshoot_rollback(self) -> None:
+        """Record a context-budget overshoot that triggered a tool-result rollback."""
+        self.overshoot_rollbacks += 1
 
     def finalize_current_branch(self) -> None:
         if (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import subprocess
 import sys
@@ -56,11 +57,18 @@ class DummyToolCall:
 
 @dataclass
 class DummyMessage:
-    """A scripted assistant turn."""
+    """A scripted assistant turn.
+
+    ``usage`` overrides the default (1, 1) ``DummyUsage`` on the
+    response, which is needed by tests that care about ``prompt_tokens``
+    — e.g. anything exercising ``summarize_at_tokens`` or
+    ``max_context_tokens``.
+    """
 
     content: str | None = None
     tool_calls: list[DummyToolCall] | None = None
     role: str = "assistant"
+    usage: "DummyUsage | None" = None
 
     def model_dump(self, exclude_none: bool = True) -> dict[str, Any]:
         out: dict[str, Any] = {"role": self.role, "content": self.content}
@@ -108,10 +116,18 @@ class DummyClient:
         self.completions = self
 
     async def create(self, **kwargs: Any) -> DummyResponse:
-        self.calls.append(kwargs)
+        # Snapshot ``messages`` so later in-place mutations by the engine
+        # (e.g. compaction rebuilds the list) don't retroactively change
+        # what a test sees when inspecting past calls.
+        recorded = dict(kwargs)
+        if "messages" in recorded:
+            recorded["messages"] = copy.deepcopy(recorded["messages"])
+        self.calls.append(recorded)
         if not self.scripted:
             raise AssertionError("DummyClient exhausted: no more scripted messages")
-        return DummyResponse(choices=[DummyChoice(message=self.scripted.pop(0))])
+        msg = self.scripted.pop(0)
+        usage = msg.usage if msg.usage is not None else DummyUsage()
+        return DummyResponse(choices=[DummyChoice(message=msg)], usage=usage)
 
 
 def tool_result(client: DummyClient, turn: int = 0) -> str:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,206 @@
+"""Tests for the context-token ceiling (``max_context_tokens``).
+
+Drives ``RLMEngine`` with scripted responses whose ``usage.prompt_tokens``
+is set explicitly, so we can verify:
+
+- the engine passes ``max_completion_tokens`` derived from remaining budget
+- an overshoot on a normal turn rolls back the last tool result and fires
+  compaction, discarding the overshot response
+- an overshoot on the compaction call itself is terminal
+  (``stop_reason = "context_budget_exceeded"``)
+- with no ceiling set, none of the above happens (huge ``prompt_tokens``
+  just pass through)
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import (
+    DummyClient,
+    DummyMessage,
+    DummyToolCall,
+    DummyUsage,
+)
+
+from rlm.engine import (
+    OVERSHOT_TOOL_RESULT_STUB,
+    POST_COMPACTION_FRAMING,
+    _BUDGET_MARGIN_TOKENS,
+    RLMEngine,
+)
+
+
+@pytest.fixture
+def no_tools(monkeypatch):
+    """Disable all tools so the engine doesn't spin up an ipython kernel."""
+    monkeypatch.setenv("RLM_TOOLS", "")
+
+
+async def test_completion_budget_kwarg_on_each_call(session, register_add_tool):
+    """``max_completion_tokens`` = max_context - last_prompt - margin on every call."""
+    messages = [
+        DummyMessage(
+            tool_calls=[DummyToolCall("add", {"a": 1, "b": 2})],
+            usage=DummyUsage(prompt_tokens=200, completion_tokens=30),
+        ),
+        DummyMessage(
+            content="done",
+            usage=DummyUsage(prompt_tokens=500, completion_tokens=20),
+        ),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        max_context_tokens=10_000,
+    )
+
+    await engine.run("go")
+
+    # First call: _last_prompt_tokens starts at 0, so cap is 10000 - 0 - margin.
+    assert (
+        client.calls[0]["max_completion_tokens"]
+        == 10_000 - 0 - _BUDGET_MARGIN_TOKENS
+    )
+    # Second call: after first response, _last_prompt_tokens is 200.
+    assert (
+        client.calls[1]["max_completion_tokens"]
+        == 10_000 - 200 - _BUDGET_MARGIN_TOKENS
+    )
+
+
+async def test_no_ceiling_no_budget_kwarg(session, register_add_tool):
+    """Without ``max_context_tokens`` set, no ``max_completion_tokens`` is sent."""
+    messages = [
+        DummyMessage(
+            content="done", usage=DummyUsage(prompt_tokens=999_999, completion_tokens=5)
+        ),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+
+    result = await engine.run("anything")
+
+    assert "max_completion_tokens" not in client.calls[0]
+    assert engine._metrics.overshoot_rollbacks == 0
+    assert engine._metrics.stop_reason == "done"
+    assert result.answer == "done"
+
+
+async def test_overshoot_rolls_back_and_compacts(session, register_add_tool):
+    """A tool result that overshoots → rollback to stub → compaction → loop continues."""
+    messages = [
+        # T1: model calls the tool. Prompt small, no overshoot yet.
+        DummyMessage(
+            tool_calls=[DummyToolCall("add", {"a": 2, "b": 3})],
+            usage=DummyUsage(prompt_tokens=300, completion_tokens=50),
+        ),
+        # T2: after tool result lands, the next call's prompt_tokens overshoots.
+        # This response will be discarded.
+        DummyMessage(
+            content="ignored",
+            usage=DummyUsage(prompt_tokens=15_000, completion_tokens=20),
+        ),
+        # Compaction call: post-rollback context is small again.
+        DummyMessage(
+            content="handoff summary",
+            usage=DummyUsage(prompt_tokens=400, completion_tokens=30),
+        ),
+        # T3: fresh context after compaction. Model finishes.
+        DummyMessage(
+            content="final answer",
+            usage=DummyUsage(prompt_tokens=600, completion_tokens=10),
+        ),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        max_context_tokens=10_000,
+    )
+
+    result = await engine.run("please do")
+
+    assert engine._metrics.overshoot_rollbacks == 1
+    assert engine._metrics.compactions_count == 1
+    assert engine._metrics.stop_reason == "done"
+    assert result.answer == "final answer"
+
+    # The compaction call saw the tool_result replaced by the stub.
+    compaction_msgs = client.calls[2]["messages"]
+    tool_msgs = [m for m in compaction_msgs if m.get("role") == "tool"]
+    assert tool_msgs and tool_msgs[-1]["content"] == OVERSHOT_TOOL_RESULT_STUB
+
+    # Post-compaction, messages are rebuilt as [system, user(framing+summary)].
+    post_msgs = client.calls[3]["messages"]
+    assert post_msgs[0]["role"] == "system"
+    assert post_msgs[1]["role"] == "user"
+    assert POST_COMPACTION_FRAMING in post_msgs[1]["content"]
+    assert "handoff summary" in post_msgs[1]["content"]
+    # No dangling tool messages referencing the discarded assistant turn.
+    assert "ignored" not in post_msgs[1]["content"]
+
+
+async def test_overshoot_with_nothing_to_roll_back_is_terminal(session, no_tools):
+    """Initial user prompt alone overshoots → rollout fails cleanly."""
+    messages = [
+        DummyMessage(
+            content="junk",
+            usage=DummyUsage(prompt_tokens=20_000, completion_tokens=5),
+        ),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        max_context_tokens=10_000,
+    )
+
+    result = await engine.run("enormous seed task")
+
+    assert engine._metrics.stop_reason == "context_budget_exceeded"
+    assert engine._metrics.overshoot_rollbacks == 0
+    assert "no tool result to roll back" in result.answer
+
+
+async def test_compaction_call_overshoot_is_terminal(session, register_add_tool):
+    """If compaction itself overshoots, rollout fails with context_budget_exceeded."""
+    messages = [
+        DummyMessage(
+            tool_calls=[DummyToolCall("add", {"a": 1, "b": 1})],
+            usage=DummyUsage(prompt_tokens=300, completion_tokens=20),
+        ),
+        # T2 overshoots → triggers rollback + compaction.
+        DummyMessage(
+            content="discarded",
+            usage=DummyUsage(prompt_tokens=15_000, completion_tokens=10),
+        ),
+        # Compaction call ALSO overshoots (e.g., system prompt alone is big).
+        DummyMessage(
+            content="never used",
+            usage=DummyUsage(prompt_tokens=11_000, completion_tokens=5),
+        ),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        max_context_tokens=10_000,
+    )
+
+    result = await engine.run("go")
+
+    assert engine._metrics.overshoot_rollbacks == 1
+    assert engine._metrics.compactions_count == 0
+    assert engine._metrics.stop_reason == "context_budget_exceeded"
+    assert "compaction call exceeded max_context_tokens" in result.answer
+
+
+def test_validation_summarize_must_be_below_ceiling():
+    """``summarize_at_tokens`` >= ``max_context_tokens`` is rejected at init."""
+    with pytest.raises(ValueError, match="summarize_at_tokens"):
+        RLMEngine(summarize_at_tokens=5_000, max_context_tokens=5_000)
+    with pytest.raises(ValueError, match="summarize_at_tokens"):
+        RLMEngine(summarize_at_tokens=6_000, max_context_tokens=5_000)
+    # Valid combo does not raise.
+    RLMEngine(summarize_at_tokens=4_000, max_context_tokens=5_000)

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -5,8 +5,11 @@ is set explicitly, so we can verify:
 
 - the engine passes ``max_completion_tokens`` derived from remaining budget
 - an overshoot on a normal turn rolls back the last tool result and fires
-  compaction, discarding the overshot response
-- an overshoot on the compaction call itself is terminal
+  compaction, discarding the overshot response (hard path)
+- soft compaction fires on a tool_call turn before execution: the tool
+  is not run, a skip stub replaces the would-be tool result, and
+  compaction runs on messages that fit under the ceiling by construction
+- compaction-call overshoot terminates cleanly
   (``stop_reason = "context_budget_exceeded"``)
 - with no ceiling set, none of the above happens (huge ``prompt_tokens``
   just pass through)
@@ -25,6 +28,7 @@ from conftest import (
 from rlm.engine import (
     OVERSHOT_TOOL_RESULT_STUB,
     POST_COMPACTION_FRAMING,
+    SOFT_COMPACT_SKIPPED_STUB,
     _BUDGET_MARGIN_TOKENS,
     RLMEngine,
 )
@@ -161,41 +165,31 @@ async def test_overshoot_with_nothing_to_roll_back_is_terminal(session, no_tools
     assert "no tool result to roll back" in result.answer
 
 
-async def test_compaction_call_overshoot_recovers_via_rollback(
-    session, register_add_tool
-):
-    """Soft compaction's own call overshoots → internal rollback + retry succeeds.
+async def test_soft_compaction_skips_tool_and_compacts(session, register_add_tool):
+    """Soft threshold crossed + tool_call present → tool is NOT run; stub + compact.
 
-    The ``summarize_at_tokens`` check uses the *previous* call's
-    ``prompt_tokens`` (stale: it doesn't reflect the current turn's
-    assistant + tool_result). When a fat tool_result lands between
-    turns, soft compaction can fire with a ``messages`` list already
-    past ``max_context_tokens``. Before the fix, that terminated the
-    rollout; now ``_compact_branch`` rolls the tool_result back to the
-    stub and retries its own call.
+    The model's assistant message (with its tool_call) is preserved, but
+    instead of executing the tool we append SOFT_COMPACT_SKIPPED_STUB as
+    the tool result. Compaction runs on those messages (prompt ≈
+    usage.prompt_tokens + small), guaranteed to fit under the ceiling.
+    The loop continues on the compacted state.
     """
     messages = [
-        # T1: model calls a tool. Prompt small.
+        # T1: small call, tool executes normally (add returns "5").
         DummyMessage(
-            tool_calls=[DummyToolCall("add", {"a": 1, "b": 2}, id="call_a")],
+            tool_calls=[DummyToolCall("add", {"a": 2, "b": 3}, id="call_a")],
             usage=DummyUsage(prompt_tokens=200, completion_tokens=30),
         ),
-        # T2: second tool call. prompt_tokens=4500 crosses summarize_at
-        # (4000) but not max_context (10000). No overshoot yet, so the
-        # normal turn runs to completion and then soft compaction fires
-        # on the stale 4500 value.
+        # T2: prompt_tokens crosses summarize_at (4000) but NOT
+        # max_context (10000). Response has a tool_call. Soft path
+        # fires BEFORE running the tool: stub is appended, compaction
+        # fires.
         DummyMessage(
-            tool_calls=[DummyToolCall("add", {"a": 2, "b": 3}, id="call_b")],
-            usage=DummyUsage(prompt_tokens=4500, completion_tokens=30),
+            tool_calls=[DummyToolCall("add", {"a": 4, "b": 5}, id="call_b")],
+            usage=DummyUsage(prompt_tokens=4_500, completion_tokens=30),
         ),
-        # Compaction call #1: after the fat(-ish) tool result from T2
-        # was appended, the actual prompt overshoots.
-        DummyMessage(
-            content="never used",
-            usage=DummyUsage(prompt_tokens=11_000, completion_tokens=10),
-        ),
-        # Compaction call #2: retried after rolling back T2's
-        # tool_result to the stub. Fits.
+        # Compaction call: fits by construction (no fat tool_result in
+        # messages because the tool was never run).
         DummyMessage(
             content="handoff summary",
             usage=DummyUsage(prompt_tokens=800, completion_tokens=30),
@@ -216,17 +210,51 @@ async def test_compaction_call_overshoot_recovers_via_rollback(
 
     result = await engine.run("do the thing")
 
-    # Compaction eventually succeeded after one internal rollback retry.
     assert engine._metrics.compactions_count == 1
-    assert engine._metrics.overshoot_rollbacks == 1
+    assert engine._metrics.overshoot_rollbacks == 0  # soft path doesn't roll back
     assert engine._metrics.stop_reason == "done"
     assert result.answer == "final answer"
 
-    # Compaction retry (call index 3) should have seen the rolled-back stub.
-    retry_call_msgs = client.calls[3]["messages"]
-    tool_msgs = [m for m in retry_call_msgs if m.get("role") == "tool"]
-    # T2's tool result (the most recent) is the one that got rolled back.
-    assert any(m["content"] == OVERSHOT_TOOL_RESULT_STUB for m in tool_msgs)
+    # Compaction call (index 2) should have seen the skip stub as T2's tool result.
+    compaction_msgs = client.calls[2]["messages"]
+    tool_msgs = [m for m in compaction_msgs if m.get("role") == "tool"]
+    assert any(m["content"] == SOFT_COMPACT_SKIPPED_STUB for m in tool_msgs)
+    # T1's real tool result ("5") is still there at this point — only
+    # T2's would-be result is the stub.
+    assert any(m["content"] == "5" for m in tool_msgs)
+    # The real `add` tool got called only once (for T1), not twice.
+    assert engine._metrics._ipython_call_count == 0  # no ipython — we only ran add
+
+
+async def test_soft_compaction_skips_on_done_response_is_unreachable(
+    session, register_add_tool
+):
+    """Done responses (no tool_call) can't trigger soft compaction.
+
+    Even if prompt_tokens >= summarize_at_tokens, a response without
+    tool_calls ends the rollout with ``stop_reason = "done"``; soft
+    compaction's placement after the done-check means it's never
+    reached. Protects final answers from being discarded.
+    """
+    messages = [
+        DummyMessage(
+            content="final answer",
+            usage=DummyUsage(prompt_tokens=5_000, completion_tokens=10),
+        ),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        summarize_at_tokens=4_000,
+        max_context_tokens=10_000,
+    )
+
+    result = await engine.run("easy")
+
+    assert engine._metrics.stop_reason == "done"
+    assert engine._metrics.compactions_count == 0
+    assert result.answer == "final answer"
 
 
 async def test_compaction_call_overshoot_is_terminal(session, register_add_tool):

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -161,6 +161,74 @@ async def test_overshoot_with_nothing_to_roll_back_is_terminal(session, no_tools
     assert "no tool result to roll back" in result.answer
 
 
+async def test_compaction_call_overshoot_recovers_via_rollback(
+    session, register_add_tool
+):
+    """Soft compaction's own call overshoots → internal rollback + retry succeeds.
+
+    The ``summarize_at_tokens`` check uses the *previous* call's
+    ``prompt_tokens`` (stale: it doesn't reflect the current turn's
+    assistant + tool_result). When a fat tool_result lands between
+    turns, soft compaction can fire with a ``messages`` list already
+    past ``max_context_tokens``. Before the fix, that terminated the
+    rollout; now ``_compact_branch`` rolls the tool_result back to the
+    stub and retries its own call.
+    """
+    messages = [
+        # T1: model calls a tool. Prompt small.
+        DummyMessage(
+            tool_calls=[DummyToolCall("add", {"a": 1, "b": 2}, id="call_a")],
+            usage=DummyUsage(prompt_tokens=200, completion_tokens=30),
+        ),
+        # T2: second tool call. prompt_tokens=4500 crosses summarize_at
+        # (4000) but not max_context (10000). No overshoot yet, so the
+        # normal turn runs to completion and then soft compaction fires
+        # on the stale 4500 value.
+        DummyMessage(
+            tool_calls=[DummyToolCall("add", {"a": 2, "b": 3}, id="call_b")],
+            usage=DummyUsage(prompt_tokens=4500, completion_tokens=30),
+        ),
+        # Compaction call #1: after the fat(-ish) tool result from T2
+        # was appended, the actual prompt overshoots.
+        DummyMessage(
+            content="never used",
+            usage=DummyUsage(prompt_tokens=11_000, completion_tokens=10),
+        ),
+        # Compaction call #2: retried after rolling back T2's
+        # tool_result to the stub. Fits.
+        DummyMessage(
+            content="handoff summary",
+            usage=DummyUsage(prompt_tokens=800, completion_tokens=30),
+        ),
+        # T3: post-compaction, model finishes.
+        DummyMessage(
+            content="final answer",
+            usage=DummyUsage(prompt_tokens=400, completion_tokens=10),
+        ),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        summarize_at_tokens=4_000,
+        max_context_tokens=10_000,
+    )
+
+    result = await engine.run("do the thing")
+
+    # Compaction eventually succeeded after one internal rollback retry.
+    assert engine._metrics.compactions_count == 1
+    assert engine._metrics.overshoot_rollbacks == 1
+    assert engine._metrics.stop_reason == "done"
+    assert result.answer == "final answer"
+
+    # Compaction retry (call index 3) should have seen the rolled-back stub.
+    retry_call_msgs = client.calls[3]["messages"]
+    tool_msgs = [m for m in retry_call_msgs if m.get("role") == "tool"]
+    # T2's tool result (the most recent) is the one that got rolled back.
+    assert any(m["content"] == OVERSHOT_TOOL_RESULT_STUB for m in tool_msgs)
+
+
 async def test_compaction_call_overshoot_is_terminal(session, register_add_tool):
     """If compaction itself overshoots, rollout fails with context_budget_exceeded."""
     messages = [

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -197,10 +197,16 @@ async def test_compaction_call_overshoot_is_terminal(session, register_add_tool)
 
 
 def test_validation_summarize_must_be_below_ceiling():
-    """``summarize_at_tokens`` >= ``max_context_tokens`` is rejected at init."""
+    """``summarize_at_tokens`` >= ``max_context_tokens`` is rejected at init.
+
+    A dummy client is passed so ``make_client()`` isn't invoked — otherwise
+    CI without ``OPENAI_API_KEY`` set would fail at the ``AsyncOpenAI()``
+    construction, long after the validation we're actually testing.
+    """
+    dummy = DummyClient([])
     with pytest.raises(ValueError, match="summarize_at_tokens"):
-        RLMEngine(summarize_at_tokens=5_000, max_context_tokens=5_000)
+        RLMEngine(summarize_at_tokens=5_000, max_context_tokens=5_000, client=dummy)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="summarize_at_tokens"):
-        RLMEngine(summarize_at_tokens=6_000, max_context_tokens=5_000)
+        RLMEngine(summarize_at_tokens=6_000, max_context_tokens=5_000, client=dummy)  # type: ignore[arg-type]
     # Valid combo does not raise.
-    RLMEngine(summarize_at_tokens=4_000, max_context_tokens=5_000)
+    RLMEngine(summarize_at_tokens=4_000, max_context_tokens=5_000, client=dummy)  # type: ignore[arg-type]

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -3,7 +3,6 @@
 Drives ``RLMEngine`` with scripted responses whose ``usage.prompt_tokens``
 is set explicitly, so we can verify:
 
-- the engine passes ``max_completion_tokens`` derived from remaining budget
 - an overshoot on a normal turn rolls back the last tool result and fires
   compaction, discarding the overshot response (hard path)
 - soft compaction fires on a tool_call turn before execution: the tool
@@ -11,8 +10,7 @@ is set explicitly, so we can verify:
   compaction runs on messages that fit under the ceiling by construction
 - compaction-call overshoot terminates cleanly
   (``stop_reason = "context_budget_exceeded"``)
-- with no ceiling set, none of the above happens (huge ``prompt_tokens``
-  just pass through)
+- with no ceiling set, huge ``prompt_tokens`` just pass through
 """
 
 from __future__ import annotations
@@ -29,7 +27,6 @@ from rlm.engine import (
     OVERSHOT_TOOL_RESULT_STUB,
     POST_COMPACTION_FRAMING,
     SOFT_COMPACT_SKIPPED_STUB,
-    _BUDGET_MARGIN_TOKENS,
     RLMEngine,
 )
 
@@ -38,37 +35,6 @@ from rlm.engine import (
 def no_tools(monkeypatch):
     """Disable all tools so the engine doesn't spin up an ipython kernel."""
     monkeypatch.setenv("RLM_TOOLS", "")
-
-
-async def test_completion_budget_kwarg_on_each_call(session, register_add_tool):
-    """``max_completion_tokens`` = max_context - last_prompt - margin on every call."""
-    messages = [
-        DummyMessage(
-            tool_calls=[DummyToolCall("add", {"a": 1, "b": 2})],
-            usage=DummyUsage(prompt_tokens=200, completion_tokens=30),
-        ),
-        DummyMessage(
-            content="done",
-            usage=DummyUsage(prompt_tokens=500, completion_tokens=20),
-        ),
-    ]
-    client = DummyClient(messages)
-    engine = RLMEngine(
-        client=client,  # type: ignore[arg-type]
-        session=session,
-        max_context_tokens=10_000,
-    )
-
-    await engine.run("go")
-
-    # First call: _last_prompt_tokens starts at 0, so cap is 10000 - 0 - margin.
-    assert (
-        client.calls[0]["max_completion_tokens"] == 10_000 - 0 - _BUDGET_MARGIN_TOKENS
-    )
-    # Second call: after first response, _last_prompt_tokens is 200.
-    assert (
-        client.calls[1]["max_completion_tokens"] == 10_000 - 200 - _BUDGET_MARGIN_TOKENS
-    )
 
 
 async def test_no_ceiling_no_budget_kwarg(session, register_add_tool):

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -59,13 +59,11 @@ async def test_completion_budget_kwarg_on_each_call(session, register_add_tool):
 
     # First call: _last_prompt_tokens starts at 0, so cap is 10000 - 0 - margin.
     assert (
-        client.calls[0]["max_completion_tokens"]
-        == 10_000 - 0 - _BUDGET_MARGIN_TOKENS
+        client.calls[0]["max_completion_tokens"] == 10_000 - 0 - _BUDGET_MARGIN_TOKENS
     )
     # Second call: after first response, _last_prompt_tokens is 200.
     assert (
-        client.calls[1]["max_completion_tokens"]
-        == 10_000 - 200 - _BUDGET_MARGIN_TOKENS
+        client.calls[1]["max_completion_tokens"] == 10_000 - 200 - _BUDGET_MARGIN_TOKENS
     )
 
 


### PR DESCRIPTION
Addresses the failure mode where a fat tool result (e.g. a log dump or a wide DataFrame print) inflates messages past the compaction threshold between turns. The existing usage.prompt_tokens check catches the next call's inflated input but only *after* paying for the oversized call, and compaction would then run on the same oversized context — so one overshoot billed twice.

Mechanism:

- New kwarg / env var: max_context_tokens / RLM_MAX_CONTEXT_TOKENS (int | None). Soft-fails when summarize_at_tokens >= it.
- Every chat.completions.create now carries max_completion_tokens = max_context - last_prompt_tokens - margin when the ceiling is set. vLLM enforces the cap server-side.
- Post-response, if usage.prompt_tokens > max_context_tokens, roll back the most recent non-stub tool result to OVERSHOT_TOOL_RESULT_STUB and fire compaction. The overshot response is discarded (its reasoning referenced the fat result, and its tool_call — if any — would dangle).
- If compaction's own call overshoots (post-rollback context is still too big), stop the rollout with stop_reason="context_budget_exceeded". Same stop_reason when there's nothing to roll back (huge initial user prompt).
- New metric: overshoot_rollbacks counter, bumped via RLMMetrics.note_overshoot_rollback(). Session log gets {"type": "overshoot_rollback", ...} for traceability. Not a CompactionApplied-style dataclass event — engine-emitted bookkeeping doesn't need the union-dispatch ceremony.

Tests: new tests/test_context_budget.py with six cases covering the budget kwarg, the disabled path, the rollback + compact flow, the no-tool-to-roll-back terminal case, the compaction-overshoots terminal case, and init validation.

Conftest: DummyMessage gains a per-response `usage` override so tests can script prompt_tokens; DummyClient deep-copies messages when recording calls so in-place mutation (compaction rebuilds the list) doesn't retroactively change what past-call inspection sees.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core agent loop to enforce a hard context ceiling and alters when tools execute (soft-compaction can skip tool runs), which can affect rollout control flow and outputs under high-token contexts.
> 
> **Overview**
> Adds an optional **hard context ceiling** via `max_context_tokens` / `RLM_MAX_CONTEXT_TOKENS`, which caps per-call generation by sending `max_completion_tokens` based on remaining budget.
> 
> If a turn returns `usage.prompt_tokens` over the ceiling, the engine now **rolls back the most recent tool result** to `OVERSHOT_TOOL_RESULT_STUB`, logs/metrics the rollback, runs compaction on the reduced context, and discards the overshot assistant response; if nothing can be rolled back (or compaction still overshoots), the run terminates with `stop_reason="context_budget_exceeded"`.
> 
> Moves auto-compaction to a **pre-tool “soft compaction”** path: when `summarize_at_tokens` is hit on a tool-call turn, the tool is skipped and a `SOFT_COMPACT_SKIPPED_STUB` tool message is appended before compacting, preserving intent without executing side effects. Updates tests and dummy LLM scaffolding to script per-response `usage` and validate the new ceiling/rollback behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25489e89dd73c13a27f3d7fe22d90155acb18e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->