### PR TITLE
metrics: track total_tool_response_tokens for length-penalty training

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -251,6 +251,11 @@ class RLMEngine:
 
         final_text = ""
         turn = 0
+        # Role of whatever the engine appended to ``messages`` since the
+        # last API call. Drives RLMMetrics.note_assistant_turn's tool-token
+        # attribution: only "tool" appendages count toward total_tool_response_tokens.
+        # ``None`` on the very first turn and after compaction (fresh branch).
+        last_appended_role: str | None = None
 
         for turn in range(self.max_turns):
             # Call LLM
@@ -286,6 +291,7 @@ class RLMEngine:
             self._metrics.note_assistant_turn(
                 usage.prompt_tokens,
                 usage.completion_tokens,
+                prev_appended_role=last_appended_role,
             )
 
             # Update metrics
@@ -381,6 +387,7 @@ class RLMEngine:
                     "content": result,
                 }
             )
+            last_appended_role = "tool"
 
             # Detect new child sessions spawned via rlm()
             self._detect_new_children()
@@ -401,6 +408,9 @@ class RLMEngine:
                     self._metrics.stop_reason = "request_too_large"
                     final_text = "[request body too large]"
                     break
+                # Branch boundary: the next API call's prompt is a fresh
+                # [system, user(framing+summary)], not a continuation.
+                last_appended_role = None
         else:
             self._metrics.stop_reason = "max_turns"
             final_text = msg.content or "[max turns reached]"

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -124,6 +124,7 @@ def _empty_context_token_stats() -> dict[str, int]:
         "branch_input_tokens_max": 0,
         "branch_output_tokens_sum": 0,
         "branch_output_tokens_max": 0,
+        "tool_response_tokens_total": 0,
     }
 
 
@@ -147,6 +148,7 @@ class ChildSessionAggregate:
         "branch_count",
         "branch_input_tokens_sum",
         "branch_output_tokens_sum",
+        "tool_response_tokens_total",
     )
     _CONTEXT_TOKEN_MAX_KEYS = ("branch_input_tokens_max", "branch_output_tokens_max")
 
@@ -207,6 +209,14 @@ class RLMMetrics:
     branch_output_tokens_mean: float = 0.0
     branch_output_tokens_max: int = 0
 
+    # Tool-response tokens: sum of bytes the agent ingested via tool results
+    # over the rollout, parent + all descendants, with no double-counting
+    # across turns, branches, or sub-RLMs. Per branch, the parent's own
+    # contribution is (visible_input_at_last_turn -
+    # visible_input_at_first_turn), which strips the system + initial-user
+    # baseline; sub-RLM contributions bubble up via context_token_stats.
+    total_tool_response_tokens: int = 0
+
     # Skill-CLI invocations from inside the ipython REPL
     programmatic_tool_calls_python: int = 0
     programmatic_tool_calls_bash: int = 0
@@ -228,6 +238,11 @@ class RLMMetrics:
     _retained_completion_tokens_total: int = field(default=0, repr=False)
     _current_branch_input_tokens: int | None = field(default=None, repr=False)
     _current_branch_output_tokens: int | None = field(default=None, repr=False)
+    # Carry the previous main-loop turn's prompt/completion sizes so the next
+    # turn can derive what was appended in between via prompt-token delta.
+    # Reset to 0 at branch boundaries (compaction / initial branch).
+    _prev_turn_prompt_tokens: int = field(default=0, repr=False)
+    _prev_turn_completion_tokens: int = field(default=0, repr=False)
     _branch_count: int = field(default=0, repr=False)
     _branch_input_tokens_sum: int = field(default=0, repr=False)
     _branch_input_tokens_max: int = field(default=0, repr=False)
@@ -243,6 +258,8 @@ class RLMMetrics:
     _sub_rlm_branch_input_tokens_max: int = field(default=0, repr=False)
     _sub_rlm_branch_output_tokens_sum: int = field(default=0, repr=False)
     _sub_rlm_branch_output_tokens_max: int = field(default=0, repr=False)
+    _tool_response_tokens: int = field(default=0, repr=False)
+    _sub_rlm_tool_response_tokens: int = field(default=0, repr=False)
     _sub_rlm_enabled: bool = field(default=False, repr=False)
 
     def note_root_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
@@ -250,7 +267,35 @@ class RLMMetrics:
         self._root_output_tokens = completion_tokens
         self._refresh_derived_metrics()
 
