### PR TITLE
chore: document that the assistant message dump preserves reasoning

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -299,6 +299,11 @@ class RLMEngine:
             )
 
             msg = response.choices[0].message
+            # Dump the WHOLE assistant message back into history: model_dump carries the
+            # provider's reasoning fields (reasoning_content / reasoning / reasoning_details)
+            # alongside content + tool_calls. Reasoning models (DeepSeek V4, Kimi K2 Thinking)
+            # require their prior-turn reasoning echoed back in later turns, so keep this a
+            # full round-trip — don't narrow it to hand-picked fields.
             msg_dict = msg.model_dump(exclude_none=True)
             msg_dict.setdefault("content", "")
             messages.append(msg_dict)


### PR DESCRIPTION
## Summary

Documents that the model loop intentionally echoes reasoning back to the provider.

Each assistant turn is appended to history via `msg.model_dump(exclude_none=True)`, which already carries the provider's reasoning fields (`reasoning_content` / `reasoning` / `reasoning_details`) alongside `content` + `tool_calls`. Reasoning models (DeepSeek V4, Kimi K2 Thinking) **require** their prior-turn reasoning echoed back in later turns, or multi-turn fails (`"the reasoning_content in the thinking mode must be passed back to the API"`).

The behavior is already correct — this just adds a comment so a future refactor doesn't narrow the dump to hand-picked fields and silently break those models. No functional change.

## Context

Surfaced while making the verifiers v1 interception server a 1:1 proxy (it was stripping reasoning before forwarding). rlm itself was already fine: `model_dump` preserves the extras the OpenAI SDK keeps. Verified end-to-end — terminal-bench `fix-git` with `z-ai/glm-4.7` ran 81 turns cleanly with reasoning round-tripping (0 "must be passed back" errors).
