### PR TITLE
chore: remove max_turns turn cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ source .venv/bin/activate
 ```bash
 rlm "fix the auth bug in login.py"
 
-# Override model/limits
-RLM_MODEL=openai/gpt-5-mini RLM_MAX_TURNS=50 rlm "refactor the parser"
+# Override model
+RLM_MODEL=openai/gpt-5-mini rlm "refactor the parser"
 
 # Append extra instructions to the generated system prompt
 RLM_APPEND_TO_SYSTEM_PROMPT="Always run tests before finishing." rlm "solve the task"
@@ -58,7 +58,6 @@ All configuration is via environment variables:
 | `RLM_API_KEY` / `RLM_BASE_URL` | — / SDK default (`https://api.openai.com/v1`) | Explicit override (highest priority). Independent: setting `RLM_API_KEY` alone targets the SDK default endpoint; set `RLM_BASE_URL` too for a custom endpoint. For PI, use `PRIME_API_KEY` (below) which owns the full pair. |
 | `PRIME_API_KEY` | — | PI Inference pair: targets `https://api.pinference.ai/api/v1` and forwards `PRIME_TEAM_ID` as `X-Prime-Team-ID` when set. |
 | `OPENAI_API_KEY` / `OPENAI_BASE_URL` | resolved by SDK | OpenAI pair — when `OPENAI_API_KEY` is set, AsyncOpenAI's native env handling is used (covers OpenAI direct and verifiers' rollout tunnel both). Provider precedence: explicit → PI → OpenAI. Keys are scoped to their own base URL so an `OPENAI_API_KEY` lying around can't leak to PI Inference. |
