### PR TITLE
restore programmatic_tool_calls logging for the python path

### DIFF
--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -151,13 +151,30 @@ class IPythonREPL:
         installed_skills = get_installed_skills()
 
         setup_code = f"""\
-import os, sys, types
+import os, sys, types, json, time
 os.chdir({self.cwd!r})
 os.environ['RLM_SESSION_DIR'] = {session_dir!r} or ''
 os.environ['RLM_DEPTH'] = str({depth!r} + 1)
 
 import nest_asyncio
 nest_asyncio.apply()
+
+
+def _log_programmatic_call(tool_name, source):
+    # Matches the line format written by install.sh's bash wrapper so
+    # ProgrammaticToolCallStats.from_log parses both sources identically.
+    session_dir = os.environ.get('RLM_SESSION_DIR', '')
+    if not session_dir:
+        return
+    try:
+        with open(os.path.join(session_dir, 'programmatic_tool_calls.jsonl'), 'a') as f:
+            f.write(json.dumps({{
+                'tool': tool_name,
+                'source': source,
+                'timestamp': time.time(),
+            }}) + '\\n')
+    except OSError:
+        pass
 
 
 class _CallableModule(types.ModuleType):
@@ -168,18 +185,26 @@ class _CallableModule(types.ModuleType):
         return await self.run(*args, **kwargs)
 
 
-def _wrap_callable(mod):
+def _wrap_callable(mod, log_source):
+    # log_source: 'python' for skills (logged to programmatic_tool_calls.jsonl),
+    # None for rlm (already aggregated via Session.aggregate_child_metrics).
     wrapped = _CallableModule(mod.__name__)
     wrapped.__dict__.update(mod.__dict__)
+    if log_source is not None:
+        _original_run = wrapped.run
+        async def _logged_run(*args, **kwargs):
+            _log_programmatic_call(mod.__name__, log_source)
+            return await _original_run(*args, **kwargs)
+        wrapped.run = _logged_run
     sys.modules[mod.__name__] = wrapped
     return wrapped
 
 
 for _name in {installed_skills!r}:
-    globals()[_name] = _wrap_callable(__import__(_name))
+    globals()[_name] = _wrap_callable(__import__(_name), 'python')
 
 if {allow_recursion!r}:
-    globals()['rlm'] = _wrap_callable(__import__('rlm'))
+    globals()['rlm'] = _wrap_callable(__import__('rlm'), None)
 """
         self._execute_silent(setup_code)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,10 +172,36 @@ def register_fixture_tools():
     mp.undo()
 
 
+_SKILL_WRAPPER_TEMPLATE = """\
+#!/usr/bin/env bash
+set -eo pipefail
+REAL_TOOL={real_path!r}
+TOOL_NAME={tool_name!r}
+SOURCE="${{RLM_TOOL_CALL_SOURCE:-bash}}"
+if [ -n "${{RLM_SESSION_DIR:-}}" ]; then
+  printf '{{"tool":"%s","source":"%s","timestamp":%s}}\\n' \\
+      "$TOOL_NAME" "$SOURCE" "$(date +%s.%N)" \\
+      >> "${{RLM_SESSION_DIR}}/programmatic_tool_calls.jsonl" 2>/dev/null || true
+fi
+exec "$REAL_TOOL" "$@"
+"""
+
+
 @pytest.fixture(scope="session", autouse=True)
 def install_fixture_skills():
-    """Editable-install every skill under ``tests/fixtures/skills/`` once per session."""
+    """Editable-install every skill under ``tests/fixtures/skills/`` once per session.
+
+    Also installs the same bash wrapper ``install.sh`` creates around each
+    skill CLI so that ``!<skill>`` invocations log a ``source="bash"`` entry
+    to ``programmatic_tool_calls.jsonl``. Without this the fixture
+    environment diverges from production and bash-path metrics tests fail.
+    """
     installed: list[str] = []
+    wrapped: list[tuple[Path, Path]] = []  # (wrapper_path, real_path)
+    bin_dir = Path(sys.executable).parent
+    real_tool_dir = bin_dir / ".rlm-real-tools"
+    real_tool_dir.mkdir(exist_ok=True)
+
     for skill_dir in sorted(SKILL_FIXTURES_DIR.iterdir()):
         if not (skill_dir / "pyproject.toml").is_file():
             continue
@@ -193,7 +219,24 @@ def install_fixture_skills():
             check=True,
         )
         installed.append(f"rlm-skill-{skill_dir.name.replace('_', '-')}")
+
+        tool_name = skill_dir.name
+        wrapper_path = bin_dir / tool_name
+        real_path = real_tool_dir / tool_name
+        if wrapper_path.is_file() and not real_path.is_file():
+            wrapper_path.rename(real_path)
+            wrapper_path.write_text(
+                _SKILL_WRAPPER_TEMPLATE.format(
+                    real_path=str(real_path), tool_name=tool_name
+                )
+            )
+            wrapper_path.chmod(0o755)
+            wrapped.append((wrapper_path, real_path))
     yield
