### PR TITLE
fix: gate skill prompt guidance on the active tool set

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -101,6 +101,12 @@ def build_system_prompt(
         "Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
     ]
 
+    # How skills can actually be reached depends on the active tool set:
+    # the pre-imported async-function surface needs the ipython kernel, while
+    # the shell-command surface needs any shell-capable tool (bash or ipython).
+    ipython_active = _has_tool(active_tools, "ipython")
+    shell_active = any(tool.name in SHELL_TOOL_NAMES for tool in active_tools)
+
     skill_lines: list[str] = []
     if skills_dir:
         skill_lines.append(
@@ -108,16 +114,20 @@ def build_system_prompt(
         )
     if installed_skills:
         installed = ", ".join(f"`{skill}`" for skill in installed_skills)
-        skill_lines.append(f"Installed skills (pre-imported): {installed}.")
-        skill_lines.append(
-            "Each skill is an async function by the same name. "
-            "Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`."
-        )
-        skill_lines.append(
-            "Each skill is also available as a shell command by the same name: `<skill> ...`. "
-            "Discover its CLI usage with `<skill> --help`."
-        )
-        if "edit" in installed_skills:
+        if ipython_active:
+            skill_lines.append(f"Installed skills (pre-imported): {installed}.")
+            skill_lines.append(
+                "Each skill is an async function by the same name. "
+                "Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`."
+            )
+        else:
+            skill_lines.append(f"Installed skills: {installed}.")
+        if shell_active:
+            skill_lines.append(
+                "Each skill is also available as a shell command by the same name: `<skill> ...`. "
+                "Discover its CLI usage with `<skill> --help`."
+            )
+        if "edit" in installed_skills and ipython_active:
             skill_lines.append(EDIT_SKILL_PROMPT)
     if skill_lines:
         parts.extend(["", *skill_lines])
@@ -131,7 +141,7 @@ def build_system_prompt(
             ]
         )
 
-    if _has_tool(active_tools, "ipython"):
+    if ipython_active:
         parts.extend(["", IPYTHON_CONTROL_PROMPT])
 
     if _should_include_git_history_guard(active_tools):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -79,3 +79,39 @@ def test_edit_skill_prompt_included_only_when_edit_is_installed():
     assert EDIT_SKILL_PROMPT not in _prompt(
         [_Tool("ipython")], installed_skills=["search_docs"]
     )
+
+
+def test_skill_pre_imported_language_present_with_ipython():
+    prompt = _prompt([_Tool("ipython")], installed_skills=["websearch"])
+
+    assert "Installed skills (pre-imported): `websearch`." in prompt
+    assert "async function" in prompt
+    assert "also available as a shell command" in prompt
+
+
+def test_skill_usage_language_requires_ipython():
+    """Without ipython there is no kernel, so skills are not pre-imported.
+
+    The async-function language must drop, but the shell-command surface is
+    still real in bash mode.
+    """
+    prompt = _prompt([_Tool("bash")], installed_skills=["websearch"])
+
+    assert "Installed skills: `websearch`." in prompt
+    assert "(pre-imported)" not in prompt
+    assert "async function" not in prompt
+    assert "also available as a shell command" in prompt
+
+
+def test_skill_shell_command_language_requires_shell_tool():
+    """With neither ipython nor bash, skills can't be invoked — list names only."""
+    prompt = _prompt([_Tool("edit")], installed_skills=["websearch"])
+
+    assert "Installed skills: `websearch`." in prompt
+    assert "(pre-imported)" not in prompt
+    assert "also available as a shell command" not in prompt
+
+
+def test_edit_skill_prompt_omitted_without_ipython():
+    """EDIT_SKILL_PROMPT is IPython-specific; drop it when no kernel runs."""
+    assert EDIT_SKILL_PROMPT not in _prompt([_Tool("bash")], installed_skills=["edit"])


### PR DESCRIPTION
**Stacked on #107** (`feat/rename-skills-agent-dirs`) — review/merge that first.

## Problem

`build_system_prompt` advertised installed skills as `(pre-imported)` async functions with `help()`/`inspect` guidance **regardless of the active tool set**. That surface only exists when the IPython kernel runs. In `bash`/`edit` modes there's no kernel, so the prompt told the model something false — only the *"also available as a shell command"* line was actually true (and even that is false in `edit`-only mode).

## Fix

Gate each usage surface on what can actually reach a skill:

| Guidance | Shown when |
|---|---|
| `(pre-imported)` + "async function … `help()`" + `EDIT_SKILL_PROMPT` | `ipython` active |
| "also available as a shell command" | any shell tool active (`bash` or `ipython`) |
| plain "Installed skills: …" name list | always (when skills installed) |

With neither shell nor ipython, skills are listed by name without false usage instructions. IPython-mode behavior is unchanged. Also de-duplicates the now-shared `ipython_active` check used for `IPYTHON_CONTROL_PROMPT`.

## Tests

Added 4 targeted cases in `tests/test_prompt.py` (ipython / bash / edit-only / edit-skill-without-ipython). `uv run pytest tests/` — 92 passed.