### PR TITLE
remove redundant rlm_compaction_turns_dropped_mean metric

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -505,7 +505,6 @@ class RLMEngine:
         # Metrics: close the old branch.
         self._metrics.record(
             CompactionApplied(
-                num_turns_dropped=turns_since_last,
                 dropped_chars=dropped_chars,
                 summary_chars=len(summary_text),
                 turns_since_last_compaction=turns_since_last,

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -29,7 +29,6 @@ class IpythonExecuted:
 class CompactionApplied:
     """Emitted when the engine auto-compacts context after a summary turn."""
 
-    num_turns_dropped: int
     dropped_chars: int
     summary_chars: int
     turns_since_last_compaction: int

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -177,7 +177,6 @@ class RLMMetrics:
     has_compacted: int = 0  # 1 if compactions_count > 0, else 0; aggregates as the per-batch fraction of rollouts that compacted
     turns_since_last_compaction: int = 0
     turns_between_compactions_mean: float = 0.0
-    compaction_turns_dropped_mean: float = 0.0
     compaction_chars_dropped_mean: float = 0.0
     compaction_summary_chars_mean: float = 0.0
 
@@ -191,7 +190,6 @@ class RLMMetrics:
     _ipython_input_chars_total: int = field(default=0, repr=False)
     _ipython_input_loc_total: int = field(default=0, repr=False)
     _turns_between_compactions_total: int = field(default=0, repr=False)
-    _compaction_turns_dropped_total: int = field(default=0, repr=False)
     _compaction_chars_dropped_total: int = field(default=0, repr=False)
     _compaction_summary_chars_total: int = field(default=0, repr=False)
 
@@ -403,7 +401,6 @@ class RLMMetrics:
         elif isinstance(event, CompactionApplied):
             self.compactions_count += 1
             self._turns_between_compactions_total += event.turns_since_last_compaction
-            self._compaction_turns_dropped_total += event.num_turns_dropped
             self._compaction_chars_dropped_total += event.dropped_chars
             self._compaction_summary_chars_total += event.summary_chars
             # End the old branch for token accounting, then reset the retained
@@ -428,9 +425,6 @@ class RLMMetrics:
         if self.compactions_count:
             self.turns_between_compactions_mean = (
                 self._turns_between_compactions_total / self.compactions_count
-            )
-            self.compaction_turns_dropped_mean = (
-                self._compaction_turns_dropped_total / self.compactions_count
             )
             self.compaction_chars_dropped_mean = (
                 self._compaction_chars_dropped_total / self.compactions_count

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -60,7 +60,6 @@ def test_total_tool_response_tokens_across_compactions():
     )  # +30
     m.record(
         CompactionApplied(
-            num_turns_dropped=2,
             dropped_chars=0,
             summary_chars=0,
             turns_since_last_compaction=2,


### PR DESCRIPTION
`rlm_turns_between_compactions_mean` and `rlm_compaction_turns_dropped_mean` are redundant. This PR removes `rlm_compaction_turns_dropped_mean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to metric shapes and aggregation; no runtime compaction or engine behavior changes beyond what is recorded.
> 
> **Overview**
> Removes **turns-dropped** compaction telemetry that duplicated **`turns_since_last_compaction`** / **`turns_between_compactions_mean`**.
> 
> **`CompactionApplied`** no longer carries **`num_turns_dropped`**; the engine records only **`dropped_chars`**, **`summary_chars`**, and **`turns_since_last_compaction`**. **`RLMMetrics`** drops **`compaction_turns_dropped_mean`** and the internal **`_compaction_turns_dropped_total`** accumulator, including aggregation in **`record`** and **`_refresh_derived_metrics`**. Tests are updated to construct **`CompactionApplied`** without the removed field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb35fbceb44afa22cd5235337f62b2cd89a96bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->