### PR TITLE
summarize_at_tokens: accept (lo, hi) for per-group seeded draw

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -133,8 +133,7 @@ def _parse_summarize_at_tokens(
             parsed = (ints[0], ints[1])
         else:
             raise ValueError(
-                f"summarize_at_tokens string must have 1 or 2 ints "
-                f"(got {value!r})"
+                f"summarize_at_tokens string must have 1 or 2 ints (got {value!r})"
             )
     elif isinstance(value, int):
         parsed = value
@@ -160,9 +159,7 @@ def _parse_summarize_at_tokens(
             f"summarize_at_tokens values must be positive (got lo={lo}, hi={hi})"
         )
     if lo > hi:
-        raise ValueError(
-            f"summarize_at_tokens lo must be <= hi (got lo={lo}, hi={hi})"
-        )
+        raise ValueError(f"summarize_at_tokens lo must be <= hi (got lo={lo}, hi={hi})")
     return parsed
 
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
+import random
 import time
 from pathlib import Path
 
@@ -99,35 +101,92 @@ def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:
     return args, None
 
 
-def _parse_summarize_at_tokens(value: int | str | None) -> int | None:
-    """Normalize ``summarize_at_tokens`` to a positive int or ``None``.
+def _parse_summarize_at_tokens(
+    value: int | tuple[int, int] | list[int] | str | None,
+) -> int | tuple[int, int] | None:
+    """Normalize ``summarize_at_tokens`` to int, ``(lo, hi)``, or ``None``.
 
     Accepts:
       - ``None`` / empty string → disabled.
       - ``int`` → fixed threshold.
-      - ``str`` (from env var) → "N".
+      - ``(lo, hi)`` / ``[lo, hi]`` → range; the engine draws a stable
+        per-prompt threshold from this range at run time.
+      - ``str`` (from env var) → ``"N"`` or ``"lo,hi"``.
     """
     if value is None or value == "":
         return None
     if isinstance(value, bool):
-        raise ValueError("summarize_at_tokens must be an int")
+        raise ValueError("summarize_at_tokens must be an int or (lo, hi) pair")
     if isinstance(value, str):
+        parts = [p.strip() for p in value.split(",") if p.strip()]
+        if not parts:
+            return None
         try:
-            parsed = int(value.strip())
+            ints = [int(p) for p in parts]
         except ValueError as exc:
             raise ValueError(
-                f"summarize_at_tokens must be an int (got {value!r})"
+                f"summarize_at_tokens must be 'N' or 'lo,hi' (got {value!r})"
             ) from exc
+        if len(ints) == 1:
+            parsed: int | tuple[int, int] = ints[0]
+        elif len(ints) == 2:
+            parsed = (ints[0], ints[1])
+        else:
+            raise ValueError(
+                f"summarize_at_tokens string must have 1 or 2 ints "
+                f"(got {value!r})"
+            )
     elif isinstance(value, int):
         parsed = value
+    elif isinstance(value, (tuple, list)):
+        if len(value) != 2:
+            raise ValueError(
+                f"summarize_at_tokens pair must have 2 elements (got {value!r})"
+            )
+        parsed = (int(value[0]), int(value[1]))
     else:
         raise ValueError(
-            f"summarize_at_tokens must be int or None (got {type(value).__name__})"
+            f"summarize_at_tokens must be int, (lo, hi), or None "
+            f"(got {type(value).__name__})"
         )
 
-    if parsed <= 0:
-        raise ValueError(f"summarize_at_tokens must be positive (got {parsed})")
+    if isinstance(parsed, int):
+        if parsed <= 0:
+            raise ValueError(f"summarize_at_tokens must be positive (got {parsed})")
+        return parsed
+    lo, hi = parsed
+    if lo <= 0 or hi <= 0:
+        raise ValueError(
+            f"summarize_at_tokens values must be positive (got lo={lo}, hi={hi})"
+        )
+    if lo > hi:
+        raise ValueError(
+            f"summarize_at_tokens lo must be <= hi (got lo={lo}, hi={hi})"
+        )
     return parsed
+
+
+def _draw_summarize_at_tokens(
+    value: int | tuple[int, int] | None,
+    prompt: str,
+    seed: str,
+) -> int | None:
+    """Resolve a ``summarize_at_tokens`` value to a concrete int.
+
+    Ints and ``None`` pass through. A ``(lo, hi)`` range is hashed
+    against ``f"{prompt}|{seed}"`` (sha256) and draws uniformly from
+    ``[lo, hi]``. Identical (prompt, seed) → identical threshold;
+    different prompts or different seeds → different threshold.
+
+    Stable across processes and Python versions because hashlib.sha256
+    is not affected by PYTHONHASHSEED.
+    """
+    if value is None or isinstance(value, int):
+        return value
+    lo, hi = value
+    digest = hashlib.sha256(f"{prompt}|{seed}".encode("utf-8")).hexdigest()
+    seed_int = int(digest[:16], 16)
+    return random.Random(seed_int).randint(lo, hi)
 
 
 class RLMEngine:
@@ -135,7 +194,8 @@ class RLMEngine:
         self,
         model: str | None = None,
         max_turns: int | None = None,
-        summarize_at_tokens: int | None = None,
+        summarize_at_tokens: int | tuple[int, int] | list[int] | None = None,
+        random_seed: int | None = None,
         system_prompt_path: str | None = None,
         append_to_system_prompt: str | None = None,
         cwd: str | None = None,
@@ -154,11 +214,21 @@ class RLMEngine:
         self.max_output = max_output
 
         # Auto-compaction threshold: user kwarg wins; otherwise parse env var.
+        # May be int (fixed) or (lo, hi) (range; draws at run() time).
         if summarize_at_tokens is None:
             env_value = os.environ.get("RLM_SUMMARIZE_AT_TOKENS")
         else:
             env_value = summarize_at_tokens
         self.summarize_at_tokens = _parse_summarize_at_tokens(env_value)
+
+        # Seed for the per-prompt threshold draw. Default is fixed so
+        # rollouts are reproducible by default; vary externally for
+        # multi-run sweeps.
+        self._random_seed = (
+            str(random_seed)
+            if random_seed is not None
+            else os.environ.get("RLM_RANDOM_SEED", "1234567")
+        )
 
         self.system_prompt_path = system_prompt_path or os.environ.get(
             "RLM_SYSTEM_PROMPT_PATH"
@@ -206,6 +276,13 @@ class RLMEngine:
                 answer=f"[depth limit {self.max_depth} reached, cannot start]",
                 turns=0,
             )
+
+        # Resolve a (lo, hi) range to a concrete int once per rollout,
+        # seeded by (prompt, random_seed). Same (prompt, seed) → same
+        # threshold for every rollout in a group.
+        self.summarize_at_tokens = _draw_summarize_at_tokens(
+            self.summarize_at_tokens, prompt, self._random_seed
+        )
 
         self._ensure_session()
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -70,6 +70,36 @@ async def test_tool_raises(session, register_boom_tool):
         await engine.run(prompt)
 
 
+def test_draw_summarize_at_tokens_is_deterministic_per_prompt():
+    """``(lo, hi)`` resolves to the same int for the same (prompt, seed).
+
+    Range collision odds are kept negligible by using a wide range
+    (~10^9), so the inequality assertions are effectively
+    non-probabilistic.
+    """
+    from rlm.engine import _draw_summarize_at_tokens
+
+    # int and None pass through unchanged
+    assert _draw_summarize_at_tokens(500, "any", "42") == 500
+    assert _draw_summarize_at_tokens(None, "any", "42") is None
+
+    # Same (prompt, seed) → same draw, always in range
+    a = _draw_summarize_at_tokens((1000, 2000), "task A", "42")
+    b = _draw_summarize_at_tokens((1000, 2000), "task A", "42")
+    assert a == b
+    assert 1000 <= a <= 2000
+
+    # Different prompt → different draw
+    c = _draw_summarize_at_tokens((1, 10**9), "task A", "42")
+    d = _draw_summarize_at_tokens((1, 10**9), "task B", "42")
+    assert c != d
+
+    # Different seed → different draw
+    e = _draw_summarize_at_tokens((1, 10**9), "task A", "42")
+    f = _draw_summarize_at_tokens((1, 10**9), "task A", "different")
+    assert e != f
+
+
 def test_bash_tool_handles_non_utf8_output():
     """Bash command stdout containing invalid UTF-8 must not crash the tool.
 


### PR DESCRIPTION
When `summarize_at_tokens` is given as a (lo, hi) range, draw a threshold once per rollout from a sha256-seeded RNG over ``f"{prompt}|{random_seed}"``. All rollouts of the same prompt in a GRPO-style group see byte-identical input, so they get the same threshold — group coherence preserved. Different prompts get different draws; different runs (with different seeds) get different draws for the same prompt.

Stable hash via `hashlib.sha256`, not Python's `hash()` (which is process-randomized via PYTHONHASHSEED and would silently break group coherence across rollout subprocesses).

New kwarg / env var:

- `summarize_at_tokens` accepts` int | (lo, hi) | "N" | "lo,hi" | None`
- `random_seed` (kwarg) / `RLM_RANDOM_SEED`(env var); default `"1234567"` so rollouts are reproducible by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the engine’s auto-compaction threshold semantics by allowing a per-run deterministic random draw, which can subtly alter when compactions trigger and affect rollout behavior. Risk is limited to compaction/metrics behavior and is covered by a new determinism unit test.
> 
> **Overview**
> **Extends auto-compaction configuration** so `summarize_at_tokens` can be a fixed int *or* a `(lo, hi)` range (also accepted via env var string like `"lo,hi"`).
> 
> When a range is provided, `RLMEngine.run()` now resolves it once per rollout via `_draw_summarize_at_tokens`, using a sha256-based seed over `(prompt, random_seed)` (new `random_seed` kwarg / `RLM_RANDOM_SEED`) to ensure deterministic thresholds across processes for the same prompt/seed.
> 
> Adds a unit test asserting determinism and prompt/seed sensitivity for the draw logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2858ce1b5a91c4569c029cf82129f285ea1bc734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->