### PR TITLE
fix(engine): end rollout cleanly on "Request Entity Too Large" 400s

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -67,14 +67,9 @@ POST_COMPACTION_FRAMING = (
 
 
 def _is_request_too_large(exc: BadRequestError) -> bool:
-    """True if a 400 indicates the request body / context is too large.
-
-    Matches both the proxy's "Request Entity Too Large" body and the
-    standard OpenAI ``context_length_exceeded`` error code.
-    """
-    needles = ("too large", "too long", "context_length_exceeded")
+    """True if a 400 matches the proxy's "Request Entity Too Large" body."""
     haystack = f"{exc} {getattr(exc, 'body', '') or ''}".lower()
-    return any(needle in haystack for needle in needles)
+    return "request entity too large" in haystack
 
 
 def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -8,7 +8,7 @@ import os
 import time
 from pathlib import Path
 
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, BadRequestError
 
 from rlm.client import call_with_retries, extract_usage, make_client
 from rlm.prompt import build_system_prompt
@@ -64,6 +64,17 @@ POST_COMPACTION_FRAMING = (
     "the summary produced by the other language model, use the "
     "information in this summary to assist with your own analysis:"
 )
+
+
+def _is_request_too_large(exc: BadRequestError) -> bool:
+    """True if a 400 indicates the request body / context is too large.
+
+    Matches both the proxy's "Request Entity Too Large" body and the
+    standard OpenAI ``context_length_exceeded`` error code.
+    """
+    needles = ("too large", "too long", "context_length_exceeded")
+    haystack = f"{exc} {getattr(exc, 'body', '') or ''}".lower()
+    return any(needle in haystack for needle in needles)
 
 
 def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:
@@ -255,10 +266,17 @@ class RLMEngine:
             if active_tools:
                 request_kwargs["tools"] = active_tools
                 request_kwargs["parallel_tool_calls"] = False
-            response = await call_with_retries(
-                self.client.chat.completions.create,
-                **request_kwargs,
-            )
+            try:
+                response = await call_with_retries(
+                    self.client.chat.completions.create,
+                    **request_kwargs,
+                )
+            except BadRequestError as exc:
+                if not _is_request_too_large(exc):
+                    raise
+                self._metrics.stop_reason = "request_too_large"
+                final_text = "[request body too large]"
+                break
 
             usage = extract_usage(response)
             self._total_usage.prompt_tokens += usage.prompt_tokens
@@ -380,7 +398,14 @@ class RLMEngine:
                 self.summarize_at_tokens is not None
                 and usage.prompt_tokens >= self.summarize_at_tokens
             ):
-                await self._compact_branch(messages, turn)
+                try:
+                    await self._compact_branch(messages, turn)
+                except BadRequestError as exc:
+                    if not _is_request_too_large(exc):
+                        raise
+                    self._metrics.stop_reason = "request_too_large"
+                    final_text = "[request body too large]"
+                    break
         else:
             self._metrics.stop_reason = "max_turns"
             final_text = msg.content or "[max turns reached]"

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -270,7 +270,6 @@ class RLMEngine:
                 if not _is_request_too_large(e):
                     raise
                 self._metrics.stop_reason = "request_too_large"
-                final_text = "[request body too large]"
                 break
 
             usage = extract_usage(response)

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -66,9 +66,9 @@ POST_COMPACTION_FRAMING = (
 )
 
 
-def _is_request_too_large(exc: BadRequestError) -> bool:
+def _is_request_too_large(e: BadRequestError) -> bool:
     """True if a 400 matches the proxy's "Request Entity Too Large" body."""
-    haystack = f"{exc} {getattr(exc, 'body', '') or ''}".lower()
+    haystack = f"{e} {getattr(e, 'body', '') or ''}".lower()
     return "request entity too large" in haystack
 
 
@@ -266,8 +266,8 @@ class RLMEngine:
                     self.client.chat.completions.create,
                     **request_kwargs,
                 )
-            except BadRequestError as exc:
-                if not _is_request_too_large(exc):
+            except BadRequestError as e:
+                if not _is_request_too_large(e):
                     raise
                 self._metrics.stop_reason = "request_too_large"
                 final_text = "[request body too large]"
@@ -395,8 +395,8 @@ class RLMEngine:
             ):
                 try:
                     await self._compact_branch(messages, turn)
-                except BadRequestError as exc:
-                    if not _is_request_too_large(exc):
+                except BadRequestError as e:
+                    if not _is_request_too_large(e):
                         raise
                     self._metrics.stop_reason = "request_too_large"
                     final_text = "[request body too large]"

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -270,6 +270,7 @@ class RLMEngine:
                 if not _is_request_too_large(e):
                     raise
                 self._metrics.stop_reason = "request_too_large"
+                final_text = "[request body too large]"
                 break
 
             usage = extract_usage(response)

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -213,7 +213,7 @@ class RLMMetrics:
     sub_rlm_programmatic_tool_calls_python: int = 0
     sub_rlm_programmatic_tool_calls_bash: int = 0
 
-    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "invalid_tool_args", "depth_limit"
+    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "invalid_tool_args", "depth_limit", "request_too_large"
 
     @property
     def turns(self) -> int:


### PR DESCRIPTION
## Summary

Some inference proxies reject oversize request bodies with a 400 (`Invalid JSON: Request Entity Too Large`). The OpenAI SDK turns this into `BadRequestError`, which is intentionally not in `client.py`'s `_RETRYABLE` set — retrying won't help. But nothing in `_run_loop` caught it either, so it propagated out, the agent process exited 1, and the scheduler logged `AgentError(exit_code=1)` and rescheduled the rollout (up to 16×).

## What changed

- `engine.py`: catch `BadRequestError` around the main-loop `call_with_retries` and around `_compact_branch`. If the body matches the proxy's `"Request Entity Too Large"` string, end the rollout with `stop_reason="request_too_large"` and `final_text="[request body too large]"`. Other 400s still propagate so we notice real bugs in our request shape.
- `types.py`: add `request_too_large` to the `stop_reason` doc list.

The match is deliberately narrow — only the exact substring observed in the wild. Anything else (context_length_exceeded, schema bugs, etc.) keeps crashing loudly.

## Test plan

- [x] `uv run pytest tests/` — 14 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds narrowly-scoped handling for a specific oversized-request 400 to end runs cleanly instead of crashing, without changing retry behavior or normal success paths.
> 
> **Overview**
> The agent loop now catches `openai.BadRequestError` for a narrow “Request Entity Too Large” 400 during both the main completion call and the auto-compaction summary call, and **terminates the run cleanly** with `stop_reason="request_too_large"` and a placeholder final message instead of propagating the exception.
> 
> `RLMMetrics.stop_reason` documentation is updated to include the new `request_too_large` reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54de59ea39156a1afcae1bf1ed17d1c384cad187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->