### PR TITLE
Hint that extra packages install via uv pip

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -61,6 +61,7 @@ def build_system_prompt(
         f"Working directory: {cwd}",
         f"Conversation log: {messages_path}",
         f"Pre-installed Python packages: {', '.join(BASE_TOOLKIT)}.",
+        "Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
     ]
 
     skill_lines: list[str] = []


### PR DESCRIPTION
## Summary
- Add a line to the system prompt telling the agent that additional Python packages install via `uv pip install <pkg>`.
- The harness runs in a uv-managed venv that has no `pip` module, so the agent's default instinct (`python -m pip install`) fails with `No module named pip`. The hint points it at the right tool on the first try.

## Verification
Ran a dummy rollout from a clean venv (no `cowsay` installed) with a plain task that gives **no install instructions** — the system-prompt hint has to do the work:

```
$ uv run rlm "Use the 'cowsay' library to print a cow saying 'hint works'."
Done — here's the cow output:

  __________
| hint works |
  ==========
          \
           \
             ^__^
             (oo)\_______
             (__)\       )\/\
                 ||----w |
                 ||     ||
```

The agent reached straight for `uv pip install` (single IPython cell, 2 turns) instead of `python -m pip`:

```python
try:
    import cowsay
except Exception:
    import sys
    print('Installing cowsay...')
    !uv pip install cowsay
    import importlib
    cowsay = importlib.import_module('cowsay')

print(cowsay.cow('hint works'))
```

**Before** (without the hint): the agent tried `{sys.executable} -m pip install cowsay` → `No module named pip`, wasted a turn, and gave up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prompt-string addition with no runtime logic, security, or data-handling impact.
> 
> **Overview**
> Adds one line to the default agent **system prompt** (in `build_system_prompt`) right after the pre-installed package list, telling the model to install extras with **`uv pip install <pkg>`** because the harness uses a **uv-managed venv without a `pip` module**.
> 
> This steers the agent away from `python -m pip install`, which fails in that environment and previously wasted turns before giving up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193af6f54b908a0124eab23e07888142ba8ff24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->