### PR TITLE
feat: add IPython guidance to prefer Python for reading/searching files

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -57,6 +57,11 @@ IPYTHON_CONTROL_PROMPT = (
     "repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, "
     "or the active project interpreter from the repo root. Treat failures from "
     "that native environment as the relevant result."
+    "\n\n"
+    "Use Python for reading, searching, and editing files — it gives you "
+    "reusable variables you can slice, filter, and act on without re-reading. "
+    "Always assign read/search results to named variables so you can revisit "
+    "them later."
 )
 
 


### PR DESCRIPTION
Appends a paragraph to `IPYTHON_CONTROL_PROMPT` encouraging the agent to use Python for reading, searching, and editing files — assigning results to named variables for reuse rather than re-reading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change with no code paths, APIs, or security logic affected.
> 
> **Overview**
> Extends **`IPYTHON_CONTROL_PROMPT`** (appended to the agent system prompt when the `ipython` tool is active) with guidance to **use Python for reading, searching, and editing files**, keep results in **named variables**, and avoid re-reading the same content.
> 
> No runtime or tool behavior changes—only additional instructions in the prompt string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b444013cf23906bd1fee918aeb7f7e2572e2ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->