+    for wrapper_path, real_path in wrapped:
+        wrapper_path.unlink(missing_ok=True)
+        if real_path.is_file():
+            real_path.rename(wrapper_path)
     for dist in installed:
         subprocess.run(
             ["uv", "pip", "uninstall", dist, "--python", sys.executable],

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -14,6 +14,8 @@ Kernel startup is ~700ms per test; keep the set here small.
 
 from __future__ import annotations
 
+import json
+
 from conftest import (
     DummyClient,
     DummyMessage,
@@ -44,6 +46,14 @@ async def test_python_skill_valid(session):
     show_tool_result(output)
     assert "hello" in output
     assert result.answer == "ok"
+
+    # The python-form call must be logged to programmatic_tool_calls.jsonl
+    # with source="python". Regressing this (e.g. subprocess shim gets
+    # replaced with an in-process wrap that forgets to log) silently zeroes
+    # the rlm_programmatic_tool_calls_python metric.
+    log_path = session.dir / "programmatic_tool_calls.jsonl"
+    entries = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert any(e["tool"] == "say" and e["source"] == "python" for e in entries)
 
 
 async def test_bash_skill_valid(session):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -14,8 +14,6 @@ Kernel startup is ~700ms per test; keep the set here small.
 
 from __future__ import annotations
 
-import json
-
 from conftest import (
     DummyClient,
     DummyMessage,
@@ -46,14 +44,6 @@ async def test_python_skill_valid(session):
     show_tool_result(output)
     assert "hello" in output
     assert result.answer == "ok"
-
-    # The python-form call must be logged to programmatic_tool_calls.jsonl
-    # with source="python". Regressing this (e.g. subprocess shim gets
-    # replaced with an in-process wrap that forgets to log) silently zeroes
-    # the rlm_programmatic_tool_calls_python metric.
-    log_path = session.dir / "programmatic_tool_calls.jsonl"
-    entries = [json.loads(line) for line in log_path.read_text().splitlines()]
-    assert any(e["tool"] == "say" and e["source"] == "python" for e in entries)
 
 
 async def test_bash_skill_valid(session):
@@ -192,3 +182,35 @@ async def test_bash_skill_halt_on_raise(session):
     show_tool_result(output)
     assert "RuntimeError" in output
     assert "RAN" not in output
+
+
+async def test_valid_python_skill_metrics(session):
+    """Python-form skill call increments programmatic_tool_calls_python."""
+    messages = [
+        DummyMessage(
+            tool_calls=[DummyToolCall("ipython", {"code": "await say(s='hi')"})]
+        ),
+        DummyMessage(content="ok"),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    await engine.run("say hi")
+
+    assert engine._metrics.programmatic_tool_calls_python == 1
+    assert engine._metrics.programmatic_tool_calls_bash == 0
+
+
+async def test_valid_bash_skill_metrics(session):
+    """Bash-form skill call (``!say ...``) increments programmatic_tool_calls_bash."""
+    messages = [
+        DummyMessage(tool_calls=[DummyToolCall("ipython", {"code": "!say --s hi"})]),
+        DummyMessage(content="ok"),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    await engine.run("say hi")
+
+    assert engine._metrics.programmatic_tool_calls_python == 0
+    assert engine._metrics.programmatic_tool_calls_bash == 1


### PR DESCRIPTION
#52 replaced the subprocess-based kernel_shim with an in-process _CallableModule wrap. The subprocess path had been the only writer of "python"-sourced entries to programmatic_tool_calls.jsonl: the old shim would set RLM_TOOL_CALL_SOURCE=python and exec the skill's CLI, which install.sh's bash wrapper then logged. With skills called in-process via `await edit(...)` / `await edit.run(...)`, no subprocess runs, the wrapper never fires, and the rlm_programmatic_tool_calls_python metric silently goes to zero. rlm_programmatic_tool_calls_bash still works (`!<skill>` in an ipython cell still hits the subprocess path).

Fix: instrument `_wrap_callable` at kernel startup to decorate `wrapped.run` with a helper that appends the same JSONL line format as the bash wrapper. Both `await skill(...)` (which routes through __call__ → self.run) and `await skill.run(...)` (direct) get logged. Caller-side reader (ProgrammaticToolCallStats.from_log) is unchanged and picks up the entries transparently.

`rlm` (when recursion is allowed) is also wrapped by _wrap_callable but opts out of the log with source=None — sub-agent calls already flow through Session.aggregate_child_metrics and double-counting there would be wrong.

Regression assertion: test_python_skill_valid now reads programmatic_tool_calls.jsonl and asserts an entry exists for the called skill with source="python".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to metrics logging (best-effort file append) and test scaffolding, with no impact on core tool execution semantics beyond wrapping `run`.
> 
> **Overview**
> Restores **programmatic tool-call logging** for the in-kernel Python skill path (`await <skill>(...)`) by decorating imported skill modules in `ipython` startup to append `{"tool", "source", "timestamp"}` JSONL entries to `programmatic_tool_calls.jsonl` with `source="python"`.
> 
> Updates test fixtures to install a bash wrapper around skill CLIs so `!<skill>` calls log `source="bash"` like production, and adds regression tests asserting `engine._metrics.programmatic_tool_calls_python` vs `_bash` increment correctly for Python-form vs bash-form skill calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7aa022743afcc401220137ed014fca612b1a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->