### PR TITLE
fix: set NO_COLOR=1 in the IPython kernel env

### DIFF
--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -167,6 +167,7 @@ if {bool(session_dir)!r}:
     sys.path.append({session_dir!r})
 os.environ['RLM_SESSION_DIR'] = {session_dir!r} or ''
 os.environ['RLM_DEPTH'] = str({depth!r} + 1)
+os.environ['NO_COLOR'] = '1'
 
 import nest_asyncio
 nest_asyncio.apply()


### PR DESCRIPTION
Colored output from tools run in `!`/`%%bash` cells (pytest especially) leaks ANSI escape codes into the transcript, wasting tokens. 

This sets `NO_COLOR=1` in the kernel's startup code, next to the other env vars. It's honored by pytest, ruff, pip, cargo, and most modern CLI tools, and every subprocess inherits it from the kernel env. Since `restart_kernel()` re-runs `_inject_startup()`, it also survives kernel restarts.

Verified end-to-end against a live kernel: `NO_COLOR=1` is visible in both `%%bash` cells and Python `subprocess` children.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single env var in REPL setup; no auth, data, or behavioral logic changes beyond disabling colored CLI output.
> 
> **Overview**
> Sets **`NO_COLOR=1`** in the IPython kernel’s injected startup code alongside existing `RLM_*` env vars so shell and subprocess output from `!` / `%%bash` cells stays uncolored.
> 
> Child processes inherit the kernel environment, so tools like pytest no longer need per-invocation `--color=no` and ANSI escapes are less likely to pollute tool transcripts and token usage. **`restart_kernel()`** re-runs `_inject_startup()`, so the setting persists across restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb38217fb4286cdc773b06ac6b148ad31badd2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->