### PR TITLE
bash tool: don't crash on non-UTF-8 subprocess output

### DIFF
--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -81,6 +81,12 @@ class BashTool:
                 ["bash", "-c", command],
                 capture_output=True,
                 text=True,
+                # Replace invalid bytes with U+FFFD instead of raising.
+                # Without this, any non-UTF-8 byte in stdout (binary
+                # files, locale-encoded paths, truncated multibyte
+                # sequences) crashes the tool and propagates out as an
+                # AgentError that ends the rollout.
+                errors="replace",
                 timeout=timeout,
                 cwd=context.cwd or None,
             )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -68,3 +68,27 @@ async def test_tool_raises(session, register_boom_tool):
 
     with pytest.raises(RuntimeError, match="boom"):
         await engine.run(prompt)
+
+
+def test_bash_tool_handles_non_utf8_output():
+    """Bash command stdout containing invalid UTF-8 must not crash the tool.
+
+    `printf '\\xf0'` produces a single 0xf0 byte — a 4-byte UTF-8 lead
+    with no continuation bytes. Without ``errors="replace"`` on the
+    subprocess decode, this raises ``UnicodeDecodeError`` and propagates
+    up as an AgentError that ends the rollout.
+    """
+    from rlm.tools.base import ToolContext
+    from rlm.tools.bash import BashTool
+    from rlm.types import RLMMetrics, TokenUsage
+
+    tool = BashTool()
+    ctx = ToolContext(
+        messages=[],
+        metrics=RLMMetrics(),
+        total_usage=TokenUsage(),
+        last_prompt_tokens=0,
+        exec_timeout=10,
+    )
+    outcome = tool.execute({"command": "printf '\\xf0'"}, ctx)
+    assert "�" in outcome.content


### PR DESCRIPTION
subprocess.run(..., text=True) at tools/bash.py:80 was using the default 'strict' decoder. Any non-UTF-8 byte in the command's stdout/stderr (binary file dump, locale-encoded path, truncated-mid-multibyte ANSI output, git log against a repo with non-UTF-8 commit messages, etc.) raised UnicodeDecodeError, which propagated out of engine.run() as an AgentError and terminated the rollout. Saw this in production:
``UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf0 in position 81: invalid continuation byte`` from a bash tool call.

Pass errors="replace" so invalid bytes become U+FFFD (the standard replacement character) instead of crashing. The model gets a slightly garbled string instead of the rollout dying — strictly better.

Regression test: BashTool().execute({"command": "printf '\\xf0'"}) runs and returns content containing U+FFFD.

ipython tool not affected — it talks to the kernel via Jupyter Client, which handles its own decoding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes subprocess text decoding for the `bash` tool to avoid `UnicodeDecodeError`, with behavior limited to replacing invalid bytes in output.
> 
> **Overview**
> Prevents the `bash` tool from crashing when a command emits non-UTF-8 bytes by running `subprocess.run(..., text=True, errors="replace")`, so invalid output bytes become U+FFFD instead of raising and aborting the rollout.
> 
> Adds a regression test that runs `printf "\\xf0"` and asserts the tool returns output containing the replacement character.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b523e3660559f5f7af425d37042a01305a1b5573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->