-    def note_assistant_turn(self, prompt_tokens: int, completion_tokens: int) -> None:
+    def note_assistant_turn(
+        self,
+        prompt_tokens: int,
+        completion_tokens: int,
+        *,
+        prev_appended_role: str | None = None,
+    ) -> None:
+        """Record one main-loop turn's API usage.
+
+        ``prev_appended_role`` names the role of whatever the engine
+        appended to ``messages`` between the previous and current API
+        call (typically ``"tool"``). When it equals ``"tool"``, the
+        prompt-token growth — minus the previous turn's completion
+        (which is the just-appended assistant message) — is attributed
+        to ``_tool_response_tokens``. Pass ``None`` on the first turn
+        of any branch (no preceding turn) to skip the attribution; this
+        naturally excludes the system + initial-user baseline.
+        """
+        if prev_appended_role == "tool":
+            delta = (
+                prompt_tokens
+                - self._prev_turn_prompt_tokens
+                - self._prev_turn_completion_tokens
+            )
+            self._tool_response_tokens += max(0, delta)
+
+        self._prev_turn_prompt_tokens = prompt_tokens
+        self._prev_turn_completion_tokens = completion_tokens
+
         self._retained_completion_tokens.append(completion_tokens)
         self._retained_completion_tokens_total += completion_tokens
 
@@ -283,6 +328,12 @@ class RLMMetrics:
 
         self.final_input_tokens = self._current_branch_input_tokens
         self.final_output_tokens = self._current_branch_output_tokens
+
+        # Branch boundary: drop prev-turn carry so the next turn's
+        # prompt-token delta isn't attributed across a fresh-context jump.
+        self._prev_turn_prompt_tokens = 0
+        self._prev_turn_completion_tokens = 0
+
         self._current_branch_input_tokens = None
         self._current_branch_output_tokens = None
         self._refresh_derived_metrics()
@@ -302,6 +353,7 @@ class RLMMetrics:
         self._sub_rlm_branch_output_tokens_max = stats.get(
             "branch_output_tokens_max", 0
         )
+        self._sub_rlm_tool_response_tokens = stats.get("tool_response_tokens_total", 0)
         self._refresh_derived_metrics()
 
     def apply_programmatic_tool_call_stats(
@@ -337,6 +389,9 @@ class RLMMetrics:
             "branch_output_tokens_max": max(
                 self._branch_output_tokens_max,
                 self._sub_rlm_branch_output_tokens_max,
+            ),
+            "tool_response_tokens_total": (
+                self._tool_response_tokens + self._sub_rlm_tool_response_tokens
             ),
         }
 
@@ -393,6 +448,10 @@ class RLMMetrics:
                 self._branch_output_tokens_sum / self._branch_count
             )
             self.branch_output_tokens_max = self._branch_output_tokens_max
+
+        self.total_tool_response_tokens = (
+            self._tool_response_tokens + self._sub_rlm_tool_response_tokens
+        )
 
     def to_dict(self) -> dict[str, Any]:
         self._refresh_derived_metrics()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,143 @@
