### PR TITLE
1-line system prompt change to align with prime-agent

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -55,8 +55,10 @@ def build_system_prompt(
     every request.
     """
     parts: list[str] = [
-        "You are a coding agent. You solve tasks by writing and executing code, observing results, and iterating one step at a time.",
+        "You are a general purpose agent that uses code to solve tasks.",
+        "You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
         "When you are done, stop calling tools and state your final answer.",
+        "A Python project's interpreter can be in `PATH`. If not use the appropriate `.venv`.",
         "",
         f"Working directory: {cwd}",
         f"Conversation log: {messages_path}",

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -58,7 +58,6 @@ def build_system_prompt(
         "You are a general purpose agent that uses code to solve tasks.",
         "You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
         "When you are done, stop calling tools and state your final answer.",
-        "A Python project's interpreter can be in `PATH`. If not use the appropriate `.venv`.",
         "",
         f"Working directory: {cwd}",
         f"Conversation log: {messages_path}",


### PR DESCRIPTION
To make sense for the non-coding tasks we've just done one minor change to the system prompt to make it a "general agent with code" vs. a coding agent. It's very minor but it aligns with the prime-agent system prompt prefix now at least.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only wording change with no logic, auth, or data-path impact; behavior may shift slightly for how the model frames non-coding tasks.
> 
> **Overview**
> Reframes the agent’s opening system-prompt lines from a **coding agent** to a **general purpose agent that uses code**, and adds explicit guidance to break work into sub-tasks before writing and executing code.
> 
> This aligns the role prefix with **prime-agent** and broadens framing for non-coding tasks without changing environment, skills, recursion, or tool sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006774c9e68edc0f2badb82d1b688e757a3fbf5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->