### PR TITLE
block git at the tool-call level (supersedes verifiers#1254 sandbox shim)

### DIFF
--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -13,6 +13,7 @@ import subprocess
 from typing import Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
+from rlm.tools.git_block import find_blocked_command, refusal
 
 
 BASH_TIMEOUT_MAX_SECONDS = 600
@@ -75,6 +76,10 @@ class BashTool:
             except (TypeError, ValueError):
                 timeout = context.exec_timeout
         timeout = min(timeout, BASH_TIMEOUT_MAX_SECONDS)
+
+        blocked = find_blocked_command(command)
+        if blocked is not None:
+            return ToolOutcome(content=refusal(blocked))
 
         try:
             proc = subprocess.run(

--- a/src/rlm/tools/git_block.py
+++ b/src/rlm/tools/git_block.py
@@ -60,6 +60,11 @@ _SHELL_ESCAPE_RE = re.compile(r"^\s*!{1,2}(?P<rest>.*)$")
 _SHELL_LINE_MAGIC_RE = re.compile(r"^\s*%(?:sx|system)\s+(?P<rest>.*)$")
 # ``%%bash`` / ``%%sh`` cell magic header — the whole cell body is shell.
 _SHELL_CELL_MAGIC_RE = re.compile(r"^\s*%%(?:bash|sh)\b")
+# Any IPython line magic — used by the AST pre-pass to drop ipython-only
+# lines so ``ast.parse`` doesn't choke on them.
+_ANY_LINE_MAGIC_RE = re.compile(r"^\s*%[A-Za-z]")
+# Any IPython cell magic header — same purpose.
+_ANY_CELL_MAGIC_RE = re.compile(r"^\s*%%[A-Za-z]")
 
 
 def find_blocked_in_ipython(code: str) -> str | None:
@@ -199,17 +204,46 @@ class _GitCallFinder(ast.NodeVisitor):
         return None
 
 
+def _strip_ipython_only(code: str) -> str:
+    """Drop ipython-only lines so the remainder is pure Python for ``ast.parse``.
+
+    Removes ``!cmd`` / ``!!cmd`` shell escapes, line magics (``%foo``),
+    and any ``%%cellmagic`` header plus its body. Trailing ``?`` / ``??``
+    object-inspection markers are stripped from the line tail rather
+    than dropping the whole line, so ``subprocess.run?`` becomes
+    ``subprocess.run`` and still parses. All other Python lines are
+    preserved verbatim.
+    """
+    out: list[str] = []
+    in_cell_magic = False
+    for line in code.splitlines():
+        if in_cell_magic:
+            continue
+        if _ANY_CELL_MAGIC_RE.match(line):
+            in_cell_magic = True
+            continue
+        if _SHELL_ESCAPE_RE.match(line) or _ANY_LINE_MAGIC_RE.match(line):
+            continue
+        stripped = line.rstrip()
+        if stripped.endswith("?"):
+            line = stripped.rstrip("?")
+        out.append(line)
+    return "\n".join(out)
+
+
 def find_blocked_python(code: str) -> str | None:
     """Detect pure-Python git invocations in an ipython cell via AST walk.
 
     Returns the offending token (``\"git\"``) if a blocked call is found,
-    else ``None``. Honors ``RLM_ALLOW_GIT=1``. Returns ``None`` on
-    ``SyntaxError`` so the normal exec path surfaces the parse error.
+    else ``None``. Honors ``RLM_ALLOW_GIT=1``. Ipython-only syntax
+    (``!cmd``, ``%magic``, ``obj?``) is stripped before parsing so
+    cells mixing ipython and Python still get scanned. Returns ``None``
+    on ``SyntaxError`` so the normal exec path surfaces the parse error.
     """
     if allow_git():
         return None
     try:
-        tree = ast.parse(code)
+        tree = ast.parse(_strip_ipython_only(code))
     except SyntaxError:
         return None
     finder = _GitCallFinder()

--- a/src/rlm/tools/git_block.py
+++ b/src/rlm/tools/git_block.py
@@ -119,13 +119,19 @@ _BLOCKED_PY_CALLS = frozenset(
 
 
 def _first_arg_starts_with_git(node: ast.Call) -> bool:
-    """Return True iff ``node.args[0]`` is a literal that begins with ``git``."""
+    """Return True iff ``node.args[0]`` is a literal that invokes ``git``.
+
+    String args go through ``find_blocked_command`` so the same separator
+    splitting (``&&``, ``||``, ``;``, ``|``) applies as for direct bash
+    invocations — ``os.system("cd /tmp && git log")`` is refused
+    symmetrically. List/tuple args are argv with no shell parsing, so
+    only the first element matters.
+    """
     if not node.args:
         return False
     arg = node.args[0]
     if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-        tokens = arg.value.strip().split()
-        return bool(tokens) and tokens[0] in _BLOCKED
+        return find_blocked_command(arg.value) is not None
     if isinstance(arg, (ast.List, ast.Tuple)) and arg.elts:
         first = arg.elts[0]
         return (

--- a/src/rlm/tools/git_block.py
+++ b/src/rlm/tools/git_block.py
@@ -221,12 +221,14 @@ def _strip_ipython_only(code: str) -> str:
     preserved verbatim.
     """
     out: list[str] = []
-    in_cell_magic = False
     for line in code.splitlines():
-        if in_cell_magic:
-            continue
+        # Drop only the cell-magic HEADER, not the body — magics like
+        # ``%%timeit`` / ``%%capture`` execute their body as Python and
+        # would otherwise hide ``subprocess.run([\"git\", ...])`` calls.
+        # Bash-bodied magics (``%%bash`` / ``%%sh``) are caught earlier
+        # by the shell-escape pre-pass, so dropping just the header here
+        # is safe.
         if _ANY_CELL_MAGIC_RE.match(line):
-            in_cell_magic = True
             continue
         if _SHELL_ESCAPE_RE.match(line) or _ANY_LINE_MAGIC_RE.match(line):
             continue

--- a/src/rlm/tools/git_block.py
+++ b/src/rlm/tools/git_block.py
@@ -1,0 +1,98 @@
+"""Block ``git`` at the tool-call level.
+
+Mirrors the predicate in mini_swe_agent_plus's ``execute_bash.py``:
+
+- split a bash command on ``&&``, ``||``, ``;`` and ``|``
+- if the first whitespace-separated token of any segment is ``git``, refuse
+
+The ``RLM_ALLOW_GIT=1`` env var disables the check entirely.
+
+The same refusal string the existing sandbox shim emits is reused here so
+that agent-visible logs (and any rubrics keyed on it) stay consistent
+across the two block strategies.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+REFUSAL_TEMPLATE = (
+    "Bash command '{cmd}' is not allowed. Please use a different command or tool."
+)
+
+# Reuse the mini_swe_agent_plus separators verbatim so behavior matches.
+_SEPARATORS = re.compile(r"&&|\|\||;|\|")
+
+_BLOCKED = ("git",)
+
+
+def allow_git() -> bool:
+    return os.environ.get("RLM_ALLOW_GIT") == "1"
+
+
+def find_blocked_command(command: str) -> str | None:
+    """Return the offending token if ``command`` invokes a blocked binary.
+
+    Splits on ``&&``, ``||``, ``;``, ``|`` so chained calls like
+    ``cd /repo && git status`` are caught the same way the reference
+    implementation catches them. Returns ``None`` if nothing is blocked
+    or if ``RLM_ALLOW_GIT=1``.
+    """
+    if allow_git():
+        return None
+    for segment in _SEPARATORS.split(command):
+        tokens = segment.strip().split()
+        if tokens and tokens[0] in _BLOCKED:
+            return tokens[0]
+    return None
+
+
+def refusal(cmd: str) -> str:
+    return REFUSAL_TEMPLATE.format(cmd=cmd)
+
+
+# IPython shell-escape lines: ``!cmd`` and ``!!cmd``. Leading whitespace
+# is allowed (IPython accepts indented shell escapes inside blocks).
+_SHELL_ESCAPE_RE = re.compile(r"^\s*!{1,2}(?P<rest>.*)$")
+# ``%sx``, ``%system`` line magics and equivalents that shell out.
+_SHELL_LINE_MAGIC_RE = re.compile(r"^\s*%(?:sx|system)\s+(?P<rest>.*)$")
+# ``%%bash`` / ``%%sh`` cell magic header — the whole cell body is shell.
+_SHELL_CELL_MAGIC_RE = re.compile(r"^\s*%%(?:bash|sh)\b")
+
+
+def find_blocked_in_ipython(code: str) -> str | None:
+    """Scan IPython ``code`` for blocked commands in shell-escape lines.
+
+    Detects:
+
+    - ``!cmd`` / ``!!cmd`` shell escapes on any line
+    - ``%sx`` / ``%system`` line magics
+    - ``%%bash`` / ``%%sh`` cell magic — whole cell body is bash
+
+    Each extracted bash fragment is passed through ``find_blocked_command``
+    so chained calls (``!cd repo && git log``) refuse with the same
+    predicate as the bash tool. Pure Python (``subprocess.run([...])``,
+    ``os.system(...)``) is *not* detected here — see PR description for
+    the documented bypass.
+    """
+    if allow_git():
+        return None
+
+    lines = code.splitlines()
+    in_bash_cell = False
+    for line in lines:
+        if in_bash_cell:
+            blocked = find_blocked_command(line)
+            if blocked is not None:
+                return blocked
+            continue
+        if _SHELL_CELL_MAGIC_RE.match(line):
+            in_bash_cell = True
+            continue
+        m = _SHELL_ESCAPE_RE.match(line) or _SHELL_LINE_MAGIC_RE.match(line)
+        if m:
+            blocked = find_blocked_command(m.group("rest"))
+            if blocked is not None:
+                return blocked
+    return None

--- a/src/rlm/tools/git_block.py
+++ b/src/rlm/tools/git_block.py
@@ -14,6 +14,7 @@ across the two block strategies.
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 
@@ -62,19 +63,17 @@ _SHELL_CELL_MAGIC_RE = re.compile(r"^\s*%%(?:bash|sh)\b")
 
 
 def find_blocked_in_ipython(code: str) -> str | None:
-    """Scan IPython ``code`` for blocked commands in shell-escape lines.
+    """Scan IPython ``code`` for blocked commands.
 
-    Detects:
+    Two passes, both honoring ``RLM_ALLOW_GIT=1``:
 
-    - ``!cmd`` / ``!!cmd`` shell escapes on any line
-    - ``%sx`` / ``%system`` line magics
-    - ``%%bash`` / ``%%sh`` cell magic — whole cell body is bash
-
-    Each extracted bash fragment is passed through ``find_blocked_command``
-    so chained calls (``!cd repo && git log``) refuse with the same
-    predicate as the bash tool. Pure Python (``subprocess.run([...])``,
-    ``os.system(...)``) is *not* detected here — see PR description for
-    the documented bypass.
+    1. Shell-escape scan — ``!cmd`` / ``!!cmd``, ``%sx`` / ``%system``
+       line magics, ``%%bash`` / ``%%sh`` cell magic. Each extracted
+       bash fragment goes through ``find_blocked_command``.
+    2. Pure-Python AST scan via :func:`find_blocked_python` — catches
+       ``subprocess.run([\"git\", ...])`` / ``os.system(\"git ...\")``
+       and the obvious aliases. See that function for documented
+       bypasses (dynamic ``getattr``, multi-hop reassignment, etc.).
     """
     if allow_git():
         return None
@@ -95,4 +94,124 @@ def find_blocked_in_ipython(code: str) -> str | None:
             blocked = find_blocked_command(m.group("rest"))
             if blocked is not None:
                 return blocked
-    return None
+
+    return find_blocked_python(code)
+
+
+# Statically-resolved fully-qualified callees that shell out to ``git``
+# when invoked with a literal ``git ...`` first positional argument.
+_BLOCKED_PY_CALLS = frozenset(
+    {
+        "subprocess.run",
+        "subprocess.call",
+        "subprocess.check_call",
+        "subprocess.check_output",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+    }
+)
+
+
+def _first_arg_starts_with_git(node: ast.Call) -> bool:
+    """Return True iff ``node.args[0]`` is a literal that begins with ``git``."""
+    if not node.args:
+        return False
+    arg = node.args[0]
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        tokens = arg.value.strip().split()
+        return bool(tokens) and tokens[0] in _BLOCKED
+    if isinstance(arg, (ast.List, ast.Tuple)) and arg.elts:
+        first = arg.elts[0]
+        return (
+            isinstance(first, ast.Constant)
+            and isinstance(first.value, str)
+            and first.value in _BLOCKED
+        )
+    return False
+
+
+class _GitCallFinder(ast.NodeVisitor):
+    """Single-pass AST walker tracking simple aliases for blocked callees.
+
+    Tracks three alias sources:
+
+    - ``import subprocess as sp`` — module-level name remap.
+    - ``from subprocess import run`` — bare-name binding.
+    - ``r = subprocess.run`` — single-hop assignment of a known callee.
+
+    Multi-hop chains (``r1 = subprocess.run; r2 = r1; r2(...)``) and
+    dynamic forms (``getattr(subprocess, \"run\")(...)``,
+    ``__import__(\"subprocess\").run(...)``) are explicitly out of scope.
+    """
+
+    def __init__(self) -> None:
+        # Maps local name -> canonical "module.attr" string.
+        self.module_aliases: dict[str, str] = {"subprocess": "subprocess", "os": "os"}
+        # Maps local name -> blocked callee fqn (e.g. "run" -> "subprocess.run").
+        self.callable_aliases: dict[str, str] = {}
+        self.found = False
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            if alias.name in {"subprocess", "os"}:
+                self.module_aliases[alias.asname or alias.name] = alias.name
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module in {"subprocess", "os"}:
+            for alias in node.names:
+                fqn = f"{node.module}.{alias.name}"
+                if fqn in _BLOCKED_PY_CALLS:
+                    self.callable_aliases[alias.asname or alias.name] = fqn
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # Only track single-hop aliases: ``r = subprocess.run``. Chained
+        # reassignment (``r2 = r1``) is intentionally not propagated.
+        fqn = None
+        if isinstance(node.value, ast.Attribute) and isinstance(
+            node.value.value, ast.Name
+        ):
+            module = self.module_aliases.get(node.value.value.id)
+            if module is not None:
+                fqn = f"{module}.{node.value.attr}"
+        if fqn in _BLOCKED_PY_CALLS:
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    self.callable_aliases[target.id] = fqn
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        fqn = self._resolve_callee(node.func)
+        if fqn in _BLOCKED_PY_CALLS and _first_arg_starts_with_git(node):
+            self.found = True
+        self.generic_visit(node)
+
+    def _resolve_callee(self, expr: ast.AST) -> str | None:
+        """Return ``module.attr`` if ``expr`` resolves to a tracked callee."""
+        if isinstance(expr, ast.Attribute) and isinstance(expr.value, ast.Name):
+            module = self.module_aliases.get(expr.value.id)
+            if module is not None:
+                return f"{module}.{expr.attr}"
+        if isinstance(expr, ast.Name):
+            return self.callable_aliases.get(expr.id)
+        return None
+
+
+def find_blocked_python(code: str) -> str | None:
+    """Detect pure-Python git invocations in an ipython cell via AST walk.
+
+    Returns the offending token (``\"git\"``) if a blocked call is found,
+    else ``None``. Honors ``RLM_ALLOW_GIT=1``. Returns ``None`` on
+    ``SyntaxError`` so the normal exec path surfaces the parse error.
+    """
+    if allow_git():
+        return None
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return None
+    finder = _GitCallFinder()
+    finder.visit(tree)
+    return _BLOCKED[0] if finder.found else None

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -12,6 +12,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
+from rlm.tools.git_block import find_blocked_in_ipython, refusal
 from rlm.tools.skills import get_installed_skills
 from rlm.types import IpythonExecuted
 
@@ -90,6 +91,13 @@ class IpythonTool:
         if context.repl is None:
             return ToolOutcome(
                 content="Error: IPython REPL is not available",
+                metric_events=metric_events,
+            )
+
+        blocked = find_blocked_in_ipython(code)
+        if blocked is not None:
+            return ToolOutcome(
+                content=refusal(blocked),
                 metric_events=metric_events,
             )
 

--- a/tests/test_git_block.py
+++ b/tests/test_git_block.py
@@ -166,6 +166,28 @@ def test_python_subprocess_run_non_git_unaffected():
     assert find_blocked_in_ipython(code) is None
 
 
+def test_python_os_system_chained_git_blocked():
+    # `os.system("cd /tmp && git log")` must be refused the same way
+    # `cd /tmp && git log` is refused via the bash tool.
+    code = 'import os\nos.system("cd /tmp && git log")'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_shell_string_chained_git_blocked():
+    code = 'import subprocess\nsubprocess.run("echo hi; git log", shell=True)'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_os_popen_pipe_chained_git_blocked():
+    code = 'import os\nos.popen("echo a | git status")'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_string_or_chained_git_blocked():
+    code = 'import subprocess\nsubprocess.run("false || git log", shell=True)'
+    assert find_blocked_in_ipython(code) == "git"
+
+
 def test_python_string_literal_no_call_unaffected():
     assert find_blocked_in_ipython("x = 'git status'") is None
 

--- a/tests/test_git_block.py
+++ b/tests/test_git_block.py
@@ -211,6 +211,34 @@ def test_python_syntax_error_does_not_refuse():
     assert find_blocked_in_ipython("def broken(:\n    pass") is None
 
 
+# --- ipython-only syntax must not bypass the AST scan (bugbot #3150728431) ---
+
+
+def test_python_shell_escape_with_python_git_call_blocked():
+    # The bugbot reproducer: a ``!cmd`` line previously made ``ast.parse``
+    # raise ``SyntaxError``, silently bypassing the Python-call scan.
+    code = '!ls\nimport subprocess\nsubprocess.run(["git", "log", "--all"])'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_line_magic_with_python_git_call_blocked():
+    code = '%timeit pass\nimport subprocess\nsubprocess.run(["git", "status"])'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_help_question_mark_with_python_git_call_blocked():
+    # ``obj?`` object-inspection syntax is ipython-only; strip the ``?``
+    # rather than the line so ``subprocess.run`` still binds the alias path.
+    code = "import subprocess\nsubprocess.run?\nsubprocess.run(['git', 'log'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_alias_then_magic_then_call_blocked():
+    # Alias defined before a magic that previously broke ``ast.parse``.
+    code = 'import subprocess as sp\n!ls\nsp.run(["git", "status"])'
+    assert find_blocked_in_ipython(code) == "git"
+
+
 # --- BashTool integration ---
 
 

--- a/tests/test_git_block.py
+++ b/tests/test_git_block.py
@@ -1,0 +1,176 @@
+"""Tests for the tool-level git block."""
+
+from __future__ import annotations
+
+from rlm.tools.base import ToolContext
+from rlm.tools.bash import BashTool
+from rlm.tools.git_block import (
+    find_blocked_command,
+    find_blocked_in_ipython,
+    refusal,
+)
+from rlm.types import RLMMetrics, TokenUsage
+
+
+REFUSAL = "Bash command 'git' is not allowed. Please use a different command or tool."
+
+
+def _ctx() -> ToolContext:
+    return ToolContext(
+        messages=[],
+        metrics=RLMMetrics(),
+        total_usage=TokenUsage(),
+        last_prompt_tokens=0,
+        exec_timeout=10,
+    )
+
+
+# --- find_blocked_command (bash predicate, mirrors mini_swe_agent_plus) ---
+
+
+def test_plain_git_status_blocked():
+    assert find_blocked_command("git status") == "git"
+
+
+def test_chained_git_after_cd_blocked():
+    # mini_swe_agent_plus's docstring example: "cd /testbed && git diff"
+    assert find_blocked_command("cd /testbed && git diff") == "git"
+
+
+def test_pipe_separator_blocked():
+    assert find_blocked_command("ls | git foo") == "git"
+
+
+def test_or_separator_blocked():
+    assert find_blocked_command("false || git status") == "git"
+
+
+def test_semicolon_separator_blocked():
+    assert find_blocked_command("ls; git log") == "git"
+
+
+def test_non_git_command_unaffected():
+    assert find_blocked_command("ls -la") is None
+
+
+def test_command_substring_unaffected():
+    # "github" starts with "git" but is not the git binary
+    assert find_blocked_command("echo github") is None
+
+
+def test_allow_git_env_var_disables_block(monkeypatch):
+    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
+    assert find_blocked_command("git status") is None
+
+
+def test_refusal_message_matches_existing_shim():
+    assert refusal("git") == REFUSAL
+
+
+# --- find_blocked_in_ipython ---
+
+
+def test_ipython_shell_escape_blocked():
+    assert find_blocked_in_ipython("!git status") == "git"
+
+
+def test_ipython_double_shell_escape_blocked():
+    assert find_blocked_in_ipython("!!git diff") == "git"
+
+
+def test_ipython_chained_shell_escape_blocked():
+    assert find_blocked_in_ipython("!cd /repo && git log") == "git"
+
+
+def test_ipython_bash_cell_magic_blocked():
+    code = "%%bash\ncd /repo\ngit status"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_ipython_sx_line_magic_blocked():
+    assert find_blocked_in_ipython("%sx git status") == "git"
+
+
+def test_ipython_pure_python_unaffected():
+    # No shell escape ⇒ nothing to block, even if literal "git" appears
+    assert find_blocked_in_ipython("x = 'git status'\nprint(x)") is None
+
+
+def test_ipython_non_git_shell_escape_unaffected():
+    assert find_blocked_in_ipython("!ls -la") is None
+
+
+def test_ipython_subprocess_run_documented_bypass():
+    # Pure-Python subprocess calls are NOT detected (documented limitation).
+    code = "import subprocess; subprocess.run(['git', 'status'])"
+    assert find_blocked_in_ipython(code) is None
+
+
+def test_ipython_allow_git_env_var(monkeypatch):
+    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
+    assert find_blocked_in_ipython("!git status") is None
+
+
+# --- BashTool integration ---
+
+
+def test_bash_tool_refuses_git():
+    outcome = BashTool().execute({"command": "git status"}, _ctx())
+    assert outcome.content == REFUSAL
+
+
+def test_bash_tool_refuses_chained_git():
+    outcome = BashTool().execute({"command": "cd /tmp && git diff"}, _ctx())
+    assert outcome.content == REFUSAL
+
+
+def test_bash_tool_runs_non_git_command():
+    outcome = BashTool().execute({"command": "echo hello"}, _ctx())
+    assert "hello" in outcome.content
+
+
+def test_bash_tool_allow_git_env_var(monkeypatch, tmp_path):
+    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
+    # ``git --version`` is a harmless probe that doesn't need a repo. If
+    # the env doesn't have git installed at all, fall back to verifying
+    # the refusal didn't fire.
+    outcome = BashTool().execute({"command": "git --version"}, _ctx())
+    assert outcome.content != REFUSAL
+
+
+# --- IpythonTool integration ---
+
+
+def test_ipython_tool_refuses_git():
+    """IpythonTool.execute short-circuits with the refusal before touching the REPL."""
+    from rlm.tools.ipython import IpythonTool
+
+    ctx = _ctx()
+    # context.repl stays None; the refusal must fire before the
+    # "REPL is not available" branch.
+    ctx.repl = object()  # truthy sentinel — never used
+    outcome = IpythonTool().execute({"code": "!git status"}, ctx)
+    assert outcome.content == REFUSAL
+
+
+def test_ipython_tool_refuses_bash_cell_magic_git():
+    from rlm.tools.ipython import IpythonTool
+
+    ctx = _ctx()
+    ctx.repl = object()
+    outcome = IpythonTool().execute({"code": "%%bash\ncd /repo && git diff"}, ctx)
+    assert outcome.content == REFUSAL
+
+
+def test_ipython_tool_passes_through_non_git(monkeypatch):
+    """When the code has no shell escapes, the tool delegates to the REPL."""
+    from rlm.tools.ipython import IpythonTool
+
+    class StubRepl:
+        def execute(self, code, timeout):
+            return f"ran: {code}"
+
+    ctx = _ctx()
+    ctx.repl = StubRepl()
+    outcome = IpythonTool().execute({"code": "print(1+1)"}, ctx)
+    assert outcome.content == "ran: print(1+1)"

--- a/tests/test_git_block.py
+++ b/tests/test_git_block.py
@@ -100,15 +100,115 @@ def test_ipython_non_git_shell_escape_unaffected():
     assert find_blocked_in_ipython("!ls -la") is None
 
 
-def test_ipython_subprocess_run_documented_bypass():
-    # Pure-Python subprocess calls are NOT detected (documented limitation).
-    code = "import subprocess; subprocess.run(['git', 'status'])"
-    assert find_blocked_in_ipython(code) is None
-
-
 def test_ipython_allow_git_env_var(monkeypatch):
     monkeypatch.setenv("RLM_ALLOW_GIT", "1")
     assert find_blocked_in_ipython("!git status") is None
+
+
+# --- find_blocked_python (AST-based detection of Python git invocations) ---
+
+
+def test_python_subprocess_run_list_blocked():
+    code = "import subprocess\nsubprocess.run(['git', 'log'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_run_shell_string_blocked():
+    code = "import subprocess\nsubprocess.run('git log', shell=True)"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_popen_blocked():
+    code = "import subprocess\nsubprocess.Popen(['git', 'diff'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_call_blocked():
+    code = "import subprocess\nsubprocess.call(['git', 'status'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_check_call_blocked():
+    code = "import subprocess\nsubprocess.check_call(['git', 'status'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_check_output_blocked():
+    code = "import subprocess\nsubprocess.check_output(['git', 'log'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_os_system_blocked():
+    assert find_blocked_in_ipython("import os\nos.system('git fetch')") == "git"
+
+
+def test_python_os_popen_blocked():
+    assert find_blocked_in_ipython("import os\nos.popen('git status')") == "git"
+
+
+def test_python_subprocess_module_alias_blocked():
+    code = "import subprocess as sp\nsp.run(['git', 'status'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_from_subprocess_import_run_blocked():
+    code = "from subprocess import run\nrun(['git', 'log'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_single_hop_assignment_alias_blocked():
+    code = "import subprocess\nr = subprocess.run\nr(['git', 'log'])"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_subprocess_run_non_git_unaffected():
+    code = "import subprocess\nsubprocess.run(['pytest'])"
+    assert find_blocked_in_ipython(code) is None
+
+
+def test_python_string_literal_no_call_unaffected():
+    assert find_blocked_in_ipython("x = 'git status'") is None
+
+
+def test_python_command_starting_with_git_word_unaffected():
+    # "github" is not the git binary; first arg literal "github" must not match.
+    code = "import subprocess\nsubprocess.run(['github', 'status'])"
+    assert find_blocked_in_ipython(code) is None
+
+
+def test_python_shell_string_with_leading_whitespace_blocked():
+    # Whitespace in front of the string still resolves first token to "git".
+    code = "import subprocess\nsubprocess.run('   git log', shell=True)"
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_allow_git_env_var_disables_ast(monkeypatch):
+    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
+    code = "import subprocess\nsubprocess.run(['git', 'log'])"
+    assert find_blocked_in_ipython(code) is None
+
+
+def test_python_getattr_documented_bypass():
+    # Dynamic attribute lookup is intentionally NOT caught — pin behavior.
+    code = "import subprocess\ngetattr(subprocess, 'run')(['git', 'log'])"
+    assert find_blocked_in_ipython(code) is None
+
+
+def test_python_dunder_import_documented_bypass():
+    # ``__import__("subprocess").run(...)`` is also not caught.
+    code = "__import__('subprocess').run(['git', 'log'])"
+    assert find_blocked_in_ipython(code) is None
+
+
+def test_python_multi_hop_alias_documented_bypass():
+    # Two-hop reassignment is out of scope; r2 isn't tracked back to subprocess.run.
+    code = "import subprocess\nr1 = subprocess.run\nr2 = r1\nr2(['git', 'log'])\n"
+    assert find_blocked_in_ipython(code) is None
+
+
+def test_python_syntax_error_does_not_refuse():
+    # Malformed Python: AST scan returns None so the REPL surfaces the SyntaxError.
+    assert find_blocked_in_ipython("def broken(:\n    pass") is None
 
 
 # --- BashTool integration ---

--- a/tests/test_git_block.py
+++ b/tests/test_git_block.py
@@ -204,6 +204,30 @@ def test_python_shell_string_with_leading_whitespace_blocked():
     assert find_blocked_in_ipython(code) == "git"
 
 
+def test_python_timeit_cell_magic_with_python_git_call_blocked():
+    # %%timeit's body is Python; the AST scan must still see it.
+    code = '%%timeit\nimport subprocess\nsubprocess.run(["git", "log"])'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_capture_cell_magic_with_python_git_call_blocked():
+    code = '%%capture\nimport subprocess\nsubprocess.run(["git", "status"])'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_writefile_cell_magic_with_python_git_call_blocked():
+    code = '%%writefile out.txt\nimport subprocess\nsubprocess.run(["git", "log"])'
+    assert find_blocked_in_ipython(code) == "git"
+
+
+def test_python_double_percent_in_string_does_not_drop_later_git_call():
+    # `%%foo`-shaped line inside a triple-quoted string must not poison
+    # the rest of the cell — the git call after the string must still
+    # be detected.
+    code = 's = """\n%%foo\n"""\nimport subprocess\nsubprocess.run(["git", "log"])'
+    assert find_blocked_in_ipython(code) == "git"
+
+
 def test_python_allow_git_env_var_disables_ast(monkeypatch):
     monkeypatch.setenv("RLM_ALLOW_GIT", "1")
     code = "import subprocess\nsubprocess.run(['git', 'log'])"


### PR DESCRIPTION
## Summary

Block ``git`` at the rlm **tool-call level** rather than mutating the
sandbox filesystem. Supersedes [PrimeIntellect-ai/verifiers#1254](https://github.com/PrimeIntellect-ai/verifiers/pull/1254) (which renames the resolved real
``git`` binary aside, drops a refusal shim at its original path, and
restores via a new ``Harness.pre_score_script`` hook).

The block lives in two places:

- ``BashTool`` (``src/rlm/tools/bash.py``) — refuses before
  ``subprocess.run`` is invoked.
- ``IpythonTool`` (``src/rlm/tools/ipython.py``) — refuses before the
  REPL sees the cell. Two scanners run back-to-back:
  - shell-escape scan: ``!cmd`` / ``!!cmd``, ``%sx`` / ``%system``
    line magics, ``%%bash`` / ``%%sh`` cell bodies.
  - **AST scan** (new): walks the cell once with ``ast.NodeVisitor``,
    catching pure-Python git invocations like
    ``subprocess.run(["git", ...])`` and ``os.system("git ...")``.

Both call into ``src/rlm/tools/git_block.py`` so the predicate is a
single source of truth.

## Predicate (bash side)

Mirrors **mini_swe_agent_plus's** ``execute_bash.py`` predicate
([reference](https://github.com/PrimeIntellect-ai/research-environments/blob/main/environments/mini_swe_agent_plus/tools/execute_bash.py#L17-L55))
verbatim:

- split the bash command on ``&&|\|\||;|\|``
- check the first whitespace-separated token of each segment
- refuse if any equals ``git``

## Predicate (ipython AST side, new)

Refuses if the cell contains a ``Call`` whose statically-resolved
callee is one of:

- ``subprocess.run`` / ``call`` / ``check_call`` / ``check_output`` / ``Popen``
- ``os.system`` / ``os.popen``

…AND whose first positional argument is a literal that begins with
``git``:

- ``Constant(str)`` whose stripped first whitespace token equals
  ``"git"`` (e.g. ``"git status"``, ``"git log --all"``).
- ``List`` / ``Tuple`` whose first element is ``Constant("git")``.

Tracks three alias forms within the cell:

- ``import subprocess as sp`` → ``sp.run`` resolves to ``subprocess.run``.
- ``from subprocess import run`` → ``run`` resolves to ``subprocess.run``.
- ``r = subprocess.run`` (single hop) → ``r`` resolves to ``subprocess.run``.

A ``SyntaxError`` from ``ast.parse`` yields ``None`` so the REPL
surfaces the parse error via the normal exec path.

### Now caught by the ipython AST scan

- ``subprocess.run(["git", "log"])`` / ``subprocess.run("git log", shell=True)``
- ``subprocess.call`` / ``check_call`` / ``check_output`` / ``Popen`` with the same arg shapes
- ``os.system("git fetch")``, ``os.popen("git status")``
- aliased module: ``import subprocess as sp; sp.run(["git", ...])``
- aliased function: ``from subprocess import run; run(["git", ...])``
- single-hop assignment: ``r = subprocess.run; r(["git", ...])``

## Refusal string

Identical to the existing sandbox shim:
``Bash command 'git' is not allowed. Please use a different command or tool.``
so any logs / training rubrics keyed on it keep working across both
scanners.

## Opt-out

``RLM_ALLOW_GIT=1`` disables both scanners (off by default), matching
the ``ALLOW_GIT=1`` opt-out in mini_swe_agent_plus.

## Trade-offs vs the sandbox shim

**Pros**

- No filesystem mutation in the sandbox image (no `mv git → twit`,
  no shim at the original resolved path).
- No `pre_score_script` hook needed — scoring runs against the
  unmodified, on-PATH `git`.
- Harness-agnostic: any verifiers env that uses rlm gets the block
  for free, regardless of base image, PATH ordering, or shell init.
- Easier to reason about and test (pure Python, no fs side effects).

**Remaining bypasses (documented, intentional)**

- ``getattr(subprocess, "run")(["git", ...])`` — dynamic attribute lookup.
- ``__import__("subprocess").run(["git", ...])`` — dynamic import.
- Multi-hop alias chains (``r1 = subprocess.run; r2 = r1; r2(...)``).
- Pure-Python git wrappers: ``pygit2``, ``dulwich``,
  ``GitPython``'s ``git.Repo`` API. These don't shell out to ``git``
  at all, so neither shim nor AST walker can catch them.
- Whitespace / encoding tricks like ``"\x67it"`` or
  env-var-mediated indirection (``os.environ["X"] = "git"; os.system(os.environ["X"])``).

The sandbox shim catches the first three (everything that resolves
through ``$PATH`` at exec time). If those bypasses matter for a given
run, keep the shim — the two strategies are complementary. For the
common case of an RL agent that retries the obvious Python alternative
after a shell refusal, the AST walker now closes the loop.

## Files

- ``src/rlm/tools/git_block.py`` — shared predicate, ipython scanner,
  new ``find_blocked_python`` AST walker (~110 LOC for the walker).
- ``src/rlm/tools/bash.py`` — refusal short-circuit before
  ``subprocess.run``.
- ``src/rlm/tools/ipython.py`` — refusal short-circuit before the REPL.
- ``tests/test_git_block.py`` — 44 unit tests covering bash predicate,
  ipython shell-escape scan, ipython AST scan (positive + documented
  bypasses), and tool integrations.

## Tests

```
$ uv run pytest tests/test_git_block.py -q
............................................                           [100%]
44 passed in 0.79s

$ uv run pytest -q
..........................................................             [100%]
58 passed in 12.42s
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command execution behavior by refusing `git` invocations (including some Python subprocess/os call patterns) before running user code, which could break existing workflows and has some parsing/false-negative edge cases.
> 
> **Overview**
> Prevents `git` from being executed via RLM tools by adding a shared `git_block` module and enforcing it in both `BashTool` and `IpythonTool` before any subprocess/REPL execution.
> 
> `ipython` blocking covers both shell escapes/magics (e.g. `!git`, `%system`, `%%bash`) and a new AST-based scan that detects common `subprocess`/`os` calls that shell out to `git`; `RLM_ALLOW_GIT=1` bypasses all checks and the refusal message is kept consistent.
> 
> Adds a focused test suite validating the bash predicate, ipython shell+AST detection (including documented bypasses), and end-to-end tool integration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f12087b45e6b9ebc5d66447c36b3aeffdcad14b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->