### PR TITLE
[codex] Minimal IPython edit prompt guidance

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -47,7 +47,9 @@ IPYTHON_CONTROL_PROMPT = (
     "benchmark, or API may have its own environment and normal interface. "
     "Evaluate external systems through their own interface, then use IPython "
     "to coordinate the process and analyze what comes back.\n\n"
-    "When running shell commands from IPython, use `%%bash` cells. Avoid "
+    "When running shell commands from IPython, use `%%bash` cells. If you use "
+    "`%%bash`, it must be the first line of the code cell: no comments, "
+    "spaces, blank lines, imports, or Python statements before it. Avoid "
     "`!cmd` shell escapes for project commands so shell behavior is explicit "
     "and multi-line commands share one shell context.\n\n"
     "Important: do not install dependencies into the IPython kernel just to "
@@ -62,6 +64,13 @@ IPYTHON_CONTROL_PROMPT = (
     "reusable variables you can slice, filter, and act on without re-reading. "
     "Always assign read/search results to named variables so you can revisit "
     "them later."
+)
+EDIT_SKILL_PROMPT = (
+    "For targeted existing-file edits, prefer the pre-imported async `edit` "
+    "skill from IPython: `old = '''...'''; new = '''...'''; await "
+    'edit(path="pkg/file.py", old_str=old, new_str=new)`. Use exact '
+    "old/new strings; if the text contains triple double quotes, use triple "
+    "single-quoted variables or build `old`/`new` from inspected file slices."
 )
 
 
@@ -108,6 +117,8 @@ def build_system_prompt(
             "Each skill is also available as a shell command by the same name: `<skill> ...`. "
             "Discover its CLI usage with `<skill> --help`."
         )
+        if "edit" in installed_skills:
+            skill_lines.append(EDIT_SKILL_PROMPT)
     if skill_lines:
         parts.extend(["", *skill_lines])
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from rlm.prompt import (
+    EDIT_SKILL_PROMPT,
     GIT_HISTORY_GUARD_PROMPT,
     IPYTHON_CONTROL_PROMPT,
     build_system_prompt,
@@ -16,11 +17,15 @@ class _Tool:
     name: str
 
 
-def _prompt(active_tools: list[_Tool]) -> str:
+def _prompt(
+    active_tools: list[_Tool],
+    *,
+    installed_skills: list[str] | None = None,
+) -> str:
     return build_system_prompt(
         "/repo",
         None,
-        [],
+        installed_skills or [],
         "/repo/.rlm/messages.jsonl",
         allow_recursion=False,
         active_tools=active_tools,
@@ -57,8 +62,20 @@ def test_ipython_control_prompt_included_for_ipython_tool():
     assert "long-lived notebook" in prompt
     assert "native runtime" in prompt
     assert "use `%%bash` cells" in prompt
+    assert "must be the first line of the code cell" in prompt
     assert "do not install dependencies into the IPython kernel" in prompt
 
 
 def test_ipython_control_prompt_omitted_without_ipython_tool():
     assert IPYTHON_CONTROL_PROMPT not in _prompt([_Tool("bash")])
+
+
+def test_edit_skill_prompt_included_only_when_edit_is_installed():
+    prompt = _prompt([_Tool("ipython")], installed_skills=["edit"])
+
+    assert EDIT_SKILL_PROMPT in prompt
+    assert 'await edit(path="pkg/file.py", old_str=old, new_str=new)' in prompt
+    assert "triple double quotes" in prompt
+    assert EDIT_SKILL_PROMPT not in _prompt(
+        [_Tool("ipython")], installed_skills=["search_docs"]
+    )


### PR DESCRIPTION
## Summary

Minimal alternative to the larger IPython prompt PR.

Changes:
- adds one short reminder that `%%bash` must be the first line of an IPython code cell
- adds a compact edit-skill hint only when `edit` is installed
- keeps a single safe `await edit(...)` example using triple-single-quoted variables for texts that may contain triple double quotes
- adds focused prompt tests

No runtime guard and no IPython tool schema changes.

## Validation

- `uv run --frozen ruff check --isolated .` => passed
- `uv run --frozen ruff format --check --isolated .` => `31 files already formatted`
- `uv run --frozen pytest tests/test_prompt.py tests/test_git_block.py -q` => `62 passed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to system prompt text and unit tests; no runtime, tool schema, or guard behavior.
> 
> **Overview**
> Tightens **IPython** system-prompt guidance and adds a conditional **edit** skill hint.
> 
> The IPython section now states that **`%%bash` must be the first line** of a code cell (no leading comments, blanks, imports, or Python). When **`edit`** is among installed skills, the prompt adds a short block recommending `await edit(path=..., old_str=..., new_str=...)` with triple-single-quoted `old`/`new` and exact string matching.
> 
> Tests cover the new `%%bash` wording and assert **`EDIT_SKILL_PROMPT`** appears only when `edit` is installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47e19ff9c2db0f561fe95cc87e8ff5e29740aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->