### PR TITLE
compaction: clarify what survives the REPL restart

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -45,15 +45,13 @@ CHECKPOINT_COMPACTION_PROMPT = (
 )
 
 # Appended to the checkpoint prompt when the IPython REPL is active.
-# The kernel is restarted on compaction, so the next LLM inherits an
-# empty Python state — flag this so the summary captures anything the
-# next LLM would otherwise need to rebuild from scratch.
 REPL_RESTART_NOTE = (
     "\n\n"
     "Note: the IPython kernel will be restarted after this summary. "
-    "All Python variables, imports, loaded data, and in-memory state "
-    "will be wiped. Capture anything the next LLM needs to re-establish "
-    "(key values, file paths, loaded datasets, etc.) in the summary itself."
+    "Python variables, imports, loaded data, and in-memory state will "
+    "be wiped. Files on disk and any external side effects you've "
+    "already produced are preserved — capture file paths and what's "
+    "in them so the next LLM can pick up without re-doing work."
 )
 
 # Wrapper text that frames the summary as the sole user-facing context


### PR DESCRIPTION
The old REPL_RESTART_NOTE only listed what gets wiped (Python variables, imports, loaded data, in-memory state) and hinted at file preservation only via the example "(key values, file paths, loaded datasets, etc.)". A model reading this can reasonably wonder whether files themselves persist or just the names.

Make the boundary explicit: files on disk and other external side effects are preserved. The model can then capture file paths + contents-as-needed in the summary instead of re-doing file work or inflating the summary with file contents it could just re-read on the next branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the compaction handoff prompt text shown during REPL-backed runs, with no runtime logic or state-handling changes.
> 
> **Overview**
> Updates `REPL_RESTART_NOTE` in `src/rlm/engine.py` to explicitly state that an IPython-kernel restart wipes only in-memory Python state, while **files on disk and other external side effects are preserved**, and to instruct the model to record relevant file paths/contents in the handoff summary to avoid rework.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44749bb9ae9d3c21d4c0770a8bebce21e0a4d6c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->