### PR TITLE
client: tag outbound requests with X-RLM-Depth

### DIFF
--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -28,17 +28,25 @@ _RETRY_DELAYS: tuple[int, ...] = (15, 30, 60, 90, 120)
 
 
 def make_client() -> AsyncOpenAI:
-    """Create an AsyncOpenAI client from environment variables."""
+    """Create an AsyncOpenAI client from environment variables.
+
+    Tags every outbound request with ``X-RLM-Depth: <RLM_DEPTH>`` so an
+    interceptor (e.g. verifiers' interception server) can distinguish
+    parent-agent calls (depth 0) from sub-agent calls (depth >= 1) and
+    decide whether to record them in the rollout's trajectory.
+    """
     base_url = os.environ.get("RLM_BASE_URL")
     api_key = (
         os.environ.get("RLM_API_KEY")
         or os.environ.get("OPENAI_API_KEY")
         or os.environ.get("ANTHROPIC_API_KEY")
     )
+    depth = os.environ.get("RLM_DEPTH", "0")
     return AsyncOpenAI(
         base_url=base_url,
         api_key=api_key,
         max_retries=int(os.environ.get("RLM_SDK_MAX_RETRIES", 5)),
+        default_headers={"X-RLM-Depth": depth},
     )
 
 


### PR DESCRIPTION
Pairs with verifiers' upcoming Harness.keep_trajectory_step hook. Without an in-band signal on the wire, the interception server can't distinguish parent-agent API calls from sub-agent ones (env vars are process-local; both share the same intercepted endpoint). Header is the only data point that crosses the HTTP boundary at request time.

RLM_DEPTH is already the canonical depth counter, incremented by the ipython kernel before spawning a sub-agent. Just plumb it onto every outbound request via AsyncOpenAI's default_headers — parent emits "0", sub-agent "1", grandchild "2", etc. Verifiers (or any other interceptor) can then filter on it without coupling to rlm internals beyond the header name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single default HTTP header derived from `RLM_DEPTH`, which may affect downstream interceptors/proxies but does not change request payloads or retry logic.
> 
> **Overview**
> `make_client()` now reads `RLM_DEPTH` (defaulting to `0`) and sets `default_headers={"X-RLM-Depth": depth}` on the `AsyncOpenAI` client so every outbound request is tagged with its agent depth.
> 
> The client docstring is expanded to document how interceptors can use this header to distinguish parent vs sub-agent calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d113a5f8d575305a73b847038064bc3179f17ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->