### PR TITLE
fix(compaction): forward tools= with tool_choice="none" to keep exten…

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -403,7 +403,7 @@ class RLMEngine:
                 and usage.prompt_tokens >= self.summarize_at_tokens
             ):
                 try:
-                    await self._compact_branch(messages, turn)
+                    await self._compact_branch(messages, turn, active_tools)
                 except BadRequestError as e:
                     if not _is_request_too_large(e):
                         raise
@@ -434,7 +434,9 @@ class RLMEngine:
         )
         return result
 
-    async def _compact_branch(self, messages: list[dict], turn: int) -> None:
+    async def _compact_branch(
+        self, messages: list[dict], turn: int, active_tools: list[dict]
+    ) -> None:
         """Ask the model for a handoff summary and rebuild ``messages``.
 
         Called in-place: mutates ``messages`` to ``[system, user(framing +
@@ -442,6 +444,16 @@ class RLMEngine:
         summary doesn't count toward ``max_turns`` — it's housekeeping,
         not a work turn — but its tokens land in ``_total_usage`` for
         cost accounting.
+
+        ``active_tools`` is forwarded as ``tools=`` with
+        ``tool_choice="none"`` so the rendered system prompt matches
+        regular turns (vLLM's chat-completions layer injects the tools
+        block into the system message only when ``tools=`` is set). With
+        a matching system prompt, prime-rl's RL trajectory walker keeps
+        the extension property across the compaction boundary instead
+        of opening an extra training-sample split. ``tool_choice="none"``
+        keeps the original "text-only summary" behaviour by forbidding
+        tool calls on this turn.
         """
         # Measure what's about to be dropped BEFORE appending the
         # checkpoint prompt — otherwise the prompt's own chars get
@@ -450,17 +462,22 @@ class RLMEngine:
         dropped_chars = _count_messages_chars(messages[2:])
         turns_since_last = turn + 1 - self._branch_start_turn
 
-        # Append the checkpoint prompt and ask the model for a summary
-        # turn with NO tools available so it can only respond with text.
+        # Append the checkpoint prompt and ask the model for a text-only
+        # summary turn. Tools are advertised to the server (so the system
+        # prompt renders identically to regular turns) but
+        # ``tool_choice="none"`` forbids the model from calling any.
         # Warn about the REPL restart only when a kernel is actually running.
         checkpoint_prompt = CHECKPOINT_COMPACTION_PROMPT
         if self._repl is not None:
             checkpoint_prompt += REPL_RESTART_NOTE
         messages.append({"role": "user", "content": checkpoint_prompt})
+        request_kwargs: dict = {"model": self.model, "messages": messages}
+        if active_tools:
+            request_kwargs["tools"] = active_tools
+            request_kwargs["tool_choice"] = "none"
         response = await call_with_retries(
             self.client.chat.completions.create,
-            model=self.model,
-            messages=messages,
+            **request_kwargs,
         )
         usage = extract_usage(response)
         self._total_usage.prompt_tokens += usage.prompt_tokens


### PR DESCRIPTION
## Summary
                                                                                                                                                     
  The compaction summary call drops `tools=` from the request entirely so the model can only respond with text. Side effect we missed: vLLM's
  chat-completions layer injects a `# Tools\n<tools>{...}</tools>` block into the rendered system message **only when `tools=` is in the request**.  
  Dropping `tools=` therefore makes the compaction call's system prompt diverge from every regular turn.
                                                                                                                                                     
  Downstream, prime-rl's RL trajectory walker (`interleave_rollout` in `src/prime_rl/orchestrator/trajectories.py`) opens a new training sample
  whenever a step's `prompt_ids` doesn't prefix-match any active sample. One compaction event creates **two** prefix-incompatible boundaries:        
                                                                      
  1. **Compaction summary turn** (no `tools=` in request → no `# Tools` block in rendered system) does not extend the prior pre-compaction sample.   
  2. **Post-compaction continuation turn** (tools back in request → `# Tools` block back) does not extend the summary turn.
                                                                                                                                                     
  So one compaction event splits the rollout into three samples where structurally two would be enough.                                              
                                          
  ## Symptoms in production                                                                                                                          
                                                                                                                                                     
  RLM-GLM5.1 run (TITO, `use_token_client=true`), all four envs:                                                                                     
                                                                                                                                                     
  | env | samples/rollout | compactions/rollout | breaks (s−1) | breaks/compaction |
  |---|---|---|---|---|                                                                                                                              
  | rlm-swe | 3.16 | 1.07 | 2.16 | **2.01** |
  | rlm-deepdive | 1.99 | 0.49 | 0.99 | **2.02** |                                                                                                   
  | rlm-swerebench-v2 | 2.62 | 0.81 | 1.62 | **2.00** |               
  | general-agent-rlm | 2.23 | 0.61 | 1.23 | **2.02** |                                                                                              
                                                                                                                                                     
  Ratio is 2.0 across all envs — too clean to be tokenization noise; structural.                                                                     
                                                                                                                                                     
  ## Fix                                                                                                                                             
                                                                                                                                                     
  Forward the active tool list to the compaction call as `tools=active_tools` with `tool_choice="none"`. The system prompt now renders identically to
   regular turns (extension property holds at the summary turn → 1 break per compaction instead of 2), while `tool_choice="none"` preserves the      
  original "text-only summary" behaviour by forbidding tool calls.    
                                                                                                                                                     
  ```python
  request_kwargs = {"model": self.model, "messages": messages}                                                                                       
  if active_tools:                                                    
      request_kwargs["tools"] = active_tools
      request_kwargs["tool_choice"] = "none"
  response = await call_with_retries(self.client.chat.completions.create, **request_kwargs)                                                          
                                              
  Why tool_choice="none" over dropping tools=                                                                                                        
                                                                                                                                                     
  tool_choice="none" is the OpenAI-spec way to say "you have tools, I just don't want you to call them this turn." It keeps the request              
  schema-consistent with regular turns (same system-prompt rendering on the server), so prime-rl's interleave_rollout keeps merging steps into one   
  sample across the compaction boundary instead of opening a third one.                                                                              
                                                                                                                                                     
  When this regressed
                                                                                                                                                     
  It hasn't — _compact_branch has called chat.completions.create without tools= since compaction was first introduced in #54 (2026-04-23, commit
  f7cda58). The bug has been silent the whole time. It only surfaced now because we noticed samples_per_rollout / rlm_compactions_count == 2.0 and
  traced the prefix break from the prime-rl orchestrator side.
                                                                                                                                                     
  Scope
                                                                                                                                                     
  - One file changed (src/rlm/engine.py), 23 insertions / 6 deletions.
  - _compact_branch signature gains an active_tools argument; the only caller is updated.
  - No test changes — tests/test_metrics.py exercises metrics shape, not the compaction request.