### PR TITLE
feat(prompt): drop misleading uv pip hint

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -80,7 +80,6 @@ def build_system_prompt(
         "When you are done, stop calling tools and state your final answer.",
         "",
         f"Working directory: {cwd}",
-        f"Conversation log: {messages_path}",
     ]
 
     skill_lines: list[str] = []

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -29,16 +29,26 @@ BASE_TOOLKIT = (
 
 SHELL_TOOL_NAMES = frozenset({"bash", "ipython"})
 
-IPYTHON_USAGE_PROMPT = (
-    "The `ipython` tool runs each call as one IPython cell. `!cmd` shells out a "
-    "single line — for multi-line shell, use the `%%bash` cell magic on its own "
-    "first line and put the script underneath. Your shell runs inside this tool's "
-    "uv-managed environment, which is NOT the project's venv. Importing the "
-    "project under test directly (e.g. `import <project>`) won't work unless you "
-    "prepend the source path to `sys.path`, run the code under the project's "
-    "interpreter (e.g. `!/usr/local/bin/python3 ...` or `%%bash` calling it), or "
-    "install the project into this environment with `uv pip install -e <path>`."
-)
+
+def _ipython_usage_prompt() -> str:
+    return (
+        "- Treat `ipython` as your scratchpad: hold Python state, jot intermediate "
+        "results, keep notes between turns, manage context. Each call is one IPython "
+        "cell.\n"
+        "- Cells default to Python. To run a shell command, prefix with `!` "
+        "(single line) or `%%bash` (multi-line, must be the cell's first line). "
+        "Prefer `%%bash`; use `!` only for one-liners.\n"
+        "- Antipatterns (each raises `SyntaxError` — the cell is parsed as Python):\n"
+        "    BAD:  find /app -name '*.py'    GOOD: !find /app -name '*.py'\n"
+        "    BAD:  grep -rn 'foo' /app       GOOD: !grep -rn 'foo' /app\n"
+        "    BAD:  cat > /tmp/x.py <<EOF     GOOD: a `%%bash` cell with the heredoc inside\n"
+        "  Also: don't wrap a shell command in `subprocess.run([...])` when `!cmd` "
+        "or `%%bash` does the same thing in fewer tokens.\n"
+        f"- The kernel has these Python imports available by default: "
+        f"{', '.join(BASE_TOOLKIT)}."
+    )
+
+
 GIT_HISTORY_GUARD_PROMPT = (
     "Do not cheat by using online solutions or hints specific to this task, or "
     "by copying or inferring solutions from other branches, tags, remotes, "
@@ -66,13 +76,11 @@ def build_system_prompt(
     every request.
     """
     parts: list[str] = [
-        "You are a coding agent. You solve tasks by writing and executing code, observing results, and iterating one step at a time.",
+        "You are a coding agent. You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
         "When you are done, stop calling tools and state your final answer.",
         "",
         f"Working directory: {cwd}",
         f"Conversation log: {messages_path}",
-        f"Pre-installed Python packages: {', '.join(BASE_TOOLKIT)}.",
-        "Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
     ]
 
     skill_lines: list[str] = []
@@ -104,7 +112,7 @@ def build_system_prompt(
         )
 
     if any(tool.name == "ipython" for tool in active_tools):
-        parts.extend(["", IPYTHON_USAGE_PROMPT])
+        parts.extend(["", _ipython_usage_prompt()])
 
     if _should_include_git_history_guard(active_tools):
         parts.extend(["", GIT_HISTORY_GUARD_PROMPT])

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -28,6 +28,17 @@ BASE_TOOLKIT = (
 )
 
 SHELL_TOOL_NAMES = frozenset({"bash", "ipython"})
+
+IPYTHON_USAGE_PROMPT = (
+    "The `ipython` tool runs each call as one IPython cell. `!cmd` shells out a "
+    "single line — for multi-line shell, use the `%%bash` cell magic on its own "
+    "first line and put the script underneath. Your shell runs inside this tool's "
+    "uv-managed environment, which is NOT the project's venv. Importing the "
+    "project under test directly (e.g. `import <project>`) won't work unless you "
+    "prepend the source path to `sys.path`, run the code under the project's "
+    "interpreter (e.g. `!/usr/local/bin/python3 ...` or `%%bash` calling it), or "
+    "install the project into this environment with `uv pip install -e <path>`."
+)
 GIT_HISTORY_GUARD_PROMPT = (
     "Do not cheat by using online solutions or hints specific to this task, or "
     "by copying or inferring solutions from other branches, tags, remotes, "
@@ -91,6 +102,9 @@ def build_system_prompt(
                 "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
             ]
         )
+
+    if any(tool.name == "ipython" for tool in active_tools):
+        parts.extend(["", IPYTHON_USAGE_PROMPT])
 
     if _should_include_git_history_guard(active_tools):
         parts.extend(["", GIT_HISTORY_GUARD_PROMPT])

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -32,20 +32,17 @@ SHELL_TOOL_NAMES = frozenset({"bash", "ipython"})
 
 def _ipython_usage_prompt() -> str:
     return (
-        "- Treat `ipython` as your scratchpad: hold Python state, jot intermediate "
-        "results, keep notes between turns, manage context. Each call is one IPython "
-        "cell.\n"
-        "- Cells default to Python. To run a shell command, prefix with `!` "
-        "(single line) or `%%bash` (multi-line, must be the cell's first line). "
-        "Prefer `%%bash`; use `!` only for one-liners.\n"
-        "- Antipatterns (each raises `SyntaxError` — the cell is parsed as Python):\n"
-        "    BAD:  find /app -name '*.py'    GOOD: !find /app -name '*.py'\n"
-        "    BAD:  grep -rn 'foo' /app       GOOD: !grep -rn 'foo' /app\n"
-        "    BAD:  cat > /tmp/x.py <<EOF     GOOD: a `%%bash` cell with the heredoc inside\n"
-        "  Also: don't wrap a shell command in `subprocess.run([...])` when `!cmd` "
-        "or `%%bash` does the same thing in fewer tokens.\n"
-        f"- The kernel has these Python imports available by default: "
-        f"{', '.join(BASE_TOOLKIT)}."
+        "`ipython` is your primary working surface — a persistent IPython kernel. "
+        "Use it as a scratchpad: hold Python state across turns, compute and inspect "
+        "intermediate results, and keep working notes that manage your own context. "
+        "Every call runs as one cell in that kernel and the namespace persists, so "
+        "build up variables and helper functions as you go rather than re-deriving "
+        "them. "
+        "A cell is Python by default. Drop to the shell only when you actually need it: "
+        "prefix a single command with `!`, or open a cell with `%%bash` for anything "
+        "multi-line. A bare shell command with no prefix is read as Python and will "
+        "fail. "
+        f"The kernel comes with {', '.join(BASE_TOOLKIT)} already importable."
     )
 
 


### PR DESCRIPTION
## Summary

After merging the IPython control guidance from #90, this PR no longer carries a separate IPython prompt rewrite.

The remaining change removes the misleading system-prompt hint to install packages with `uv pip install <pkg>`. That hint points agents toward mutating the IPython kernel environment, which conflicts with the target-runtime guidance now on `main`.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/test_prompt.py`
- `uv run pytest tests/`
