### PR TITLE
feat: default RLM_HOME to ~/.rlm

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All configuration is via environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RLM_HOME` | `.rlm` | Root directory for sessions and data |
+| `RLM_HOME` | `~/.rlm` | Root directory for sessions and data |
 | `RLM_MODEL` | `openai/gpt-5-mini` | Model name (PI Inference slug). Override with `--model` or `RLM_MODEL` for OpenAI/Anthropic direct (e.g. `gpt-4o`, `claude-sonnet-4-5`) |
 | `RLM_API_KEY` / `RLM_BASE_URL` | — / SDK default (`https://api.openai.com/v1`) | Explicit override (highest priority). Independent: setting `RLM_API_KEY` alone targets the SDK default endpoint; set `RLM_BASE_URL` too for a custom endpoint. For PI, use `PRIME_API_KEY` (below) which owns the full pair. |
 | `PRIME_API_KEY` | — | PI Inference pair: targets `https://api.pinference.ai/api/v1` and forwards `PRIME_TEAM_ID` as `X-Prime-Team-ID` when set. |

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -15,7 +15,7 @@ class Session:
     def __init__(self, session_dir: Path | None = None):
         if session_dir is None:
             sid = uuid.uuid4().hex[:12]
-            rlm_home = Path(os.environ.get("RLM_HOME", ".rlm"))
+            rlm_home = Path(os.environ.get("RLM_HOME") or Path.home() / ".rlm")
             session_dir = rlm_home / "sessions" / sid
         # Absolute path so later writes (meta.json.tmp, messages.jsonl) keep
         # working if something changes cwd mid-rollout (a tool's os.chdir,


### PR DESCRIPTION
## Summary

- Change the default `RLM_HOME` from the cwd-relative `.rlm` to the home-anchored `~/.rlm`, matching the convention used by Claude Code (`~/.claude`) and Codex (`~/.codex`). Sessions now centralize under the user's home dir regardless of which directory `rlm` is invoked from.
- Setting the `RLM_HOME` env var still overrides the default (and an explicit relative path remains supported).
- Update the config table in the README to document the new default.

## Breaking

- **`RLM_HOME` default changed** from `.rlm` (relative to cwd) to `~/.rlm` (user home). Anyone relying on session artifacts landing in the project working directory should set `RLM_HOME=.rlm` explicitly to preserve the old behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for where sessions and artifacts are written; low code risk but breaks anyone relying on cwd-local `.rlm` unless they set `RLM_HOME`.
> 
> **Overview**
> **Default `RLM_HOME` is now `~/.rlm` instead of cwd-relative `.rlm`.** New sessions are created under the user home directory no matter where `rlm` is launched from, aligning with other agent CLIs that keep state under `~`.
> 
> `Session` resolves the root with `Path(os.environ.get("RLM_HOME") or Path.home() / ".rlm")` when no explicit session dir is passed. **Setting `RLM_HOME` still overrides** (including a relative path like `.rlm` for the old per-project layout). The README config table documents the new default.
> 
> **Breaking:** workflows that expected artifacts in `./.rlm` must set `RLM_HOME=.rlm` (or another path) explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15684f7dcb5b940416658c4c200c2e6e8aa35eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->