### PR TITLE
Invalid tool calls: return error msg and continue rollout

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -172,7 +172,9 @@ class RLMEngine:
         )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
-        self.allow_unknown_tool = os.environ.get("RLM_ALLOW_UNKNOWN_TOOL") == "1"
+        self.allow_invalid_tool_calls = (
+            os.environ.get("RLM_ALLOW_INVALID_TOOL_CALLS") == "1"
+        )
 
         # Token budget
         _max_tok = int(os.environ.get("RLM_MAX_TOKENS", "0"))
@@ -329,18 +331,25 @@ class RLMEngine:
                 )
                 break
 
-            # Malformed tool-call arguments: fail the rollout so training
-            # penalises the mistake. Final_text + stop_reason make the failure
-            # visible to the verifiers harness without raising an exception.
             if msg.tool_calls and parsed_args[0] is None:
-                tool_name = msg.tool_calls[0].function.name
+                tc = msg.tool_calls[0]
+                tool_name = tc.function.name
                 err_info = tool_calls_log[0]["args"]
-                self._metrics.stop_reason = "invalid_tool_args"
-                final_text = (
-                    f"[invalid JSON arguments for tool '{tool_name}': "
-                    f"{err_info['_parse_error']}]"
+                error_content = (
+                    f"invalid JSON arguments for tool '{tool_name}': "
+                    f"{err_info['_parse_error']}"
                 )
-                break
+                if not self.allow_invalid_tool_calls:
+                    self._metrics.stop_reason = "invalid_tool_args"
+                    final_text = f"[{error_content}]"
+                    break
+                feedback = f"Error: {error_content}"
+                self.session.log_tool_result(turn, tool_name, feedback, 0.0)
+                messages.append(
+                    {"role": "tool", "tool_call_id": tc.id, "content": feedback}
+                )
+                last_appended_role = "tool"
+                continue
 
             # Token budget check
             if (
@@ -366,7 +375,7 @@ class RLMEngine:
             t0 = time.time()
             tool = get_builtin_tool(tool_name)
             if tool is None:
-                if not self.allow_unknown_tool:
+                if not self.allow_invalid_tool_calls:
                     self._metrics.stop_reason = "unknown_tool"
                     final_text = f"[unknown tool '{tool_name}']"
                     break

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -172,9 +172,7 @@ class RLMEngine:
         )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
-        self.allow_invalid_tool_calls = (
-            os.environ.get("RLM_ALLOW_INVALID_TOOL_CALLS") == "1"
-        )
+        self.strict_tool_calls = os.environ.get("RLM_STRICT_TOOL_CALLS") == "1"
 
         # Token budget
         _max_tok = int(os.environ.get("RLM_MAX_TOKENS", "0"))
@@ -325,11 +323,20 @@ class RLMEngine:
             self.session.log_assistant(turn, tool_calls_log, msg.content)
 
             if msg.tool_calls and len(msg.tool_calls) > 1:
-                self._metrics.stop_reason = "multiple_tool_calls"
-                final_text = (
-                    "[emitted multiple tool calls in one turn; at most 1 is allowed]"
-                )
-                break
+                if self.strict_tool_calls:
+                    self._metrics.stop_reason = "multiple_tool_calls"
+                    final_text = (
+                        "[emitted multiple tool calls in one turn; at most 1 is allowed]"
+                    )
+                    break
+                feedback = "Error: only one tool call per turn allowed"
+                for tc in msg.tool_calls:
+                    self.session.log_tool_result(turn, tc.function.name, feedback, 0.0)
+                    messages.append(
+                        {"role": "tool", "tool_call_id": tc.id, "content": feedback}
+                    )
+                last_appended_role = "tool"
+                continue
 
             if msg.tool_calls and parsed_args[0] is None:
                 tc = msg.tool_calls[0]
@@ -339,7 +346,7 @@ class RLMEngine:
                     f"invalid JSON arguments for tool '{tool_name}': "
                     f"{err_info['_parse_error']}"
                 )
