### PR TITLE
fix(client): retry transient tunnel 404s with widely-spaced backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ All configuration is via environment variables:
 | `RLM_SYSTEM_PROMPT_PATH` | — | Path to a file whose contents fully replace the generated system prompt |
 | `RLM_TOOLS` | `ipython,summarize` | Comma-separated subset of builtin tools to enable. Empty string = no tools. Unknown names raise. |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
+| `RLM_SDK_MAX_RETRIES` | `5` | Per-request retry count passed to the OpenAI SDK (in addition to the call-site retry wrapper that rides out longer outages). |
 
 `RLM_SYSTEM_PROMPT_PATH` takes precedence over `RLM_APPEND_TO_SYSTEM_PROMPT`. CLI flags override env vars: `rlm --model gpt-5-mini --max-turns 50 --append-to-system-prompt "..." --system-prompt-path /tmp/system.txt "prompt"`.
 

--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -35,11 +35,11 @@ def make_client() -> AsyncOpenAI:
         or os.environ.get("OPENAI_API_KEY")
         or os.environ.get("ANTHROPIC_API_KEY")
     )
-    kwargs: dict[str, Any] = {"base_url": base_url, "api_key": api_key}
-    sdk_max_retries = os.environ.get("RLM_SDK_MAX_RETRIES")
-    if sdk_max_retries is not None:
-        kwargs["max_retries"] = int(sdk_max_retries)
-    return AsyncOpenAI(**kwargs)
+    return AsyncOpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        max_retries=int(os.environ.get("RLM_SDK_MAX_RETRIES", 5)),
+    )
 
 
 async def call_with_retries(

--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -1,10 +1,30 @@
 """Thin LLM client wrapper. Extracts token usage from responses."""
 
+import asyncio
 import os
+from typing import Any, Awaitable, Callable
 
-from openai import AsyncOpenAI
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    AsyncOpenAI,
+    InternalServerError,
+    NotFoundError,
+    RateLimitError,
+)
 
 from rlm.types import TokenUsage
+
+_RETRYABLE: tuple[type[BaseException], ...] = (
+    APIConnectionError,
+    APITimeoutError,
+    InternalServerError,
+    NotFoundError,
+    RateLimitError,
+)
+
+# Widely-spaced delays (seconds) between attempts; total ~5 min wall budget.
+_RETRY_DELAYS: tuple[int, ...] = (15, 30, 60, 90, 120)
 
 
 def make_client() -> AsyncOpenAI:
@@ -15,7 +35,27 @@ def make_client() -> AsyncOpenAI:
         or os.environ.get("OPENAI_API_KEY")
         or os.environ.get("ANTHROPIC_API_KEY")
     )
-    return AsyncOpenAI(base_url=base_url, api_key=api_key)
+    kwargs: dict[str, Any] = {"base_url": base_url, "api_key": api_key}
+    sdk_max_retries = os.environ.get("RLM_SDK_MAX_RETRIES")
+    if sdk_max_retries is not None:
+        kwargs["max_retries"] = int(sdk_max_retries)
+    return AsyncOpenAI(**kwargs)
+
+
+async def call_with_retries(
+    func: Callable[..., Awaitable[Any]], /, **kwargs: Any
+) -> Any:
+    """Call ``func(**kwargs)`` with widely-spaced retries on transient errors.
+
+    Extends the SDK's retry set with ``NotFoundError`` to ride out intermittent
+    tunnel/proxy 404s that the SDK itself does not retry.
+    """
+    for delay in _RETRY_DELAYS:
+        try:
+            return await func(**kwargs)
+        except _RETRYABLE:
+            await asyncio.sleep(delay)
+    return await func(**kwargs)
 
 
 def extract_usage(response) -> TokenUsage:

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from openai import AsyncOpenAI
 
-from rlm.client import extract_usage, make_client
+from rlm.client import call_with_retries, extract_usage, make_client
 from rlm.prompt import build_system_prompt
 from rlm.session import Session
 from rlm.tools import (
@@ -256,7 +256,8 @@ class RLMEngine:
             if active_tools:
                 request_kwargs["tools"] = active_tools
                 request_kwargs["parallel_tool_calls"] = False
-            response = await self.client.chat.completions.create(
+            response = await call_with_retries(
+                self.client.chat.completions.create,
                 **request_kwargs,
             )
 
@@ -425,7 +426,8 @@ class RLMEngine:
         if self._repl is not None:
             checkpoint_prompt += REPL_RESTART_NOTE
         messages.append({"role": "user", "content": checkpoint_prompt})
-        response = await self.client.chat.completions.create(
+        response = await call_with_retries(
+            self.client.chat.completions.create,
             model=self.model,
             messages=messages,
         )


### PR DESCRIPTION
## Summary

- Production rollouts crash mid-run when the LLM proxy/tunnel returns an HTML 404 (\"Tunnel not found\"). Observed: a 23-turn rollout aborted by a single \`openai.NotFoundError\`. The OpenAI SDK's \`_should_retry\` covers 408/409/429/≥500 + connection errors only — 404 is excluded.
- Add \`call_with_retries\` in \`src/rlm/client.py\` that wraps \`chat.completions.create\` with a fixed \`[15, 30, 60, 90, 120]\`s schedule (~5 min wall budget, 6 attempts total) and an extended retry set \`{APIConnectionError, APITimeoutError, InternalServerError, NotFoundError, RateLimitError}\`. Wired into both call sites in \`engine.py\` (main loop + compaction summary).
- Expose the SDK's per-request retry count via \`RLM_SDK_MAX_RETRIES\` (default: 5).

## Tradeoffs

- A misconfigured \`RLM_BASE_URL\` or genuinely-missing model now takes ~5 min to surface instead of failing immediately. Acceptable given a single rollout is worth far more.
- Outer retries don't share an idempotency key with the original request, so in the rare case the first call actually went through, a retry could double-bill tokens. Tradeoff accepted vs. losing the rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an outer retry loop around core LLM calls and changes retry behavior/time-to-failure; misconfiguration may now take minutes to surface and retries can duplicate requests/cost.
> 
> **Overview**
> Improves resilience of LLM calls by adding `call_with_retries` (widely-spaced backoff) around `chat.completions.create`, expanding retryable errors to include transient `NotFoundError` (tunnel/proxy 404s) plus common connection/timeout/5xx/429 cases.
> 
> Makes the OpenAI SDK per-request retry count configurable via `RLM_SDK_MAX_RETRIES` (default `5`) and wires the new wrapper into both the main agent loop and the compaction-summary LLM call. **README** is updated to document the new env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f9ab46f438dc0bfa4493d06944e4443788d09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->