-| `RLM_MAX_TURNS` | `30` | Max tool-calling turns per agent |
 | `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |
 | `RLM_EXEC_TIMEOUT` | `300` | Seconds per IPython execution |
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
@@ -70,7 +69,7 @@ All configuration is via environment variables:
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 | `RLM_SDK_MAX_RETRIES` | `5` | Per-request retry count passed to the OpenAI SDK (in addition to the call-site retry wrapper that rides out longer outages). |
 
-`RLM_SYSTEM_PROMPT_PATH` takes precedence over `RLM_APPEND_TO_SYSTEM_PROMPT`. CLI flags override env vars: `rlm --model gpt-5-mini --max-turns 50 --append-to-system-prompt "..." --system-prompt-path /tmp/system.txt "prompt"`.
+`RLM_SYSTEM_PROMPT_PATH` takes precedence over `RLM_APPEND_TO_SYSTEM_PROMPT`. CLI flags override env vars: `rlm --model gpt-5-mini --append-to-system-prompt "..." --system-prompt-path /tmp/system.txt "prompt"`.
 
 ## Recursion
 

--- a/src/rlm/cli.py
+++ b/src/rlm/cli.py
@@ -25,12 +25,6 @@ def main():
         "--model", default=None, help="Model name (overrides RLM_MODEL)"
     )
     parser.add_argument(
-        "--max-turns",
-        type=int,
-        default=None,
-        help="Max turns (overrides RLM_MAX_TURNS)",
-    )
-    parser.add_argument(
         "--system-prompt-path",
         default=None,
         help="Path to a file whose contents replace the generated system prompt",
@@ -45,8 +39,6 @@ def main():
     # Apply CLI overrides to env
     if args.model:
         os.environ["RLM_MODEL"] = args.model
-    if args.max_turns:
-        os.environ["RLM_MAX_TURNS"] = str(args.max_turns)
     if args.system_prompt_path:
         os.environ["RLM_SYSTEM_PROMPT_PATH"] = args.system_prompt_path
     if args.append_to_system_prompt:

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 import os
 import time
@@ -137,7 +138,6 @@ class RLMEngine:
     def __init__(
         self,
         model: str | None = None,
-        max_turns: int | None = None,
         summarize_at_tokens: int | None = None,
         system_prompt_path: str | None = None,
         append_to_system_prompt: str | None = None,
@@ -146,7 +146,6 @@ class RLMEngine:
         client: AsyncOpenAI | None = None,
     ):
         self.model = model or os.environ.get("RLM_MODEL", "openai/gpt-5-mini")
-        self.max_turns = max_turns or int(os.environ.get("RLM_MAX_TURNS", "30"))
         self.cwd = cwd or os.getcwd()
         self.exec_timeout = int(os.environ.get("RLM_EXEC_TIMEOUT", "300"))
         max_output = int(os.environ.get("RLM_MAX_OUTPUT", "-1"))
@@ -256,7 +255,7 @@ class RLMEngine:
         # ``None`` on the very first turn and after compaction (fresh branch).
         last_appended_role: str | None = None
 
-        for turn in range(self.max_turns):
+        for turn in itertools.count():
             # Call LLM
             request_kwargs = {
                 "model": self.model,
@@ -412,9 +411,6 @@ class RLMEngine:
                 # Branch boundary: the next API call's prompt is a fresh
                 # [system, user(framing+summary)], not a continuation.
                 last_appended_role = None
-        else:
-            self._metrics.stop_reason = "max_turns"
-            final_text = msg.content or "[max turns reached]"
 
         result = RLMResult(
             answer=final_text,
@@ -440,9 +436,8 @@ class RLMEngine:
 
         Called in-place: mutates ``messages`` to ``[system, user(framing +
         summary)]`` and restarts the ipython kernel. The LLM call for the
-        summary doesn't count toward ``max_turns`` — it's housekeeping,
-        not a work turn — but its tokens land in ``_total_usage`` for
-        cost accounting.
+        summary is housekeeping, not a work turn, but its tokens land in
+        ``_total_usage`` for cost accounting.
 
         ``active_tools`` is forwarded as ``tools=`` with
         ``tool_choice="none"`` so the rendered system prompt matches

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -223,9 +223,7 @@ class RLMMetrics:
     sub_rlm_programmatic_tool_calls_python: int = 0
     sub_rlm_programmatic_tool_calls_bash: int = 0
 
-    stop_reason: str = (
-        ""  # "done", "max_turns", "token_budget", "depth_limit", "request_too_large"
-    )
+    stop_reason: str = ""  # "done", "token_budget", "depth_limit", "request_too_large"
 
     @property
     def turns(self) -> int:


### PR DESCRIPTION
## Summary

- Remove the `max_turns` turn cap from the engine loop. The agent loop now runs unbounded (`itertools.count()`) and termination is governed entirely by the remaining stop conditions: no-tool-call completion (`done`), token budget (`token_budget`), depth limit (`depth_limit`), and request-too-large.
- Drop the `max_turns` constructor param on `RLMEngine`, the `RLM_MAX_TURNS` env var, and the `--max-turns` CLI flag.
- Remove the `"max_turns"` stop reason (and the `[max turns reached]` fallback answer).
- Update README config table / CLI examples and the compaction docstring accordingly.

## Breaking

- **`RLM_MAX_TURNS` env var removed.** It is no longer read; set a `RLM_MAX_TOKENS` budget instead if you need to bound a run.
- **`--max-turns` CLI flag removed.** The flag no longer exists.
- **`RLMEngine(max_turns=...)` param removed.** Callers passing `max_turns=` will now raise `TypeError`.
- **`stop_reason == "max_turns"` no longer emitted.** Anything matching on that value should drop the case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unbounded agent loops can run longer and cost more unless `RLM_MAX_TOKENS` or external limits are used; breaking API/env changes for integrations that set or read max turns.
> 
> **Overview**
> Removes the **per-run turn cap** so the agent loop is no longer bounded by `RLM_MAX_TURNS` / `--max-turns` / `RLMEngine(max_turns=...)`. The main loop in `engine.py` now uses **`itertools.count()`** instead of `range(self.max_turns)`, and the **`max_turns` stop reason** plus **`[max turns reached]`** fallback are gone.
> 
> Runs are expected to end via existing guards only: normal completion (`done`), **`RLM_MAX_TOKENS`** (`token_budget`), depth limit, and request-too-large. README and CLI docs drop the max-turns config row and examples; **`stop_reason` docs** in `types.py` no longer mention `max_turns`.
> 
> **Breaking:** callers relying on `RLM_MAX_TURNS`, `--max-turns`, or `stop_reason == "max_turns"` need to use a token budget or external orchestration instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79818912841a2ea35a8734dd1b94339f490572ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->