### PR TITLE
chore(metrics): hide sub_rlm_* fields when sub-RLMs disabled

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -180,6 +180,7 @@ class RLMEngine:
 
         # Metrics
         self._metrics = RLMMetrics()
+        self._metrics._sub_rlm_enabled = self.max_depth > 0
 
         self._tool_state: dict[str, object] = {}
 

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -243,6 +243,7 @@ class RLMMetrics:
     _sub_rlm_branch_input_tokens_max: int = field(default=0, repr=False)
     _sub_rlm_branch_output_tokens_sum: int = field(default=0, repr=False)
     _sub_rlm_branch_output_tokens_max: int = field(default=0, repr=False)
+    _sub_rlm_enabled: bool = field(default=False, repr=False)
 
     def note_root_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
         self._root_input_tokens = prompt_tokens
@@ -395,8 +396,12 @@ class RLMMetrics:
 
     def to_dict(self) -> dict[str, Any]:
         self._refresh_derived_metrics()
+        sub_rlm_enabled = self._sub_rlm_enabled
         return {
-            key: value for key, value in asdict(self).items() if not key.startswith("_")
+            key: value
+            for key, value in asdict(self).items()
+            if not key.startswith("_")
+            and (sub_rlm_enabled or not key.startswith("sub_rlm_"))
         }
 
 


### PR DESCRIPTION
## Summary

When `RLM_MAX_DEPTH=0` (the default), sub-RLMs can never spawn, so the four `sub_rlm_*` metrics are always 0 — they just add noise to every rollout's metrics dict (e.g. `rlm_sub_rlm_programmatic_tool_calls_python 0`, `rlm_sub_rlm_programmatic_tool_calls_bash 0`).

This PR filters those keys out of `RLMMetrics.to_dict()` unless `RLM_MAX_DEPTH > 0`.

- `RLMMetrics` gains a private `_sub_rlm_enabled` flag (default `False`).
- `RLMEngine.__init__` sets it to `self.max_depth > 0`.
- `to_dict()` skips any key starting with `sub_rlm_` when the flag is `False`. The four affected keys are `sub_rlm_input_tokens`, `sub_rlm_output_tokens`, `sub_rlm_programmatic_tool_calls_python`, `sub_rlm_programmatic_tool_calls_bash`.

When recursion is enabled the dict is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-touch change to metrics serialization, but it changes the shape of emitted metrics dicts and could break downstream dashboards/alerts that assume `sub_rlm_*` keys are always present.
> 
> **Overview**
> Reduces metrics noise by **omitting `sub_rlm_*` fields from `RLMMetrics.to_dict()`** when sub-RLM recursion is disabled.
> 
> Adds a private `_sub_rlm_enabled` flag to `RLMMetrics`, sets it from `RLMEngine` based on `RLM_MAX_DEPTH > 0`, and filters out `sub_rlm_`-prefixed keys unless recursion is enabled (leaving output unchanged when enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc5fb2d1fc64ed80284aacce50533dd67b5bfc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->