-                if not self.allow_invalid_tool_calls:
+                if self.strict_tool_calls:
                     self._metrics.stop_reason = "invalid_tool_args"
                     final_text = f"[{error_content}]"
                     break
@@ -375,7 +382,7 @@ class RLMEngine:
             t0 = time.time()
             tool = get_builtin_tool(tool_name)
             if tool is None:
-                if not self.allow_invalid_tool_calls:
+                if self.strict_tool_calls:
                     self._metrics.stop_reason = "unknown_tool"
                     final_text = f"[unknown tool '{tool_name}']"
                     break

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -172,6 +172,7 @@ class RLMEngine:
         )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
+        self.allow_unknown_tool = os.environ.get("RLM_ALLOW_UNKNOWN_TOOL") == "1"
 
         # Token budget
         _max_tok = int(os.environ.get("RLM_MAX_TOKENS", "0"))
@@ -365,6 +366,10 @@ class RLMEngine:
             t0 = time.time()
             tool = get_builtin_tool(tool_name)
             if tool is None:
+                if not self.allow_unknown_tool:
+                    self._metrics.stop_reason = "unknown_tool"
+                    final_text = f"[unknown tool '{tool_name}']"
+                    break
                 tool_result = ToolOutcome(content=f"Error: unknown tool '{tool_name}'")
             else:
                 tool_result = await asyncio.to_thread(

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -172,7 +172,6 @@ class RLMEngine:
         )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
-        self.strict_tool_calls = os.environ.get("RLM_STRICT_TOOL_CALLS") == "1"
 
         # Token budget
         _max_tok = int(os.environ.get("RLM_MAX_TOKENS", "0"))
@@ -323,10 +322,6 @@ class RLMEngine:
             self.session.log_assistant(turn, tool_calls_log, msg.content)
 
             if msg.tool_calls and len(msg.tool_calls) > 1:
-                if self.strict_tool_calls:
-                    self._metrics.stop_reason = "multiple_tool_calls"
-                    final_text = "[emitted multiple tool calls in one turn; at most 1 is allowed]"
-                    break
                 feedback = "Error: only one tool call per turn allowed"
                 for tc in msg.tool_calls:
                     self.session.log_tool_result(turn, tc.function.name, feedback, 0.0)
@@ -340,15 +335,10 @@ class RLMEngine:
                 tc = msg.tool_calls[0]
                 tool_name = tc.function.name
                 err_info = tool_calls_log[0]["args"]
