### PR TITLE
fix(prompt): clarify how to call the recursive `rlm` sub-agent

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -56,7 +56,7 @@ def build_system_prompt(
         parts.extend(
             [
                 "",
-                "The `rlm` module is pre-imported. `await rlm('sub-task')` spawns a recursive sub-agent and returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
+                "A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
                 "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
             ]
         )


### PR DESCRIPTION
Models trained on `from foo import foo` patterns were trying `from rlm import rlm`, which fails because `rlm` is injected into the IPython global namespace at startup, not as an attribute of the package. Some also wrapped the call in `asyncio.run` / `run_until_complete` even though nest_asyncio is applied.

Reword the recursion line to spell out both: it's already in globals (don't import it) and top-level await works (don't wrap it).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only rewords system-prompt text and does not change runtime logic or APIs.
> 
> **Overview**
> Clarifies the system prompt’s recursion guidance to state that `rlm` is *already available in the global namespace* and should be called directly via top-level `await rlm('sub-task')`, avoiding incorrect `from rlm import rlm` usage.
> 
> Keeps the existing guidance for running recursive sub-agents in parallel with `asyncio.gather`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea783e489c255c1f834927e8cc5370bf1a78a6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->