### PR TITLE
feat(install): bake common Python libs into rlm tool venv by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,14 +60,20 @@ if [ -d /task/rlm-skills ]; then
     done
 fi
 
-# Forward caller-supplied `uv tool install` extras (e.g. "--with numpy
-# --with sympy") when set, so environments can inject extra pip deps into
-# the rlm tool venv without patching this script. Tokens are word-split by
-# the shell, so avoid shell metacharacters (e.g. `>=`) inside package specs.
-EXTRA_UV_ARGS=""
-if [ -n "${RLM_EXTRA_UV_ARGS:-}" ]; then
-    EXTRA_UV_ARGS="$RLM_EXTRA_UV_ARGS"
+# Build the default `--with` flags from src/rlm/default_packages.txt so the
+# agent can `import` common libs (requests, pandas, …) without pip-installing
+# mid-rollout. Callers override the full set via RLM_EXTRA_UV_ARGS (e.g.
+# "--with numpy --with sympy"). Word-splitting applies, so avoid shell
+# metacharacters (e.g. `>=`) inside package specs.
+DEFAULT_EXTRA_UV_ARGS=""
+PACKAGES_FILE="$RLM_CHECKOUT/src/rlm/default_packages.txt"
+if [ -f "$PACKAGES_FILE" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        pkg=$(printf '%s\n' "$line" | sed 's/#.*//' | awk '{print $1}')
+        [ -n "$pkg" ] && DEFAULT_EXTRA_UV_ARGS="$DEFAULT_EXTRA_UV_ARGS --with $pkg"
+    done < "$PACKAGES_FILE"
 fi
+EXTRA_UV_ARGS="${RLM_EXTRA_UV_ARGS:-$DEFAULT_EXTRA_UV_ARGS}"
 
 uv tool install --python 3.10 --editable "$RLM_CHECKOUT" $SKILL_ARGS $EXTRA_UV_ARGS
 

--- a/src/rlm/default_packages.txt
+++ b/src/rlm/default_packages.txt
@@ -1,0 +1,20 @@
+# Python packages pre-installed into the rlm tool venv by install.sh, so
+# the agent can `import` them from the IPython kernel without pip-installing
+# mid-rollout. Listed here (not just in install.sh) so the system prompt can
+# advertise them to the model.
+#
+# Format: one entry per line; either `pip-name` or `pip-name import-name`
+# when the import name differs from the pip-install name. Comments start
+# with `#`. Avoid shell metacharacters (e.g. `>=`) — install.sh word-splits
+# this into `uv tool install --with ...` args.
+requests
+httpx
+pyyaml yaml
+tomli
+python-dotenv dotenv
+pandas
+numpy
+scipy
+beautifulsoup4 bs4
+lxml
+pydantic

--- a/src/rlm/packages.py
+++ b/src/rlm/packages.py
@@ -1,0 +1,34 @@
+"""Default Python packages pre-installed in the rlm tool venv.
+
+`default_packages.txt` is the single source of truth, read by both
+`install.sh` (to build `uv tool install --with ...` args) and the system
+prompt (to tell the agent which libraries are already importable).
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from typing import NamedTuple
+
+
+class DefaultPackage(NamedTuple):
+    install: str
+    imp: str
+
+
+def _parse(text: str) -> list[DefaultPackage]:
+    packages: list[DefaultPackage] = []
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        install = parts[0]
+        imp = parts[1] if len(parts) > 1 else install
+        packages.append(DefaultPackage(install, imp))
+    return packages
+
+
+DEFAULT_PACKAGES: list[DefaultPackage] = _parse(
+    files("rlm").joinpath("default_packages.txt").read_text()
+)

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from rlm.packages import DEFAULT_PACKAGES
+
 if TYPE_CHECKING:
     from rlm.tools.base import BuiltinTool
 
@@ -50,6 +52,15 @@ def build_system_prompt(
         )
     if skill_lines:
         parts.extend(["", *skill_lines])
+
+    if DEFAULT_PACKAGES:
+        importable = ", ".join(f"`{pkg.imp}`" for pkg in DEFAULT_PACKAGES)
+        parts.extend(
+            [
+                "",
+                f"Pre-installed Python packages (importable in the IPython kernel): {importable}.",
+            ]
+        )
 
     if allow_recursion:
         parts.extend(


### PR DESCRIPTION
## Summary

Pre-install common Python libraries (`requests`, `httpx`, `pyyaml`, `tomli`, `python-dotenv`, `pandas`, `numpy`, `scipy`, `beautifulsoup4`, `lxml`, `pydantic`) into the rlm tool venv via `install.sh`, and tell the agent about them in the system prompt so it doesn't have to discover or `pip install` them mid-rollout.

## Why here (and not in verifiers)

The first cut of this lived in verifiers' `build_install_script` (PrimeIntellect-ai/verifiers#1432). Moved here so the **install list and the system prompt share one source of truth** — the prompt now advertises pre-installed libs by their import names (`yaml`, `dotenv`, `bs4`), which the model needs to actually use them.

## Mechanism

- `src/rlm/default_packages.txt` is the single list. Format: one `pip-name [import-name]` per line; import name defaults to pip name. Comments allowed.
- `install.sh` parses the file into `--with X --with Y …` and uses it as the fallback for `RLM_EXTRA_UV_ARGS` (so callers can still override the whole set).
- `src/rlm/packages.py` exposes the parsed list as `DEFAULT_PACKAGES`; `prompt.py` joins their import names into a "Pre-installed Python packages" line.

Once this lands, verifiers' rlm harness no longer needs the `DEFAULT_RLM_EXTRA_UV_ARGS` it added in #1432 — the install.sh forwarder is enough.