### PR TITLE
restrict git log all history access

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ All configuration is via environment variables:
 | `RLM_APPEND_TO_SYSTEM_PROMPT` | — | Extra instructions appended to the generated system prompt |
 | `RLM_SYSTEM_PROMPT_PATH` | — | Path to a file whose contents fully replace the generated system prompt |
 | `RLM_TOOLS` | `ipython,summarize` | Comma-separated subset of builtin tools to enable. Empty string = no tools. Unknown names raise. |
+| `RLM_ALLOW_GIT` | — | Set to `1` to disable the restricted git-history guard. When unset, shell-capable prompts tell agents not to use task-specific online hints or solutions from other git history, and broad-history `git log` options such as `--all` are refused. |
 | `RLM_HOME` | `.rlm` | Root directory for sessions and data |
 | `RLM_SDK_MAX_RETRIES` | `5` | Per-request retry count passed to the OpenAI SDK (in addition to the call-site retry wrapper that rides out longer outages). |
 

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from rlm.tools.git_block import allow_git
+
 if TYPE_CHECKING:
     from rlm.tools.base import BuiltinTool
 
@@ -23,6 +25,16 @@ BASE_TOOLKIT = (
     "bs4",
     "lxml",
     "pydantic",
+)
+
+SHELL_TOOL_NAMES = frozenset({"bash", "ipython"})
+GIT_HISTORY_GUARD_PROMPT = (
+    "Do not cheat by using online solutions or hints specific to this task, or "
+    "by copying or inferring solutions from other branches, tags, remotes, "
+    "reflogs, or broad git history in the project. Broad-history `git log` "
+    "options such as `--all`, `-all`, `--branches`, `--remotes`, `--tags`, "
+    "`--glob`, `--alternate-refs`, `--reflog`, `--walk-reflogs`, or `-g` will "
+    "be refused."
 )
 
 
@@ -79,7 +91,16 @@ def build_system_prompt(
             ]
         )
 
+    if _should_include_git_history_guard(active_tools):
+        parts.extend(["", GIT_HISTORY_GUARD_PROMPT])
+
     if active_tools:
         parts.extend(["", "Call at most one built-in tool per turn."])
 
     return "\n".join(parts)
+
+
+def _should_include_git_history_guard(active_tools: list["BuiltinTool"]) -> bool:
+    if allow_git():
+        return False
+    return any(tool.name in SHELL_TOOL_NAMES for tool in active_tools)

--- a/src/rlm/tools/git_block.py
+++ b/src/rlm/tools/git_block.py
@@ -1,15 +1,15 @@
-"""Block ``git`` at the tool-call level.
+"""Restrict history-wide ``git log`` access at the tool-call level.
 
-Mirrors the predicate in mini_swe_agent_plus's ``execute_bash.py``:
+Ordinary git commands are allowed. The guard refuses ``git log`` invocations
+that ask for non-current-branch history, such as ``git log --all``. This keeps
+the agent's visibility close to current-branch history while preserving useful
+commands like ``git status`` and ``git diff``.
 
 - split a bash command on ``&&``, ``||``, ``;`` and ``|``
-- if the first whitespace-separated token of any segment is ``git``, refuse
+- if a segment invokes ``git log`` with a restricted history flag, refuse
 
-The ``RLM_ALLOW_GIT=1`` env var disables the check entirely.
-
-The same refusal string the existing sandbox shim emits is reused here so
-that agent-visible logs (and any rubrics keyed on it) stay consistent
-across the two block strategies.
+The ``RLM_ALLOW_GIT=1`` env var disables the check entirely for backwards
+compatibility with environments that already opted out of git restrictions.
 """
 
 from __future__ import annotations
@@ -17,15 +17,39 @@ from __future__ import annotations
 import ast
 import os
 import re
+import shlex
 
 REFUSAL_TEMPLATE = (
-    "Bash command '{cmd}' is not allowed. Please use a different command or tool."
+    "Git history option '{cmd}' is not allowed. Use current-branch history only."
 )
 
 # Reuse the mini_swe_agent_plus separators verbatim so behavior matches.
 _SEPARATORS = re.compile(r"&&|\|\||;|\|")
 
-_BLOCKED = ("git",)
+_RESTRICTED_LOG_OPTIONS = {
+    "--all",
+    "-all",
+    "--alternate-refs",
+    "--reflog",
+    "--walk-reflogs",
+    "-g",
+}
+_RESTRICTED_LOG_OPTION_PREFIXES = (
+    "--branches",
+    "--glob",
+    "--remotes",
+    "--tags",
+)
+
+_GIT_GLOBAL_OPTIONS_WITH_VALUE = {
+    "-C",
+    "-c",
+    "--config-env",
+    "--exec-path",
+    "--git-dir",
+    "--namespace",
+    "--work-tree",
+}
 
 
 def allow_git() -> bool:
@@ -33,24 +57,75 @@ def allow_git() -> bool:
 
 
 def find_blocked_command(command: str) -> str | None:
-    """Return the offending token if ``command`` invokes a blocked binary.
+    """Return the offending token if ``command`` asks for broad git history.
 
     Splits on ``&&``, ``||``, ``;``, ``|`` so chained calls like
-    ``cd /repo && git status`` are caught the same way the reference
-    implementation catches them. Returns ``None`` if nothing is blocked
-    or if ``RLM_ALLOW_GIT=1``.
+    ``cd /repo && git log --all`` are caught. Returns ``None`` if nothing is
+    blocked or if ``RLM_ALLOW_GIT=1``.
     """
     if allow_git():
         return None
     for segment in _SEPARATORS.split(command):
