### PR TITLE
Add TASK_FINISHED stop ritual to system prompt

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -64,4 +64,20 @@ def build_system_prompt(
     if active_tools:
         parts.extend(["", "Call at most one built-in tool per turn."])
 
+    active_tool_names = {tool.name for tool in active_tools}
+    if "bash" in active_tool_names:
+        parts.extend(
+            [
+                "",
+                "When you are confident the task is complete and verified, signal the"
+                " end of the rollout by issuing exactly one `bash` tool call with the"
+                " command:",
+                "",
+                '    echo "TASK_FINISHED"',
+                "",
+                "Emit no further tool calls or text after this. You cannot continue"
+                " working on this task after submitting.",
+            ]
+        )
+
     return "\n".join(parts)


### PR DESCRIPTION
## Summary

Adds an explicit "I'm done" ritual to the rlm system prompt: when the model is confident the task is complete, it must emit exactly one `bash` tool call with the command `echo "TASK_FINISHED"` and emit nothing further. This is analogous to mini-swe-agent-plus's `MINI_SWE_AGENT_FINAL_OUTPUT` submission signal.

The new section is only appended when `bash` is an active tool, so non-bash configurations are unaffected.

## Motivation

The rlm engine already supports a passive-stop path when the model returns `tool_calls=[]`, but the model rarely takes that exit on its own. Analysis of v4-p1 step-27 rollouts showed a 54.5% rate of "summary-while-still-tool-calling" behavior — the agent narrates that it's done while continuing to issue tool calls — whereas mini-swe-agent-plus's analogous ritual is emitted in 97.4% of its rollouts.

A ritual + matching verifiers stop hook gives the engine a reliable way to terminate when the model commits to a fix, preventing that pathology.

## Companion PR

This prompt change is a **no-op without the companion verifiers PR** that watches for `TASK_FINISHED` in tool responses and concludes the rollout via `@vf.stop`. See PrimeIntellect-ai/verifiers (forthcoming companion PR) for the matching stop hook.

## Follow-ups

- Re-emission ablation once training catches up to this prompt change, to measure how often the model takes the new exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes system-prompt behavior to introduce a new termination signal, which can affect agent control flow and rollout stopping behavior when `bash` is enabled. Low code complexity but potentially impacts runtime behavior across tasks.
> 
> **Overview**
> Adds a new **explicit rollout termination ritual** to the system prompt: when `bash` is an active tool, the agent is instructed to finish by making exactly one `bash` call with `echo "TASK_FINISHED"` and then emit nothing further.
> 
> The prompt construction now conditionally appends this instruction based on `active_tools`, leaving non-`bash` tool configurations unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7543f1489ca7f972739b410458612c35031fc825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->