### PR TITLE
fix(skills): preserve run's signature and docstring through shim

### DIFF
--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -159,7 +159,7 @@ class IPythonREPL:
         installed_skills = get_installed_skills()
 
         setup_code = f"""\
-import os, sys, types, json, time
+import os, sys, types, json, time, functools, inspect
 os.chdir({self.cwd!r})
 os.environ['RLM_SESSION_DIR'] = {session_dir!r} or ''
 os.environ['RLM_DEPTH'] = str({depth!r} + 1)
@@ -200,10 +200,17 @@ def _wrap_callable(mod, log_source):
     wrapped.__dict__.update(mod.__dict__)
     if log_source is not None:
         _original_run = wrapped.run
+        @functools.wraps(_original_run)
         async def _logged_run(*args, **kwargs):
             _log_programmatic_call(mod.__name__, log_source)
             return await _original_run(*args, **kwargs)
         wrapped.run = _logged_run
+    # Mirror run's signature and docstring onto the module so
+    # `inspect.signature(<skill>)` and `help(<skill>)` expose the real API
+    # surface instead of `_CallableModule.__call__`'s `(*args, **kwargs)`
+    # and the file-level module docstring.
+    wrapped.__signature__ = inspect.signature(wrapped.run)
+    wrapped.__doc__ = wrapped.run.__doc__
     sys.modules[mod.__name__] = wrapped
     return wrapped
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -214,3 +214,36 @@ async def test_valid_bash_skill_metrics(session):
 
     assert engine._metrics.programmatic_tool_calls_python == 0
     assert engine._metrics.programmatic_tool_calls_bash == 1
+
+
+async def test_skill_introspection(session):
+    """``inspect.signature`` and ``__doc__`` see through the logger wrapper.
+
+    Without ``functools.wraps`` + a ``__signature__`` override on the
+    callable module, ``inspect.signature(say)`` returns
+    ``_CallableModule.__call__``'s ``(*args, **kwargs)`` and
+    ``inspect.signature(say.run)`` returns the logger shim's
+    ``(*args, **kwargs)`` — both useless for the model that prompt.py
+    tells to introspect the skill API.
+    """
+    code = (
+        "import inspect\n"
+        "print('sig:', list(inspect.signature(say).parameters))\n"
+        "print('sig.run:', list(inspect.signature(say.run).parameters))\n"
+        "print('doc match:', say.__doc__ == say.run.__doc__)"
+    )
+    messages = [
+        DummyMessage(tool_calls=[DummyToolCall("ipython", {"code": code})]),
+        DummyMessage(content="ok"),
+    ]
+
+    client = DummyClient(messages)
+    engine = RLMEngine(client=client, session=session)  # type: ignore
+
+    await engine.run("introspect say")
+
+    output = tool_result(client)
+    show_tool_result(output)
+    assert "sig: ['s']" in output
+    assert "sig.run: ['s']" in output
+    assert "doc match: True" in output


### PR DESCRIPTION
Wrap `_logged_run` with `functools.wraps` so `inspect.signature(<skill>.run)` follows `__wrapped__` to the real signature, and mirror run's signature and docstring onto the `_CallableModule` instance so `inspect.signature(<skill>)` and `help(<skill>)` expose the real API instead of `__call__`'s `(*args, **kwargs)` and the file-level module docstring. *prompt.py* advertises these introspection paths, so this restores the documented API for the model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the IPython startup wrapper metadata for skills and add a test to validate introspection; execution behavior of the skills remains the same aside from metadata exposure.
> 
> **Overview**
> Fixes skill introspection in the IPython kernel by preserving wrapped `run` metadata and surfacing the real API on the callable module.
> 
> The startup shim now uses `functools.wraps` for the logged `run` wrapper and sets `__signature__`/`__doc__` on the wrapped skill module so `inspect.signature(<skill>)`, `inspect.signature(<skill>.run)`, and `help(<skill>)` reflect the underlying skill implementation. Adds a regression test (`test_skill_introspection`) to assert signatures and docstrings match through the wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5fc05a5a11341aece8794858576a76dc942c3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->