-        tokens = segment.strip().split()
-        if tokens and tokens[0] in _BLOCKED:
-            return tokens[0]
+        blocked = find_blocked_git_log_option(_split_segment(segment))
+        if blocked is not None:
+            return blocked
     return None
 
 
 def refusal(cmd: str) -> str:
     return REFUSAL_TEMPLATE.format(cmd=cmd)
+
+
+def _split_segment(segment: str) -> list[str]:
+    try:
+        return shlex.split(segment)
+    except ValueError:
+        return segment.strip().split()
+
+
+def _is_git_binary(token: str) -> bool:
+    return token == "git" or token.rsplit("/", 1)[-1] == "git"
+
+
+def _skip_git_global_options(argv: list[str], index: int) -> int:
+    while index < len(argv):
+        token = argv[index]
+        if token == "--":
+            return index + 1
+        if not token.startswith("-"):
+            return index
+
+        option = token.split("=", 1)[0]
+        if option in _GIT_GLOBAL_OPTIONS_WITH_VALUE and "=" not in token:
+            index += 2
+        else:
+            index += 1
+    return index
+
+
+def _is_restricted_log_option(token: str) -> bool:
+    if token in _RESTRICTED_LOG_OPTIONS:
+        return True
+    return any(
+        token == option or token.startswith(f"{option}=")
+        for option in _RESTRICTED_LOG_OPTION_PREFIXES
+    )
+
+
+def find_blocked_git_log_option(argv: list[str]) -> str | None:
+    if not argv or not _is_git_binary(argv[0]):
+        return None
+
+    subcommand_index = _skip_git_global_options(argv, 1)
+    if subcommand_index >= len(argv) or argv[subcommand_index] != "log":
+        return None
+
+    for token in argv[subcommand_index + 1 :]:
+        if token == "--":
+            return None
+        if _is_restricted_log_option(token):
+            return token
+    return None
 
 
 # IPython shell-escape lines: ``!cmd`` and ``!!cmd``. Leading whitespace
@@ -76,9 +151,9 @@ def find_blocked_in_ipython(code: str) -> str | None:
        line magics, ``%%bash`` / ``%%sh`` cell magic. Each extracted
        bash fragment goes through ``find_blocked_command``.
     2. Pure-Python AST scan via :func:`find_blocked_python` — catches
