### PR TITLE
fix: use plain `tyro` help for skill CLIs

### DIFF
--- a/src/rlm/skill.py
+++ b/src/rlm/skill.py
@@ -23,6 +23,7 @@ def run_cli(func: Any, prog: str | None = None) -> None:
 
     Async returns are awaited; non-``None`` return values are printed.
     """
+    tyro._experimental_options["utf8_boxes"] = False
     result = tyro.cli(func, prog=prog or Path(sys.argv[0]).stem)
     if inspect.isawaitable(result):
         result = asyncio.run(result)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -102,6 +102,10 @@ async def test_bash_skill_invalid_args(session):
     show_tool_result(output)
     assert "--s" in output
     assert "required" in output
+    assert "╭" not in output
+    assert "╰" not in output
+    assert "│" not in output
+    assert "─" not in output
     assert result.answer == "the call failed"
 
 


### PR DESCRIPTION
## Summary
- Configure shared skill CLIs to use Tyro's ASCII/plain help framing while preserving ANSI coloring.
- Assert bash skill errors no longer include UTF-8 box drawing characters.

## Verification
- `uv run ruff check src tests`
- `uv run pytest tests/test_skills.py::test_bash_skill_invalid_args -q`
- `uv run pytest tests/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks CLI help formatting via a Tyro experimental option and tightens a test assertion around error output formatting.
> 
> **Overview**
> Skill CLIs now force Tyro to render *plain/ASCII* help output by disabling `tyro._experimental_options["utf8_boxes"]` in `run_cli`.
> 
> Tests for bash-form invalid args were updated to assert the usage error output no longer contains UTF-8 box-drawing characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 446f34568090aa3736f8f80336c7f1b1afa1b93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->