### PR TITLE
Simplify uv installer update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,13 +42,10 @@ ensure_command() {
 }
 
 install_uv() {
-    local installer="/tmp/rlm-uv-install.sh"
-    if ! curl -LsSf https://astral.sh/uv/install.sh -o "$installer"; then
+    if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
         install_system_packages ca-certificates
-        curl -LsSf https://astral.sh/uv/install.sh -o "$installer"
+        curl -LsSf https://astral.sh/uv/install.sh | sh
     fi
-    sh "$installer"
-    rm -f "$installer"
 }
 
 python_supports_rlm() {


### PR DESCRIPTION
## Summary

Simplify `install_uv` while preserving the retry path that installs CA certificates through `install_system_packages` if the first Astral installer download fails.

## Why

Sandbox images can contain a stale `uv` binary. The setup path must run Astral's installer even when `uv` already exists, because later `uv tool install` arguments such as `--with-executables-from` require a newer uv.

This keeps the always-update behavior and removes the temporary installer file plumbing.

## Validation

- `bash -n install.sh`