### PR TITLE
Prompt agents to use edit skill

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -63,6 +63,17 @@ IPYTHON_CONTROL_PROMPT = (
     "Always assign read/search results to named variables so you can revisit "
     "them later."
 )
+EDIT_SKILL_PROMPT = (
+    "For file changes that are exact replacements, prefer the pre-imported "
+    "`edit` skill over manual file writes. Use exactly "
+    "`await edit(path=\"relative/file.py\", old_str=\"\"\"old text\"\"\", "
+    "new_str=\"\"\"new text\"\"\")`. The target `old_str` must appear exactly "
+    "once. The supported keyword arguments are `path`, `old_str`, `new_str`, "
+    "and optional `cwd`; do not use `file`, `old`, `new`, line numbers, "
+    "`after`, or `insert`. If the replacement is not unique or the change is "
+    "too broad for an exact string replacement, then use normal Python file "
+    "I/O."
+)
 
 
 def build_system_prompt(
@@ -108,6 +119,8 @@ def build_system_prompt(
             "Each skill is also available as a shell command by the same name: `<skill> ...`. "
             "Discover its CLI usage with `<skill> --help`."
         )
+        if "edit" in installed_skills:
+            skill_lines.append(EDIT_SKILL_PROMPT)
     if skill_lines:
         parts.extend(["", *skill_lines])
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from rlm.prompt import (
+    EDIT_SKILL_PROMPT,
     GIT_HISTORY_GUARD_PROMPT,
     IPYTHON_CONTROL_PROMPT,
     build_system_prompt,
@@ -16,11 +17,15 @@ class _Tool:
     name: str
 
 
-def _prompt(active_tools: list[_Tool]) -> str:
+def _prompt(
+    active_tools: list[_Tool],
+    *,
+    installed_skills: list[str] | None = None,
+) -> str:
     return build_system_prompt(
         "/repo",
         None,
-        [],
+        installed_skills or [],
         "/repo/.rlm/messages.jsonl",
         allow_recursion=False,
         active_tools=active_tools,
@@ -62,3 +67,18 @@ def test_ipython_control_prompt_included_for_ipython_tool():
 
 def test_ipython_control_prompt_omitted_without_ipython_tool():
     assert IPYTHON_CONTROL_PROMPT not in _prompt([_Tool("bash")])
+
+
+def test_edit_skill_prompt_included_when_edit_is_installed():
+    prompt = _prompt([_Tool("ipython")], installed_skills=["edit"])
+
+    assert EDIT_SKILL_PROMPT in prompt
+    assert 'await edit(path="relative/file.py"' in prompt
+    assert "`old_str` must appear exactly once" in prompt
+    assert "do not use `file`, `old`, `new`, line numbers" in prompt
+
+
+def test_edit_skill_prompt_omitted_without_edit_skill():
+    prompt = _prompt([_Tool("ipython")], installed_skills=["search_docs"])
+
+    assert EDIT_SKILL_PROMPT not in prompt


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Prompt-only change gated on installed skills; no runtime or auth behavior changes.
> 
> **Overview**
> When the **`edit`** skill is installed, the agent system prompt now includes **`EDIT_SKILL_PROMPT`**, telling the model to prefer **`await edit(path=..., old_str=..., new_str=...)`** for unique exact string replacements and to fall back to normal Python file I/O otherwise. The text spells out supported kwargs and explicitly forbids wrong parameter names and line-based edit styles.
> 
> **`tests/test_prompt.py`** extends the prompt test helper with an **`installed_skills`** override and adds coverage that the edit block appears only when **`edit`** is in the installed skills list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ba4c9dd46ef330a133744049d747aee47f9bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->