### PR TITLE
metrics: add has_compacted (1 if any compaction fired this rollout)

### DIFF
--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -172,6 +172,7 @@ class RLMMetrics:
 
     # Compaction metrics (auto-summarization at a token threshold)
     compactions_count: int = 0
+    has_compacted: int = 0  # 1 if compactions_count > 0, else 0; aggregates as the per-batch fraction of rollouts that compacted
     turns_since_last_compaction: int = 0
     turns_between_compactions_mean: float = 0.0
     compaction_turns_dropped_mean: float = 0.0
@@ -367,6 +368,7 @@ class RLMMetrics:
             self.ipython_input_loc_mean = (
                 self._ipython_input_loc_total / self._ipython_call_count
             )
+        self.has_compacted = 1 if self.compactions_count > 0 else 0
         if self.compactions_count:
             self.turns_between_compactions_mean = (
                 self._turns_between_compactions_total / self.compactions_count


### PR DESCRIPTION
Derived from compactions_count in _refresh_derived_metrics. Per-rollout the metric is 0 or 1; aggregated across a training batch (mean) it gives the fraction of rollouts that triggered at least one compaction — useful for tracking compaction prevalence over the course of a training run, separate from how many compactions a given rollout had.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a derived, read-only metric flag computed from existing `compactions_count` without changing compaction behavior or control flow.
> 
> **Overview**
> Adds a new `RLMMetrics.has_compacted` metric that is derived in `_refresh_derived_metrics` as `1` when `compactions_count > 0` (else `0`).
> 
> This enables aggregations to track the fraction of rollouts that triggered at least one compaction, separately from the total number of compactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c7748f538df7c92f6c8a00daa4c4eb9cf79ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->