+"""Tests for RLMMetrics token-tracking, especially total_tool_response_tokens."""
+
+from rlm.types import CompactionApplied, RLMMetrics
+
+
+def test_total_tool_response_tokens_single_turn_no_tools():
+    """One-turn rollout, model answered without a tool call: zero tool tokens."""
+    m = RLMMetrics()
+    m.note_assistant_turn(prompt_tokens=100, completion_tokens=50)
+    m.finalize_current_branch()
+    assert m.total_tool_response_tokens == 0
+
+
+def test_total_tool_response_tokens_multi_turn_with_tools():
+    """Multi-turn branch: tool tokens = sum of per-turn deltas where role == tool.
+
+    The engine signals each appendage's role. delta = curr.prompt - prev.prompt
+    - prev.completion. Only "tool" appendages count toward the total.
+    """
+    m = RLMMetrics()
+    # Turn 0: prompt = 100 (system + user), completion = 50. No prior turn.
+    m.note_assistant_turn(prompt_tokens=100, completion_tokens=50)
+    # Turn 1: prompt = 100 + 50 (asst_0) + 30 (tool_0) = 180. completion = 40.
+    # delta = 180 - 100 - 50 = 30 → tool_response_tokens += 30.
+    m.note_assistant_turn(
+        prompt_tokens=180, completion_tokens=40, prev_appended_role="tool"
+    )
+    # Turn 2: prompt = 180 + 40 (asst_1) + 70 (tool_1) = 290. completion = 20.
+    # delta = 290 - 180 - 40 = 70 → tool_response_tokens += 70.
+    m.note_assistant_turn(
+        prompt_tokens=290, completion_tokens=20, prev_appended_role="tool"
+    )
+    m.finalize_current_branch()
+    assert m.total_tool_response_tokens == 100
+
+
+def test_total_tool_response_tokens_user_message_not_counted():
+    """Non-tool appendages (e.g. mid-branch user message) are excluded."""
+    m = RLMMetrics()
+    m.note_assistant_turn(prompt_tokens=100, completion_tokens=50)
+    # Imagine a future env injects a user message here. delta = 30 but not counted.
+    m.note_assistant_turn(
+        prompt_tokens=180, completion_tokens=40, prev_appended_role="user"
+    )
+    # Now a tool result follows: delta = 70, counted.
+    m.note_assistant_turn(
+        prompt_tokens=290, completion_tokens=20, prev_appended_role="tool"
+    )
+    m.finalize_current_branch()
+    assert m.total_tool_response_tokens == 70
+
+
+def test_total_tool_response_tokens_across_compactions():
+    """prev-turn carry resets at branch boundaries; tool tokens still summed correctly."""
+    m = RLMMetrics()
+    # Branch 1
+    m.note_assistant_turn(prompt_tokens=100, completion_tokens=50)
+    m.note_assistant_turn(
+        prompt_tokens=180, completion_tokens=40, prev_appended_role="tool"
+    )  # +30
+    m.record(
+        CompactionApplied(
+            num_turns_dropped=2,
+            dropped_chars=0,
+            summary_chars=0,
+            turns_since_last_compaction=2,
+        )
+    )
+    # Branch 2 — fresh context. First turn has no prior turn (None).
+    m.note_assistant_turn(prompt_tokens=80, completion_tokens=30)
+    m.note_assistant_turn(
+        prompt_tokens=130, completion_tokens=20, prev_appended_role="tool"
+    )  # +20
+    m.note_assistant_turn(
+        prompt_tokens=200, completion_tokens=10, prev_appended_role="tool"
+    )  # +50
+    m.finalize_current_branch()
+    # Branch 1: 30 + Branch 2: 20 + 50 = 100.
+    assert m.total_tool_response_tokens == 100
+
+
+def test_total_tool_response_tokens_includes_sub_rlm_aggregate():
+    """total_tool_response_tokens = parent's own + descendants', via context_token_stats."""
+    m = RLMMetrics()
+    m.note_assistant_turn(prompt_tokens=100, completion_tokens=50)
+    m.note_assistant_turn(
+        prompt_tokens=200, completion_tokens=30, prev_appended_role="tool"
+    )  # +50
+    m.finalize_current_branch()
+
+    m.apply_child_aggregates(
+        {
+            "session_count": 2,
+            "input_tokens_total": 1000,
+            "output_tokens_total": 200,
+            "final_input_tokens_total": 500,
+            "final_output_tokens_total": 100,
+            "branch_count": 2,
+            "branch_input_tokens_sum": 800,
+            "branch_input_tokens_max": 600,
+            "branch_output_tokens_sum": 200,
+            "branch_output_tokens_max": 150,
+            "tool_response_tokens_total": 300,
+        }
+    )
+
+    # 50 (parent) + 300 (descendants) = 350.
+    assert m.total_tool_response_tokens == 350
+
+
+def test_context_token_stats_bubbles_subtree_total():
+    """Child's context_token_stats() reports parent + own sub-RLM tool tokens."""
+    m = RLMMetrics()
+    m.note_assistant_turn(prompt_tokens=100, completion_tokens=50)
+    m.note_assistant_turn(
+        prompt_tokens=180, completion_tokens=40, prev_appended_role="tool"
+    )  # +30
+    m.finalize_current_branch()
+    m.apply_child_aggregates(
+        {
+            "session_count": 1,
+            "input_tokens_total": 0,
+            "output_tokens_total": 0,
+            "final_input_tokens_total": 0,
+            "final_output_tokens_total": 0,
+            "branch_count": 0,
+            "branch_input_tokens_sum": 0,
+            "branch_input_tokens_max": 0,
+            "branch_output_tokens_sum": 0,
+            "branch_output_tokens_max": 0,
+            "tool_response_tokens_total": 70,
+        }
+    )
+
+    stats = m.context_token_stats()
+    assert stats["tool_response_tokens_total"] == 100
+
+
+def test_total_tool_response_tokens_handles_empty_finalize():
+    """Finalize before any turn: no contribution, no crash."""
+    m = RLMMetrics()
+    m.finalize_current_branch()
+    assert m.total_tool_response_tokens == 0


### PR DESCRIPTION
Adds a single public RLMMetrics field, ``total_tool_response_tokens``, covering the agent's cumulative tool-result token consumption across the whole rollout (parent + every sub-RLM), with no double-counting across turns, branches, or recursion levels.

Per branch, the parent's own contribution is derived as ``visible_input_at_last_turn − visible_input_at_first_turn`` — which strips the system + initial-user-message baseline and leaves only tool-response growth. Sub-RLM contributions bubble up via the existing ``context_token_stats`` / ``apply_child_aggregates`` path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 38dbc0f2fb0f5637498ab94da99406f37b22b4b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->