-                error_content = (
-                    f"invalid JSON arguments for tool '{tool_name}': "
+                feedback = (
+                    f"Error: invalid JSON arguments for tool '{tool_name}': "
                     f"{err_info['_parse_error']}"
                 )
-                if self.strict_tool_calls:
-                    self._metrics.stop_reason = "invalid_tool_args"
-                    final_text = f"[{error_content}]"
-                    break
-                feedback = f"Error: {error_content}"
                 self.session.log_tool_result(turn, tool_name, feedback, 0.0)
                 messages.append(
                     {"role": "tool", "tool_call_id": tc.id, "content": feedback}
@@ -371,19 +361,12 @@ class RLMEngine:
                 final_text = msg.content or ""
                 break
 
-            # Execute the single allowed tool call (reuse parsed args from above;
-            # parse failures have already broken the loop, so parsed_args[0] is
-            # guaranteed to be a dict here).
             tc = msg.tool_calls[0]
             tool_name = tc.function.name
             tool_args = parsed_args[0]
             t0 = time.time()
             tool = get_builtin_tool(tool_name)
             if tool is None:
-                if self.strict_tool_calls:
-                    self._metrics.stop_reason = "unknown_tool"
-                    final_text = f"[unknown tool '{tool_name}']"
-                    break
                 tool_result = ToolOutcome(content=f"Error: unknown tool '{tool_name}'")
             else:
                 tool_result = await asyncio.to_thread(

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -325,9 +325,7 @@ class RLMEngine:
             if msg.tool_calls and len(msg.tool_calls) > 1:
                 if self.strict_tool_calls:
                     self._metrics.stop_reason = "multiple_tool_calls"
-                    final_text = (
-                        "[emitted multiple tool calls in one turn; at most 1 is allowed]"
-                    )
+                    final_text = "[emitted multiple tool calls in one turn; at most 1 is allowed]"
                     break
                 feedback = "Error: only one tool call per turn allowed"
                 for tc in msg.tool_calls:

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -223,7 +223,9 @@ class RLMMetrics:
     sub_rlm_programmatic_tool_calls_python: int = 0
     sub_rlm_programmatic_tool_calls_bash: int = 0
 
-    stop_reason: str = ""  # "done", "max_turns", "token_budget", "depth_limit", "request_too_large"
+    stop_reason: str = (
+        ""  # "done", "max_turns", "token_budget", "depth_limit", "request_too_large"
+    )
 
     @property
     def turns(self) -> int:

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -223,7 +223,7 @@ class RLMMetrics:
     sub_rlm_programmatic_tool_calls_python: int = 0
     sub_rlm_programmatic_tool_calls_bash: int = 0
 
-    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "invalid_tool_args", "depth_limit", "request_too_large"
+    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "invalid_tool_args", "unknown_tool", "depth_limit", "request_too_large"
 
     @property
     def turns(self) -> int:

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -223,7 +223,7 @@ class RLMMetrics:
     sub_rlm_programmatic_tool_calls_python: int = 0
     sub_rlm_programmatic_tool_calls_bash: int = 0
 
-    stop_reason: str = ""  # "done", "max_turns", "token_budget", "multiple_tool_calls", "invalid_tool_args", "unknown_tool", "depth_limit", "request_too_large"
+    stop_reason: str = ""  # "done", "max_turns", "token_budget", "depth_limit", "request_too_large"
 
     @property
     def turns(self) -> int:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -38,46 +38,8 @@ async def test_valid_tool(session, register_add_tool):
     assert result.turns == 2
 
 
-async def test_invalid_tool_args(session, register_add_tool):
-    """Default (lenient): parse error is fed back and the loop continues."""
-    prompt = "add 2 and 3"
-    messages = [
-        DummyMessage(tool_calls=[DummyToolCall("add", "not-valid-json")]),
-        DummyMessage(content="ok, giving up"),
-    ]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    assert len(client.calls) == 2
-    assert "Error: invalid JSON arguments for tool 'add'" in tool_result(client)
-    assert result.answer == "ok, giving up"
-    assert result.turns == 2
-
-
-async def test_unknown_tool(session, register_add_tool):
-    """Default (lenient): unknown-tool error is fed back and the loop continues."""
-    prompt = "do something"
-    messages = [
-        DummyMessage(tool_calls=[DummyToolCall("ipytron", {})]),
-        DummyMessage(content="ok, giving up"),
-    ]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    assert len(client.calls) == 2
-    assert "Error: unknown tool 'ipytron'" in tool_result(client)
-    assert result.answer == "ok, giving up"
-    assert result.turns == 2
-
-
 async def test_multiple_tool_calls(session, register_add_tool):
-    """Default (lenient): each tool_call_id receives an error and the loop continues."""
+    """Each tool_call_id in a multi-call assistant message receives a tool result."""
     prompt = "add things"
     messages = [
         DummyMessage(
@@ -86,24 +48,18 @@ async def test_multiple_tool_calls(session, register_add_tool):
                 DummyToolCall("add", {"a": 3, "b": 4}, id="call_1"),
             ]
         ),
-        DummyMessage(content="ok, giving up"),
+        DummyMessage(content=""),
     ]
 
     client = DummyClient(messages)
     engine = RLMEngine(client=client, session=session)  # type: ignore
 
-    result = await engine.run(prompt)
+    await engine.run(prompt)
 
-    assert len(client.calls) == 2
-    request_messages = client.calls[1]["messages"]
-    tool_messages = [m for m in request_messages if m.get("role") == "tool"]
-    assert len(tool_messages) == 2
-    assert all(
-        "only one tool call per turn allowed" in m["content"] for m in tool_messages
-    )
-    assert {m["tool_call_id"] for m in tool_messages} == {"call_0", "call_1"}
-    assert result.answer == "ok, giving up"
-    assert result.turns == 2
+    tool_messages = [
+        m for m in client.calls[1]["messages"] if m.get("role") == "tool"
+    ]
+    assert sorted(m["tool_call_id"] for m in tool_messages) == ["call_0", "call_1"]
 
 
 async def test_tool_raises(session, register_boom_tool):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,10 +2,8 @@
 
 Drives ``rlm.engine.RLMEngine`` with a scripted DummyClient and a dummy
 ``add(a, b)`` tool (registered per-test, not part of the package) to
-exercise how the harness reacts to model tool-call behavior:
-
-- valid tool call   → dispatched, result fed back as a ``tool`` message
-- invalid tool call → loop short-circuits, final answer reports the error
+exercise how the harness reacts to model tool-call behavior across
+both default-lenient and ``RLM_STRICT_TOOL_CALLS=1`` modes.
 """
 
 from __future__ import annotations
@@ -42,64 +40,7 @@ async def test_valid_tool(session, register_add_tool):
 
 
 async def test_invalid_tool_args(session, register_add_tool):
-    """Malformed JSON in a tool call: rollout short-circuits with an error answer."""
-    prompt = "add 2 and 3"
-    messages = [DummyMessage(tool_calls=[DummyToolCall("add", "not-valid-json")])]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    # Harness short-circuits — no second round-trip to the model.
-    assert len(client.calls) == 1
-    assert "invalid JSON arguments" in result.answer
-    assert result.turns == 1
-    assert engine._metrics.stop_reason == "invalid_tool_args"
-
-
-async def test_unknown_tool_terminates(session, register_add_tool):
-    """Unknown tool name: rollout short-circuits with stop_reason=unknown_tool."""
-    prompt = "do something"
-    messages = [DummyMessage(tool_calls=[DummyToolCall("ipytron", {})])]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    assert len(client.calls) == 1
-    assert "unknown tool 'ipytron'" in result.answer
-    assert result.turns == 1
-    assert engine._metrics.stop_reason == "unknown_tool"
-
-
-async def test_unknown_tool_lenient_with_env(session, register_add_tool, monkeypatch):
-    """RLM_ALLOW_INVALID_TOOL_CALLS=1: unknown-tool error is fed back and the loop continues."""
-    monkeypatch.setenv("RLM_ALLOW_INVALID_TOOL_CALLS", "1")
-    prompt = "do something"
-    messages = [
-        DummyMessage(tool_calls=[DummyToolCall("ipytron", {})]),
-        DummyMessage(content="ok, giving up"),
-    ]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    assert len(client.calls) == 2
-    assert "Error: unknown tool 'ipytron'" in tool_result(client)
-    assert result.answer == "ok, giving up"
-    assert result.turns == 2
-    assert engine._metrics.stop_reason == "done"
-
-
-async def test_invalid_tool_args_lenient_with_env(
-    session, register_add_tool, monkeypatch
-):
-    """RLM_ALLOW_INVALID_TOOL_CALLS=1: parse error is fed back and the loop continues."""
-    monkeypatch.setenv("RLM_ALLOW_INVALID_TOOL_CALLS", "1")
+    """Default (lenient): parse error is fed back and the loop continues."""
     prompt = "add 2 and 3"
     messages = [
         DummyMessage(tool_calls=[DummyToolCall("add", "not-valid-json")]),
@@ -115,7 +56,113 @@ async def test_invalid_tool_args_lenient_with_env(
     assert "Error: invalid JSON arguments for tool 'add'" in tool_result(client)
     assert result.answer == "ok, giving up"
     assert result.turns == 2
-    assert engine._metrics.stop_reason == "done"
+
+
+async def test_invalid_tool_args_strict(session, register_add_tool, monkeypatch):
+    """RLM_STRICT_TOOL_CALLS=1: rollout short-circuits with stop_reason=invalid_tool_args."""
+    monkeypatch.setenv("RLM_STRICT_TOOL_CALLS", "1")
+    prompt = "add 2 and 3"
+    messages = [DummyMessage(tool_calls=[DummyToolCall("add", "not-valid-json")])]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 1
+    assert "invalid JSON arguments" in result.answer
+    assert result.turns == 1
+    assert engine._metrics.stop_reason == "invalid_tool_args"
+
+
+async def test_unknown_tool(session, register_add_tool):
+    """Default (lenient): unknown-tool error is fed back and the loop continues."""
+    prompt = "do something"
+    messages = [
+        DummyMessage(tool_calls=[DummyToolCall("ipytron", {})]),
+        DummyMessage(content="ok, giving up"),
+    ]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 2
+    assert "Error: unknown tool 'ipytron'" in tool_result(client)
+    assert result.answer == "ok, giving up"
+    assert result.turns == 2
+
+
+async def test_unknown_tool_strict(session, register_add_tool, monkeypatch):
+    """RLM_STRICT_TOOL_CALLS=1: rollout short-circuits with stop_reason=unknown_tool."""
+    monkeypatch.setenv("RLM_STRICT_TOOL_CALLS", "1")
+    prompt = "do something"
+    messages = [DummyMessage(tool_calls=[DummyToolCall("ipytron", {})])]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 1
+    assert "unknown tool 'ipytron'" in result.answer
+    assert result.turns == 1
+    assert engine._metrics.stop_reason == "unknown_tool"
+
+
+async def test_multiple_tool_calls(session, register_add_tool):
+    """Default (lenient): each tool_call_id receives an error and the loop continues."""
+    prompt = "add things"
+    messages = [
+        DummyMessage(
+            tool_calls=[
+                DummyToolCall("add", {"a": 1, "b": 2}, id="call_0"),
+                DummyToolCall("add", {"a": 3, "b": 4}, id="call_1"),
+            ]
+        ),
+        DummyMessage(content="ok, giving up"),
+    ]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 2
+    request_messages = client.calls[1]["messages"]
+    tool_messages = [m for m in request_messages if m.get("role") == "tool"]
+    assert len(tool_messages) == 2
+    assert all(
+        "only one tool call per turn allowed" in m["content"] for m in tool_messages
+    )
+    assert {m["tool_call_id"] for m in tool_messages} == {"call_0", "call_1"}
+    assert result.answer == "ok, giving up"
+    assert result.turns == 2
+
+
+async def test_multiple_tool_calls_strict(session, register_add_tool, monkeypatch):
+    """RLM_STRICT_TOOL_CALLS=1: rollout short-circuits with stop_reason=multiple_tool_calls."""
+    monkeypatch.setenv("RLM_STRICT_TOOL_CALLS", "1")
+    prompt = "add things"
+    messages = [
+        DummyMessage(
+            tool_calls=[
+                DummyToolCall("add", {"a": 1, "b": 2}, id="call_0"),
+                DummyToolCall("add", {"a": 3, "b": 4}, id="call_1"),
+            ]
+        )
+    ]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 1
+    assert "multiple tool calls" in result.answer
+    assert result.turns == 1
+    assert engine._metrics.stop_reason == "multiple_tool_calls"
 
 
 async def test_tool_raises(session, register_boom_tool):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -58,6 +58,43 @@ async def test_invalid_tool_args(session, register_add_tool):
     assert engine._metrics.stop_reason == "invalid_tool_args"
 
 
+async def test_unknown_tool_terminates(session, register_add_tool):
+    """Unknown tool name: rollout short-circuits with stop_reason=unknown_tool."""
+    prompt = "do something"
+    messages = [DummyMessage(tool_calls=[DummyToolCall("ipytron", {})])]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 1
+    assert "unknown tool 'ipytron'" in result.answer
+    assert result.turns == 1
+    assert engine._metrics.stop_reason == "unknown_tool"
+
+
+async def test_unknown_tool_lenient_with_env(session, register_add_tool, monkeypatch):
+    """RLM_ALLOW_UNKNOWN_TOOL=1: error is fed back and the loop continues."""
+    monkeypatch.setenv("RLM_ALLOW_UNKNOWN_TOOL", "1")
+    prompt = "do something"
+    messages = [
+        DummyMessage(tool_calls=[DummyToolCall("ipytron", {})]),
+        DummyMessage(content="ok, giving up"),
+    ]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 2
+    assert "Error: unknown tool 'ipytron'" in tool_result(client)
+    assert result.answer == "ok, giving up"
+    assert result.turns == 2
+    assert engine._metrics.stop_reason == "done"
+
+
 async def test_tool_raises(session, register_boom_tool):
     """Tool raising from execute() propagates out of engine.run()."""
     prompt = "set off the boom tool"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,8 +2,7 @@
 
 Drives ``rlm.engine.RLMEngine`` with a scripted DummyClient and a dummy
 ``add(a, b)`` tool (registered per-test, not part of the package) to
-exercise how the harness reacts to model tool-call behavior across
-both default-lenient and ``RLM_STRICT_TOOL_CALLS=1`` modes.
+exercise how the harness reacts to model tool-call behavior.
 """
 
 from __future__ import annotations
@@ -58,23 +57,6 @@ async def test_invalid_tool_args(session, register_add_tool):
     assert result.turns == 2
 
 
-async def test_invalid_tool_args_strict(session, register_add_tool, monkeypatch):
-    """RLM_STRICT_TOOL_CALLS=1: rollout short-circuits with stop_reason=invalid_tool_args."""
-    monkeypatch.setenv("RLM_STRICT_TOOL_CALLS", "1")
-    prompt = "add 2 and 3"
-    messages = [DummyMessage(tool_calls=[DummyToolCall("add", "not-valid-json")])]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    assert len(client.calls) == 1
-    assert "invalid JSON arguments" in result.answer
-    assert result.turns == 1
-    assert engine._metrics.stop_reason == "invalid_tool_args"
-
-
 async def test_unknown_tool(session, register_add_tool):
     """Default (lenient): unknown-tool error is fed back and the loop continues."""
     prompt = "do something"
@@ -92,23 +74,6 @@ async def test_unknown_tool(session, register_add_tool):
     assert "Error: unknown tool 'ipytron'" in tool_result(client)
     assert result.answer == "ok, giving up"
     assert result.turns == 2
-
-
-async def test_unknown_tool_strict(session, register_add_tool, monkeypatch):
-    """RLM_STRICT_TOOL_CALLS=1: rollout short-circuits with stop_reason=unknown_tool."""
-    monkeypatch.setenv("RLM_STRICT_TOOL_CALLS", "1")
-    prompt = "do something"
-    messages = [DummyMessage(tool_calls=[DummyToolCall("ipytron", {})])]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    assert len(client.calls) == 1
-    assert "unknown tool 'ipytron'" in result.answer
-    assert result.turns == 1
-    assert engine._metrics.stop_reason == "unknown_tool"
 
 
 async def test_multiple_tool_calls(session, register_add_tool):
@@ -139,30 +104,6 @@ async def test_multiple_tool_calls(session, register_add_tool):
     assert {m["tool_call_id"] for m in tool_messages} == {"call_0", "call_1"}
     assert result.answer == "ok, giving up"
     assert result.turns == 2
-
-
-async def test_multiple_tool_calls_strict(session, register_add_tool, monkeypatch):
-    """RLM_STRICT_TOOL_CALLS=1: rollout short-circuits with stop_reason=multiple_tool_calls."""
-    monkeypatch.setenv("RLM_STRICT_TOOL_CALLS", "1")
-    prompt = "add things"
-    messages = [
-        DummyMessage(
-            tool_calls=[
-                DummyToolCall("add", {"a": 1, "b": 2}, id="call_0"),
-                DummyToolCall("add", {"a": 3, "b": 4}, id="call_1"),
-            ]
-        )
-    ]
-
-    client = DummyClient(messages)
-    engine = RLMEngine(client=client, session=session)  # type: ignore
-
-    result = await engine.run(prompt)
-
-    assert len(client.calls) == 1
-    assert "multiple tool calls" in result.answer
-    assert result.turns == 1
-    assert engine._metrics.stop_reason == "multiple_tool_calls"
 
 
 async def test_tool_raises(session, register_boom_tool):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -75,8 +75,8 @@ async def test_unknown_tool_terminates(session, register_add_tool):
 
 
 async def test_unknown_tool_lenient_with_env(session, register_add_tool, monkeypatch):
-    """RLM_ALLOW_UNKNOWN_TOOL=1: error is fed back and the loop continues."""
-    monkeypatch.setenv("RLM_ALLOW_UNKNOWN_TOOL", "1")
+    """RLM_ALLOW_INVALID_TOOL_CALLS=1: unknown-tool error is fed back and the loop continues."""
+    monkeypatch.setenv("RLM_ALLOW_INVALID_TOOL_CALLS", "1")
     prompt = "do something"
     messages = [
         DummyMessage(tool_calls=[DummyToolCall("ipytron", {})]),
@@ -90,6 +90,27 @@ async def test_unknown_tool_lenient_with_env(session, register_add_tool, monkeyp
 
     assert len(client.calls) == 2
     assert "Error: unknown tool 'ipytron'" in tool_result(client)
+    assert result.answer == "ok, giving up"
+    assert result.turns == 2
+    assert engine._metrics.stop_reason == "done"
+
+
+async def test_invalid_tool_args_lenient_with_env(session, register_add_tool, monkeypatch):
+    """RLM_ALLOW_INVALID_TOOL_CALLS=1: parse error is fed back and the loop continues."""
+    monkeypatch.setenv("RLM_ALLOW_INVALID_TOOL_CALLS", "1")
+    prompt = "add 2 and 3"
+    messages = [
+        DummyMessage(tool_calls=[DummyToolCall("add", "not-valid-json")]),
+        DummyMessage(content="ok, giving up"),
+    ]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    result = await engine.run(prompt)
+
+    assert len(client.calls) == 2
+    assert "Error: invalid JSON arguments for tool 'add'" in tool_result(client)
     assert result.answer == "ok, giving up"
     assert result.turns == 2
     assert engine._metrics.stop_reason == "done"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -95,7 +95,9 @@ async def test_unknown_tool_lenient_with_env(session, register_add_tool, monkeyp
     assert engine._metrics.stop_reason == "done"
 
 
-async def test_invalid_tool_args_lenient_with_env(session, register_add_tool, monkeypatch):
+async def test_invalid_tool_args_lenient_with_env(
+    session, register_add_tool, monkeypatch
+):
     """RLM_ALLOW_INVALID_TOOL_CALLS=1: parse error is fed back and the loop continues."""
     monkeypatch.setenv("RLM_ALLOW_INVALID_TOOL_CALLS", "1")
     prompt = "add 2 and 3"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -56,9 +56,7 @@ async def test_multiple_tool_calls(session, register_add_tool):
 
     await engine.run(prompt)
 
-    tool_messages = [
-        m for m in client.calls[1]["messages"] if m.get("role") == "tool"
-    ]
+    tool_messages = [m for m in client.calls[1]["messages"] if m.get("role") == "tool"]
     assert sorted(m["tool_call_id"] for m in tool_messages) == ["call_0", "call_1"]
 
 


### PR DESCRIPTION
  Makes invalid_tool_args and multiple_tool_calls consistent with the existing unknown_tool  behavior: rlm now feeds an error message back to the model on every structurally invalid tool call and continues the rollout, rather than aborting partway through. The error is shaped as a normal tool-result message, so the model can read the failure and recover.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent-loop control flow for malformed or multi-tool-call responses, which can alter conversation state, metrics, and downstream tool dispatch behavior.
> 
> **Overview**
> **Tool-call error handling is now non-fatal.** When the model emits *multiple* tool calls in one assistant message or provides *invalid JSON args*, the engine now appends `tool`-role error results (one per `tool_call_id`) and continues to the next turn, instead of stopping early with `stop_reason`/final answer text.
> 
> Metrics are adjusted to remove `multiple_tool_calls`/`invalid_tool_args` from `RLMMetrics.stop_reason`, and tests are updated to assert that multi-call responses receive corresponding tool-result messages rather than short-circuiting the rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713354bdac0050ad187c759968cf5547d307a5d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->