-       ``subprocess.run([\"git\", ...])`` / ``os.system(\"git ...\")``
-       and the obvious aliases. See that function for documented
-       bypasses (dynamic ``getattr``, multi-hop reassignment, etc.).
+       restricted literal subprocess / ``os.system`` git-log invocations
+       and the obvious aliases. See that function for documented bypasses
+       (dynamic ``getattr``, multi-hop reassignment, etc.).
     """
     if allow_git():
         return None
@@ -103,8 +178,8 @@ def find_blocked_in_ipython(code: str) -> str | None:
     return find_blocked_python(code)
 
 
-# Statically-resolved fully-qualified callees that shell out to ``git``
-# when invoked with a literal ``git ...`` first positional argument.
+# Statically-resolved fully-qualified callees that shell out when invoked
+# with a literal first positional argument.
 _BLOCKED_PY_CALLS = frozenset(
     {
         "subprocess.run",
@@ -118,28 +193,20 @@ _BLOCKED_PY_CALLS = frozenset(
 )
 
 
-def _first_arg_starts_with_git(node: ast.Call) -> bool:
-    """Return True iff ``node.args[0]`` is a literal that invokes ``git``.
-
-    String args go through ``find_blocked_command`` so the same separator
-    splitting (``&&``, ``||``, ``;``, ``|``) applies as for direct bash
-    invocations — ``os.system("cd /tmp && git log")`` is refused
-    symmetrically. List/tuple args are argv with no shell parsing, so
-    only the first element matters.
-    """
+def _blocked_option_from_python_call(node: ast.Call) -> str | None:
     if not node.args:
-        return False
+        return None
     arg = node.args[0]
     if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-        return find_blocked_command(arg.value) is not None
+        return find_blocked_command(arg.value)
     if isinstance(arg, (ast.List, ast.Tuple)) and arg.elts:
-        first = arg.elts[0]
-        return (
-            isinstance(first, ast.Constant)
-            and isinstance(first.value, str)
-            and first.value in _BLOCKED
-        )
-    return False
+        argv: list[str] = []
+        for elt in arg.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            argv.append(elt.value)
+        return find_blocked_git_log_option(argv)
+    return None
 
 
 class _GitCallFinder(ast.NodeVisitor):
@@ -161,7 +228,7 @@ class _GitCallFinder(ast.NodeVisitor):
         self.module_aliases: dict[str, str] = {"subprocess": "subprocess", "os": "os"}
         # Maps local name -> blocked callee fqn (e.g. "run" -> "subprocess.run").
         self.callable_aliases: dict[str, str] = {}
-        self.found = False
+        self.found: str | None = None
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -195,8 +262,10 @@ class _GitCallFinder(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> None:
         fqn = self._resolve_callee(node.func)
-        if fqn in _BLOCKED_PY_CALLS and _first_arg_starts_with_git(node):
-            self.found = True
+        if fqn in _BLOCKED_PY_CALLS:
+            blocked = _blocked_option_from_python_call(node)
+            if blocked is not None:
+                self.found = blocked
         self.generic_visit(node)
 
     def _resolve_callee(self, expr: ast.AST) -> str | None:
@@ -240,9 +309,9 @@ def _strip_ipython_only(code: str) -> str:
 
 
 def find_blocked_python(code: str) -> str | None:
-    """Detect pure-Python git invocations in an ipython cell via AST walk.
+    """Detect restricted pure-Python git invocations via AST walk.
 
-    Returns the offending token (``\"git\"``) if a blocked call is found,
+    Returns the offending token (``\"--all\"`` etc.) if a blocked call is found,
     else ``None``. Honors ``RLM_ALLOW_GIT=1``. Ipython-only syntax
     (``!cmd``, ``%magic``, ``obj?``) is stripped before parsing so
     cells mixing ipython and Python still get scanned. Returns ``None``
@@ -256,4 +325,4 @@ def find_blocked_python(code: str) -> str | None:
         return None
     finder = _GitCallFinder()
     finder.visit(tree)
-    return _BLOCKED[0] if finder.found else None
+    return finder.found

--- a/tests/test_git_block.py
+++ b/tests/test_git_block.py
@@ -1,4 +1,4 @@
-"""Tests for the tool-level git block."""
+"""Tests for restricted git-history access."""
 
 from __future__ import annotations
 
@@ -6,13 +6,14 @@ from rlm.tools.base import ToolContext
 from rlm.tools.bash import BashTool
 from rlm.tools.git_block import (
     find_blocked_command,
+    find_blocked_git_log_option,
     find_blocked_in_ipython,
     refusal,
 )
 from rlm.types import RLMMetrics, TokenUsage
 
 
-REFUSAL = "Bash command 'git' is not allowed. Please use a different command or tool."
+REFUSAL = "Git history option '--all' is not allowed. Use current-branch history only."
 
 
 def _ctx() -> ToolContext:
@@ -25,276 +26,256 @@ def _ctx() -> ToolContext:
     )
 
 
-# --- find_blocked_command (bash predicate, mirrors mini_swe_agent_plus) ---
+# --- argv-level git log restrictions ---
 
 
-def test_plain_git_status_blocked():
-    assert find_blocked_command("git status") == "git"
+def test_git_status_allowed():
+    assert find_blocked_git_log_option(["git", "status"]) is None
 
 
-def test_chained_git_after_cd_blocked():
-    # mini_swe_agent_plus's docstring example: "cd /testbed && git diff"
-    assert find_blocked_command("cd /testbed && git diff") == "git"
+def test_current_branch_git_log_allowed():
+    assert find_blocked_git_log_option(["git", "log", "--oneline", "-n", "5"]) is None
 
 
-def test_pipe_separator_blocked():
-    assert find_blocked_command("ls | git foo") == "git"
+def test_git_log_all_blocked():
+    assert find_blocked_git_log_option(["git", "log", "--all"]) == "--all"
 
 
-def test_or_separator_blocked():
-    assert find_blocked_command("false || git status") == "git"
+def test_git_log_single_dash_all_blocked():
+    assert find_blocked_git_log_option(["git", "log", "-all"]) == "-all"
 
 
-def test_semicolon_separator_blocked():
-    assert find_blocked_command("ls; git log") == "git"
+def test_git_log_remote_history_blocked():
+    assert (
+        find_blocked_git_log_option(["git", "log", "--remotes=origin/*"])
+        == "--remotes=origin/*"
+    )
 
 
-def test_non_git_command_unaffected():
-    assert find_blocked_command("ls -la") is None
+def test_git_log_reflog_blocked():
+    assert find_blocked_git_log_option(["git", "log", "-g"]) == "-g"
 
 
-def test_command_substring_unaffected():
-    # "github" starts with "git" but is not the git binary
-    assert find_blocked_command("echo github") is None
+def test_git_global_options_before_log_are_supported():
+    assert (
+        find_blocked_git_log_option(
+            ["git", "-C", "/repo", "--no-pager", "log", "--all"]
+        )
+        == "--all"
+    )
 
 
-def test_allow_git_env_var_disables_block(monkeypatch):
-    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
+def test_git_log_path_separator_stops_option_scan():
+    assert find_blocked_git_log_option(["git", "log", "--", "--all"]) is None
+
+
+def test_absolute_git_binary_is_checked():
+    assert find_blocked_git_log_option(["/usr/bin/git", "log", "--all"]) == "--all"
+
+
+# --- find_blocked_command shell predicate ---
+
+
+def test_plain_git_status_allowed():
     assert find_blocked_command("git status") is None
 
 
-def test_refusal_message_matches_existing_shim():
-    assert refusal("git") == REFUSAL
+def test_plain_git_diff_allowed():
+    assert find_blocked_command("git diff") is None
+
+
+def test_git_log_all_command_blocked():
+    assert find_blocked_command("git log --all") == "--all"
+
+
+def test_chained_git_log_all_after_cd_blocked():
+    assert find_blocked_command("cd /testbed && git log --all") == "--all"
+
+
+def test_pipe_separator_git_log_all_blocked():
+    assert find_blocked_command("echo hello | git log --all") == "--all"
+
+
+def test_or_separator_git_log_all_blocked():
+    assert find_blocked_command("false || git log --all") == "--all"
+
+
+def test_semicolon_git_log_all_blocked():
+    assert find_blocked_command("ls; git log --all") == "--all"
+
+
+def test_quoted_path_named_all_unaffected():
+    assert find_blocked_command("git log -- '--all'") is None
+
+
+def test_command_substring_unaffected():
+    assert find_blocked_command("echo github --all") is None
+
+
+def test_allow_git_env_var_disables_restriction(monkeypatch):
+    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
+    assert find_blocked_command("git log --all") is None
+
+
+def test_refusal_message_names_restricted_option():
+    assert refusal("--all") == REFUSAL
 
 
 # --- find_blocked_in_ipython ---
 
 
-def test_ipython_shell_escape_blocked():
-    assert find_blocked_in_ipython("!git status") == "git"
+def test_ipython_shell_escape_git_status_allowed():
+    assert find_blocked_in_ipython("!git status") is None
 
 
-def test_ipython_double_shell_escape_blocked():
-    assert find_blocked_in_ipython("!!git diff") == "git"
+def test_ipython_shell_escape_git_log_all_blocked():
+    assert find_blocked_in_ipython("!git log --all") == "--all"
 
 
-def test_ipython_chained_shell_escape_blocked():
-    assert find_blocked_in_ipython("!cd /repo && git log") == "git"
+def test_ipython_double_shell_escape_git_log_all_blocked():
+    assert find_blocked_in_ipython("!!git log --all") == "--all"
 
 
-def test_ipython_bash_cell_magic_blocked():
-    code = "%%bash\ncd /repo\ngit status"
-    assert find_blocked_in_ipython(code) == "git"
+def test_ipython_chained_shell_escape_git_log_all_blocked():
+    assert find_blocked_in_ipython("!cd /repo && git log --all") == "--all"
 
 
-def test_ipython_sx_line_magic_blocked():
-    assert find_blocked_in_ipython("%sx git status") == "git"
+def test_ipython_bash_cell_magic_git_log_all_blocked():
+    code = "%%bash\ncd /repo\ngit log --all"
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_ipython_sx_line_magic_git_log_all_blocked():
+    assert find_blocked_in_ipython("%sx git log --all") == "--all"
 
 
 def test_ipython_pure_python_unaffected():
-    # No shell escape ⇒ nothing to block, even if literal "git" appears
-    assert find_blocked_in_ipython("x = 'git status'\nprint(x)") is None
-
-
-def test_ipython_non_git_shell_escape_unaffected():
-    assert find_blocked_in_ipython("!ls -la") is None
+    assert find_blocked_in_ipython("x = 'git log --all'\nprint(x)") is None
 
 
 def test_ipython_allow_git_env_var(monkeypatch):
     monkeypatch.setenv("RLM_ALLOW_GIT", "1")
-    assert find_blocked_in_ipython("!git status") is None
+    assert find_blocked_in_ipython("!git log --all") is None
 
 
-# --- find_blocked_python (AST-based detection of Python git invocations) ---
+# --- AST-based detection of Python broad-history invocations ---
 
 
-def test_python_subprocess_run_list_blocked():
-    code = "import subprocess\nsubprocess.run(['git', 'log'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_subprocess_run_shell_string_blocked():
-    code = "import subprocess\nsubprocess.run('git log', shell=True)"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_subprocess_popen_blocked():
-    code = "import subprocess\nsubprocess.Popen(['git', 'diff'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_subprocess_call_blocked():
-    code = "import subprocess\nsubprocess.call(['git', 'status'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_subprocess_check_call_blocked():
-    code = "import subprocess\nsubprocess.check_call(['git', 'status'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_subprocess_check_output_blocked():
-    code = "import subprocess\nsubprocess.check_output(['git', 'log'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_os_system_blocked():
-    assert find_blocked_in_ipython("import os\nos.system('git fetch')") == "git"
-
-
-def test_python_os_popen_blocked():
-    assert find_blocked_in_ipython("import os\nos.popen('git status')") == "git"
-
-
-def test_python_subprocess_module_alias_blocked():
-    code = "import subprocess as sp\nsp.run(['git', 'status'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_from_subprocess_import_run_blocked():
-    code = "from subprocess import run\nrun(['git', 'log'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_single_hop_assignment_alias_blocked():
-    code = "import subprocess\nr = subprocess.run\nr(['git', 'log'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_subprocess_run_non_git_unaffected():
-    code = "import subprocess\nsubprocess.run(['pytest'])"
+def test_python_subprocess_run_git_status_allowed():
+    code = "import subprocess\nsubprocess.run(['git', 'status'])"
     assert find_blocked_in_ipython(code) is None
 
 
-def test_python_os_system_chained_git_blocked():
-    # `os.system("cd /tmp && git log")` must be refused the same way
-    # `cd /tmp && git log` is refused via the bash tool.
-    code = 'import os\nos.system("cd /tmp && git log")'
-    assert find_blocked_in_ipython(code) == "git"
+def test_python_subprocess_run_list_git_log_all_blocked():
+    code = "import subprocess\nsubprocess.run(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
 
 
-def test_python_subprocess_shell_string_chained_git_blocked():
-    code = 'import subprocess\nsubprocess.run("echo hi; git log", shell=True)'
-    assert find_blocked_in_ipython(code) == "git"
+def test_python_subprocess_run_shell_string_git_log_all_blocked():
+    code = "import subprocess\nsubprocess.run('git log --all', shell=True)"
+    assert find_blocked_in_ipython(code) == "--all"
 
 
-def test_python_os_popen_pipe_chained_git_blocked():
-    code = 'import os\nos.popen("echo a | git status")'
-    assert find_blocked_in_ipython(code) == "git"
+def test_python_subprocess_popen_current_log_allowed():
+    code = "import subprocess\nsubprocess.Popen(['git', 'log', '--oneline'])"
+    assert find_blocked_in_ipython(code) is None
 
 
-def test_python_subprocess_string_or_chained_git_blocked():
-    code = 'import subprocess\nsubprocess.run("false || git log", shell=True)'
-    assert find_blocked_in_ipython(code) == "git"
+def test_python_subprocess_call_git_log_all_blocked():
+    code = "import subprocess\nsubprocess.call(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_python_subprocess_check_call_git_log_all_blocked():
+    code = "import subprocess\nsubprocess.check_call(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_python_subprocess_check_output_git_log_all_blocked():
+    code = "import subprocess\nsubprocess.check_output(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_python_os_system_chained_git_log_all_blocked():
+    code = 'import os\nos.system("cd /tmp && git log --all")'
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_python_os_popen_git_log_all_blocked():
+    code = 'import os\nos.popen("git log --all")'
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_python_subprocess_module_alias_git_log_all_blocked():
+    code = "import subprocess as sp\nsp.run(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_python_from_subprocess_import_run_git_log_all_blocked():
+    code = "from subprocess import run\nrun(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
+
+
+def test_python_single_hop_assignment_alias_git_log_all_blocked():
+    code = "import subprocess\nr = subprocess.run\nr(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
 
 
 def test_python_string_literal_no_call_unaffected():
-    assert find_blocked_in_ipython("x = 'git status'") is None
+    assert find_blocked_in_ipython("x = 'git log --all'") is None
 
 
 def test_python_command_starting_with_git_word_unaffected():
-    # "github" is not the git binary; first arg literal "github" must not match.
-    code = "import subprocess\nsubprocess.run(['github', 'status'])"
+    code = "import subprocess\nsubprocess.run(['github', 'log', '--all'])"
     assert find_blocked_in_ipython(code) is None
 
 
-def test_python_shell_string_with_leading_whitespace_blocked():
-    # Whitespace in front of the string still resolves first token to "git".
-    code = "import subprocess\nsubprocess.run('   git log', shell=True)"
-    assert find_blocked_in_ipython(code) == "git"
+def test_python_timeit_cell_magic_with_git_log_all_blocked():
+    code = '%%timeit\nimport subprocess\nsubprocess.run(["git", "log", "--all"])'
+    assert find_blocked_in_ipython(code) == "--all"
 
 
-def test_python_timeit_cell_magic_with_python_git_call_blocked():
-    # %%timeit's body is Python; the AST scan must still see it.
-    code = '%%timeit\nimport subprocess\nsubprocess.run(["git", "log"])'
-    assert find_blocked_in_ipython(code) == "git"
+def test_python_shell_escape_with_python_git_log_all_blocked():
+    code = '!ls\nimport subprocess\nsubprocess.run(["git", "log", "--all"])'
+    assert find_blocked_in_ipython(code) == "--all"
 
 
-def test_python_capture_cell_magic_with_python_git_call_blocked():
-    code = '%%capture\nimport subprocess\nsubprocess.run(["git", "status"])'
-    assert find_blocked_in_ipython(code) == "git"
+def test_python_line_magic_with_python_git_log_all_blocked():
+    code = '%timeit pass\nimport subprocess\nsubprocess.run(["git", "log", "--all"])'
+    assert find_blocked_in_ipython(code) == "--all"
 
 
-def test_python_writefile_cell_magic_with_python_git_call_blocked():
-    code = '%%writefile out.txt\nimport subprocess\nsubprocess.run(["git", "log"])'
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_double_percent_in_string_does_not_drop_later_git_call():
-    # `%%foo`-shaped line inside a triple-quoted string must not poison
-    # the rest of the cell — the git call after the string must still
-    # be detected.
-    code = 's = """\n%%foo\n"""\nimport subprocess\nsubprocess.run(["git", "log"])'
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_allow_git_env_var_disables_ast(monkeypatch):
-    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
-    code = "import subprocess\nsubprocess.run(['git', 'log'])"
-    assert find_blocked_in_ipython(code) is None
+def test_python_help_question_mark_with_python_git_log_all_blocked():
+    code = "import subprocess\nsubprocess.run?\nsubprocess.run(['git', 'log', '--all'])"
+    assert find_blocked_in_ipython(code) == "--all"
 
 
 def test_python_getattr_documented_bypass():
-    # Dynamic attribute lookup is intentionally NOT caught — pin behavior.
-    code = "import subprocess\ngetattr(subprocess, 'run')(['git', 'log'])"
-    assert find_blocked_in_ipython(code) is None
-
-
-def test_python_dunder_import_documented_bypass():
-    # ``__import__("subprocess").run(...)`` is also not caught.
-    code = "__import__('subprocess').run(['git', 'log'])"
+    code = "import subprocess\ngetattr(subprocess, 'run')(['git', 'log', '--all'])"
     assert find_blocked_in_ipython(code) is None
 
 
 def test_python_multi_hop_alias_documented_bypass():
-    # Two-hop reassignment is out of scope; r2 isn't tracked back to subprocess.run.
-    code = "import subprocess\nr1 = subprocess.run\nr2 = r1\nr2(['git', 'log'])\n"
+    code = (
+        "import subprocess\nr1 = subprocess.run\nr2 = r1\nr2(['git', 'log', '--all'])\n"
+    )
     assert find_blocked_in_ipython(code) is None
 
 
 def test_python_syntax_error_does_not_refuse():
-    # Malformed Python: AST scan returns None so the REPL surfaces the SyntaxError.
     assert find_blocked_in_ipython("def broken(:\n    pass") is None
-
-
-# --- ipython-only syntax must not bypass the AST scan (bugbot #3150728431) ---
-
-
-def test_python_shell_escape_with_python_git_call_blocked():
-    # The bugbot reproducer: a ``!cmd`` line previously made ``ast.parse``
-    # raise ``SyntaxError``, silently bypassing the Python-call scan.
-    code = '!ls\nimport subprocess\nsubprocess.run(["git", "log", "--all"])'
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_line_magic_with_python_git_call_blocked():
-    code = '%timeit pass\nimport subprocess\nsubprocess.run(["git", "status"])'
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_help_question_mark_with_python_git_call_blocked():
-    # ``obj?`` object-inspection syntax is ipython-only; strip the ``?``
-    # rather than the line so ``subprocess.run`` still binds the alias path.
-    code = "import subprocess\nsubprocess.run?\nsubprocess.run(['git', 'log'])"
-    assert find_blocked_in_ipython(code) == "git"
-
-
-def test_python_alias_then_magic_then_call_blocked():
-    # Alias defined before a magic that previously broke ``ast.parse``.
-    code = 'import subprocess as sp\n!ls\nsp.run(["git", "status"])'
-    assert find_blocked_in_ipython(code) == "git"
 
 
 # --- BashTool integration ---
 
 
-def test_bash_tool_refuses_git():
-    outcome = BashTool().execute({"command": "git status"}, _ctx())
-    assert outcome.content == REFUSAL
+def test_bash_tool_allows_git_status():
+    outcome = BashTool().execute({"command": "git --version"}, _ctx())
+    assert outcome.content != REFUSAL
 
 
-def test_bash_tool_refuses_chained_git():
-    outcome = BashTool().execute({"command": "cd /tmp && git diff"}, _ctx())
+def test_bash_tool_refuses_git_log_all():
+    outcome = BashTool().execute({"command": "git log --all"}, _ctx())
     assert outcome.content == REFUSAL
 
 
@@ -303,41 +284,39 @@ def test_bash_tool_runs_non_git_command():
     assert "hello" in outcome.content
 
 
-def test_bash_tool_allow_git_env_var(monkeypatch, tmp_path):
+def test_bash_tool_allow_git_env_var(monkeypatch):
     monkeypatch.setenv("RLM_ALLOW_GIT", "1")
-    # ``git --version`` is a harmless probe that doesn't need a repo. If
-    # the env doesn't have git installed at all, fall back to verifying
-    # the refusal didn't fire.
-    outcome = BashTool().execute({"command": "git --version"}, _ctx())
+    outcome = BashTool().execute({"command": "git log --all"}, _ctx())
     assert outcome.content != REFUSAL
 
 
 # --- IpythonTool integration ---
 
 
-def test_ipython_tool_refuses_git():
+def test_ipython_tool_refuses_git_log_all():
     """IpythonTool.execute short-circuits with the refusal before touching the REPL."""
     from rlm.tools.ipython import IpythonTool
 
     ctx = _ctx()
-    # context.repl stays None; the refusal must fire before the
-    # "REPL is not available" branch.
-    ctx.repl = object()  # truthy sentinel — never used
-    outcome = IpythonTool().execute({"code": "!git status"}, ctx)
+    ctx.repl = object()
+    outcome = IpythonTool().execute({"code": "!git log --all"}, ctx)
     assert outcome.content == REFUSAL
 
 
-def test_ipython_tool_refuses_bash_cell_magic_git():
+def test_ipython_tool_allows_git_status(monkeypatch):
     from rlm.tools.ipython import IpythonTool
 
+    class StubRepl:
+        def execute(self, code, timeout):
+            return f"ran: {code}"
+
     ctx = _ctx()
-    ctx.repl = object()
-    outcome = IpythonTool().execute({"code": "%%bash\ncd /repo && git diff"}, ctx)
-    assert outcome.content == REFUSAL
+    ctx.repl = StubRepl()
+    outcome = IpythonTool().execute({"code": "!git status"}, ctx)
+    assert outcome.content == "ran: !git status"
 
 
-def test_ipython_tool_passes_through_non_git(monkeypatch):
-    """When the code has no shell escapes, the tool delegates to the REPL."""
+def test_ipython_tool_passes_through_non_git():
     from rlm.tools.ipython import IpythonTool
 
     class StubRepl:

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,46 @@
+"""Tests for system prompt construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rlm.prompt import GIT_HISTORY_GUARD_PROMPT, build_system_prompt
+
+
+@dataclass
+class _Tool:
+    name: str
+
+
+def _prompt(active_tools: list[_Tool]) -> str:
+    return build_system_prompt(
+        "/repo",
+        None,
+        [],
+        "/repo/.rlm/messages.jsonl",
+        allow_recursion=False,
+        active_tools=active_tools,
+    )
+
+
+def test_git_history_guard_prompt_included_for_shell_tools(monkeypatch):
+    monkeypatch.delenv("RLM_ALLOW_GIT", raising=False)
+    prompt = _prompt([_Tool("bash")])
+
+    assert GIT_HISTORY_GUARD_PROMPT in prompt
+    assert "Do not cheat" in prompt
+    assert "online solutions or hints specific to this task" in prompt
+    assert "other branches, tags, remotes" in prompt
+    assert "`--all`" in prompt
+
+
+def test_git_history_guard_prompt_omitted_when_unrestricted(monkeypatch):
+    monkeypatch.setenv("RLM_ALLOW_GIT", "1")
+
+    assert GIT_HISTORY_GUARD_PROMPT not in _prompt([_Tool("bash")])
+
+
+def test_git_history_guard_prompt_omitted_without_shell_tools(monkeypatch):
+    monkeypatch.delenv("RLM_ALLOW_GIT", raising=False)
+
+    assert GIT_HISTORY_GUARD_PROMPT not in _prompt([_Tool("summarize")])


### PR DESCRIPTION
 ## Summary

  Change RLM's git guard from a blanket refusal of every literal `git` invocation to a narrower restricted-history policy. Agents can now use
  normal current-repo git workflows such as `git status`, `git diff`, and current-branch `git log`, while `git log` forms that walk broader
  repository history are refused before tool execution.

  This is intended to match the SWE training safeguard pattern of limiting git history visibility rather than removing git entirely.

  ## What Changed

  - Allow ordinary git commands in bash and IPython tool calls.
  - Refuse `git log` options that expose cross-ref or repo-wide history:
    - `--all`, `-all`
    - `--remotes`, `--branches`, `--tags`, `--glob` and their `=pattern` forms
    - reflog traversal via `--reflog`, `--walk-reflogs`, `-g`
    - `--alternate-refs`
  - Parse shell command segments with `shlex` and preserve the existing split over `&&`, `||`, `;`, and `|`.
  - Handle common git global options before `log`, including `-C`, `-c`, `--git-dir`, and `--work-tree`.
  - Keep `RLM_ALLOW_GIT=1` as an opt-out for environments that intentionally disable the guard.
  - Update tests for bash, IPython shell escapes, bash cell magics, and literal Python `subprocess` / `os` calls.

  ## Limitations

  This remains a tool-layer guard, not a sandbox security boundary. It catches literal command and AST patterns currently covered by RLM's
  preflight checks, but dynamic indirection can still evade it. The goal is to reduce accidental or direct reward-leakage via broad git history,
  not to make git execution impossible.

  ## Validation

  - `uv run pytest tests/test_git_block.py`
  - `uv run pytest`
  - `uv run ruff check`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent sandbox/training safeguards around shell and IPython execution; behavior shift is intentional but agents may rely on previously blocked git commands or evade via dynamic subprocess calls documented as out of scope.
> 
> **Overview**
> Replaces the blanket **block all `git`** tool guard with a **narrow restricted-history policy**: normal git (`status`, `diff`, current-branch `log`) is allowed, while `git log` with repo-wide or cross-ref options (`--all`, remotes/branches/tags/glob, reflog, etc.) is refused before bash/IPython execution.
> 
> **`git_block.py`** now parses segments with `shlex`, skips common git global options, and only flags restricted `log` flags; refusal messages name the offending option. IPython/AST checks follow the same rule for shell escapes and literal `subprocess`/`os` calls. **`RLM_ALLOW_GIT=1`** still disables the guard.
> 
> **`prompt.py`** adds a git-history anti-cheat paragraph when shell tools (`bash`/`ipython`) are enabled and the guard is on. **README** documents `RLM_ALLOW_GIT`. Tests are rewritten/added for the new behavior and prompt wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be61072fdd55850c5c5f25f7818664f035d89e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->