### PR TITLE
fix: retry malformed/reset model responses to survive flaky interception tunnel

### DIFF
--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -6,12 +6,14 @@ from typing import Any, Awaitable, Callable
 
 from openai import (
     APIConnectionError,
+    APIResponseValidationError,
     APITimeoutError,
     AsyncOpenAI,
     InternalServerError,
     NotFoundError,
     RateLimitError,
 )
+from pydantic import ValidationError
 
 from rlm.types import TokenUsage
 
@@ -21,6 +23,14 @@ _RETRYABLE: tuple[type[BaseException], ...] = (
     InternalServerError,
     NotFoundError,
     RateLimitError,
+    # Malformed/corrupted responses from a flaky tunnel/proxy: the body parses as JSON
+    # but fails schema validation (e.g. finish_reason='error'), or the SDK's own response
+    # validation trips. Retrying the call rides out the intermittent corruption instead of
+    # crashing the whole rollout. See PrimeIntellect-ai/rlm tunnel-corruption investigation.
+    APIResponseValidationError,
+    ValidationError,
+    # Raw connection resets on the tunnel that don't surface as APIConnectionError.
+    ConnectionResetError,
 )
 
 # Widely-spaced delays (seconds) between attempts; total ~5 min wall budget.

--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -23,13 +23,8 @@ _RETRYABLE: tuple[type[BaseException], ...] = (
     InternalServerError,
     NotFoundError,
     RateLimitError,
-    # Malformed/corrupted responses from a flaky tunnel/proxy: the body parses as JSON
-    # but fails schema validation (e.g. finish_reason='error'), or the SDK's own response
-    # validation trips. Retrying the call rides out the intermittent corruption instead of
-    # crashing the whole rollout. See PrimeIntellect-ai/rlm tunnel-corruption investigation.
     APIResponseValidationError,
     ValidationError,
-    # Raw connection resets on the tunnel that don't surface as APIConnectionError.
     ConnectionResetError,
 )
 


### PR DESCRIPTION
## Problem

longpdfs (and other rlm) rollouts crash at a high rate with:

```
HarnessError: harness 'rlm' exited 1: .989391,14.8705 3.22984,2.928 … z" fill="#ffffff"/>
```

The payload is a fixed SVG error-page body. It turned out **not** to be the model, the docs, the dataset, GPUs, or the sandbox image — it's **intermittent corruption of streamed model responses on the sandbox → host interception tunnel**. A corrupted response surfaces as either a malformed body (`finish_reason='error'` → pydantic `ValidationError`), a truncated stream / `ConnectionResetError`, or an error-page body — none of which were in `_RETRYABLE`, so a single bad call crashed the whole rollout.

Rates observed (same eval, same model/docs, only the network path differs):

| path | rollout crash rate |
|---|---|
| off-cluster | ~0% |
| cluster + prime sandbox | ~90% |
| cluster + modal sandbox | ~12% |

Per-*call* failure is only ~5-6%; it's the compounding over ~30-100 calls/rollout that produces the ~90% per-rollout crash.

## Fix

Add the corruption failure modes to `_RETRYABLE` so `call_with_retries` rides them out instead of letting one bad response kill the rollout:

- `openai.APIResponseValidationError` — SDK response-schema validation failure
- `pydantic.ValidationError` — raw schema failures (e.g. `finish_reason='error'`)
- `ConnectionResetError` — raw resets / truncated streams not surfaced as `APIConnectionError`

This is targeted (does not retry legitimate 4xx) and safe: the interception server already resets its pending-turn state before each model turn, so a retried call doesn't double-record a turn.

Since per-call failure is ~5-6%, a few retries drop the effective per-call failure to <0.1%, taking the rollout crash rate from ~90% → ~1-2% on the affected path — without waiting on an infra fix to the tunnel.

## Verification

Ran an eval pinned to this commit against the affected cluster inference at the ~90%-crash config (8 docs): the SVG crash rate collapsed (0% on the completed rollouts vs ~90% baseline), with rollouts completing and scoring normally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to retry policy for known transient failures; does not broaden retries to legitimate 4xx or alter auth/data paths.
> 
> **Overview**
> Expands **`_RETRYABLE`** in `call_with_retries` so intermittent corruption on the sandbox→host inference tunnel no longer aborts whole rollouts on the first bad response.
> 
> **`APIResponseValidationError`**, **`ValidationError`**, and **`ConnectionResetError`** are now retried with the existing backoff schedule (alongside connection, rate-limit, and similar transient errors). Legitimate client errors such as **`BadRequestError`** are unchanged and still fail fast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5411c9647c6f480abbf2d6aac32ddac3efa59340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->