### PR TITLE
feat: add native ACP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ RLM_MODEL=openai/gpt-5-mini rlm --acp
 
 Each ACP session owns one persistent RLM engine. Repeated `session/prompt`
 requests retain both the model conversation and the live IPython kernel. The
-agent accepts text prompts and streamable HTTP MCP servers, including request
-headers, and supports `session/close`. It intentionally does not advertise
-`session/load`: an arbitrary live Python kernel cannot be reconstructed after
-the ACP process exits, so clients must keep the process alive for the lifetime
-of a session.
+agent accepts text prompts and stdio or streamable HTTP MCP servers, including
+HTTP request headers. It supports cancellation and `session/close`; cancelling
+a turn leaves its session available for the next prompt. It intentionally does
+not advertise `session/load`: an arbitrary live Python kernel cannot be
+reconstructed after the ACP process exits, so clients must keep the process
+alive for the lifetime of a session.
 
 ## Python SDK
 
@@ -77,7 +78,7 @@ All configuration is via environment variables:
 | `PRIME_API_KEY` | — | PI Inference pair: targets `https://api.pinference.ai/api/v1` and forwards `PRIME_TEAM_ID` as `X-Prime-Team-ID` when set. |
 | `OPENAI_API_KEY` / `OPENAI_BASE_URL` | resolved by SDK | OpenAI pair — when `OPENAI_API_KEY` is set, AsyncOpenAI's native env handling is used (covers OpenAI direct and verifiers' rollout tunnel both). Provider precedence: explicit → PI → OpenAI. Keys are scoped to their own base URL so an `OPENAI_API_KEY` lying around can't leak to PI Inference. |
 | `RLM_SKILLS` | — | Comma-separated built-in skills to enable (`edit`, `search`); pre-imported into the kernel. Unknown names raise. See [Skills](#skills). |
-| `RLM_MCP_CONFIG` | — | Standard `mcpServers` URL map; each server's tools become pre-imported IPython skills (`<server>_<tool>`). See [MCP tools as skills](#mcp-tools-as-skills). |
+| `RLM_MCP_CONFIG` | — | Standard `mcpServers` config (streamable HTTP or stdio); each server's tools become pre-imported IPython skills (`<server>_<tool>`). See [MCP tools as skills](#mcp-tools-as-skills). |
 | `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |
 | `RLM_EXEC_TIMEOUT` | `300` | Seconds per IPython execution |
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
@@ -197,13 +198,22 @@ For running `rlm` against a specific skill set outside of a sandbox-orchestrated
 
 ### MCP tools as skills
 
-A host harness can wire task-specific [MCP](https://modelcontextprotocol.io) tool servers to `rlm` by setting `RLM_MCP_CONFIG` to a standard `mcpServers` URL map:
+A host harness can wire task-specific [MCP](https://modelcontextprotocol.io) tool servers to `rlm` by setting `RLM_MCP_CONFIG` to a standard `mcpServers` config. Streamable HTTP and stdio transports are supported:
 
 ```json
-{"mcpServers": {"tools": {"url": "http://127.0.0.1:8000/mcp"}}}
+{
+  "mcpServers": {
+    "remote": {"url": "http://127.0.0.1:8000/mcp"},
+    "local": {
+      "command": "/path/to/tool-server",
+      "args": ["--stdio"],
+      "env": {"API_KEY": "..."}
+    }
+  }
+}
 ```
 
-Programmatically, pass `mcp_servers={"tools": "http://127.0.0.1:8000/mcp"}` to `RLMEngine` / `rlm.run` instead (it takes precedence over `RLM_MCP_CONFIG`). A server may instead be `{"url": "...", "headers": {"Authorization": "..."}}` when it needs HTTP headers.
+Programmatically, pass `mcp_servers={"tools": "http://127.0.0.1:8000/mcp"}` to `RLMEngine` / `rlm.run` instead (it takes precedence over `RLM_MCP_CONFIG`). An HTTP server may instead be `{"url": "...", "headers": {"Authorization": "..."}}` when it needs request headers; stdio servers use the same `command` / `args` / `env` shape shown above.
 
 At startup `rlm` connects to each server, lists its tools, and generates one skill per tool (named `<server>_<tool>`, e.g. `tools_add_event`). These join the installed skills — pre-imported into the IPython namespace as async functions the agent calls programmatically, with a signature built from the tool's input schema:
 
@@ -212,7 +222,7 @@ help(tools_add_event)  # signature (typed from the schema) + the tool's descript
 await tools_add_event(day="monday", title="standup")
 ```
 
-Each call connects to the server over streamable HTTP, invokes the tool, and returns its text content (a tool-reported error is raised as `RuntimeError`). The generated modules are written into the session directory and the kernel imports them from there. Unlike installed skills, MCP skills are IPython-only — they're not exposed as shell commands.
+Each call connects using the configured transport, invokes the tool, and returns its text content (a tool-reported error is raised as `RuntimeError`). The generated modules are written into the session directory and the kernel imports them from there. Unlike installed skills, MCP skills are IPython-only — they're not exposed as shell commands.
 
 ## Kernel
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ RLM_SYSTEM_PROMPT_PATH=/tmp/system.txt rlm "solve the task"
 
 Skill CLIs provided by the host environment are on `$PATH` and invoked the same way (e.g. `websearch --queries "latest jupyter_client release"` when the `websearch` skill is installed).
 
+## Agent Client Protocol
+
+RLM can run as an [Agent Client Protocol](https://agentclientprotocol.com/)
+agent over stdio:
+
+```bash
+RLM_MODEL=openai/gpt-5-mini rlm --acp
+```
+
+Each ACP session owns one persistent RLM engine. Repeated `session/prompt`
+requests retain both the model conversation and the live IPython kernel. The
+agent accepts text prompts and streamable HTTP MCP servers, including request
+headers, and supports `session/close`. It intentionally does not advertise
+`session/load`: an arbitrary live Python kernel cannot be reconstructed after
+the ACP process exits, so clients must keep the process alive for the lifetime
+of a session.
+
 ## Python SDK
 
 ```python
@@ -186,7 +203,7 @@ A host harness can wire task-specific [MCP](https://modelcontextprotocol.io) too
 {"mcpServers": {"tools": {"url": "http://127.0.0.1:8000/mcp"}}}
 ```
 
-Programmatically, pass `mcp_servers={"tools": "http://127.0.0.1:8000/mcp"}` to `RLMEngine` / `rlm.run` instead (it takes precedence over `RLM_MCP_CONFIG`).
+Programmatically, pass `mcp_servers={"tools": "http://127.0.0.1:8000/mcp"}` to `RLMEngine` / `rlm.run` instead (it takes precedence over `RLM_MCP_CONFIG`). A server may instead be `{"url": "...", "headers": {"Authorization": "..."}}` when it needs HTTP headers.
 
 At startup `rlm` connects to each server, lists its tools, and generates one skill per tool (named `<server>_<tool>`, e.g. `tools_add_event`). These join the installed skills — pre-imported into the IPython namespace as async functions the agent calls programmatically, with a signature built from the tool's input schema:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ name = "rlm"
 version = "0.1.0"
 description = "A minimalistic CLI agent for true recursion."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 license = { text = "MIT" }
 dependencies = [
+    "agent-client-protocol==0.11.0",
     "openai>=1.0",
     "ipykernel",
     "jupyter_client",

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -172,11 +172,6 @@ class RLMACPAgent(Agent):
                 result = await task
             except asyncio.CancelledError:
                 return PromptResponse(stop_reason="cancelled")
-            except Exception:
-                state.closing = True
-                state.engine.close()
-                self._sessions.pop(session_id, None)
-                raise
             finally:
                 state.prompt_task = None
 

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -58,14 +58,21 @@ def _mcp_servers(
 ) -> dict[str, MCPServer]:
     resolved: dict[str, MCPServer] = {}
     for server in servers or []:
-        if not isinstance(server, HttpMcpServer):
-            raise RequestError.invalid_params(
-                {"reason": "RLM supports streamable HTTP MCP servers only"}
+        if isinstance(server, HttpMcpServer):
+            headers = {header.name: header.value for header in server.headers}
+            resolved[server.name] = (
+                {"url": server.url, "headers": headers} if headers else server.url
             )
-        headers = {header.name: header.value for header in server.headers}
-        resolved[server.name] = (
-            {"url": server.url, "headers": headers} if headers else server.url
-        )
+        elif isinstance(server, McpServerStdio):
+            resolved[server.name] = {
+                "command": server.command,
+                "args": list(server.args),
+                "env": {item.name: item.value for item in server.env},
+            }
+        else:
+            raise RequestError.invalid_params(
+                {"reason": "RLM supports stdio and streamable HTTP MCP servers only"}
+            )
     return resolved
 
 
@@ -162,8 +169,6 @@ class RLMACPAgent(Agent):
             try:
                 result = await task
             except asyncio.CancelledError:
-                state.engine.close()
-                self._sessions.pop(session_id, None)
                 return PromptResponse(stop_reason="cancelled")
             except Exception:
                 state.engine.close()

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -1,0 +1,221 @@
+"""Agent Client Protocol transport for RLM."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
+from importlib.metadata import version
+from typing import Any
+
+from acp import (
+    PROTOCOL_VERSION,
+    Agent,
+    InitializeResponse,
+    NewSessionResponse,
+    PromptResponse,
+    RequestError,
+    run_agent,
+    text_block,
+    update_agent_message,
+)
+from acp.interfaces import Client
+from acp.schema import (
+    AcpMcpServer,
+    AgentCapabilities,
+    AudioContentBlock,
+    ClientCapabilities,
+    CloseSessionResponse,
+    EmbeddedResourceContentBlock,
+    HttpMcpServer,
+    ImageContentBlock,
+    Implementation,
+    McpCapabilities,
+    McpServerStdio,
+    PromptCapabilities,
+    ResourceContentBlock,
+    SessionCapabilities,
+    SessionCloseCapabilities,
+    SseMcpServer,
+    TextContentBlock,
+    Usage,
+)
+
+from rlm.engine import RLMEngine
+from rlm.mcp import MCPServer
+from rlm.session import Session
+
+
+@dataclass
+class _SessionState:
+    engine: RLMEngine
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    prompt_task: asyncio.Task | None = None
+
+
+def _mcp_servers(
+    servers: list[HttpMcpServer | SseMcpServer | AcpMcpServer | McpServerStdio] | None,
+) -> dict[str, MCPServer]:
+    resolved: dict[str, MCPServer] = {}
+    for server in servers or []:
+        if not isinstance(server, HttpMcpServer):
+            raise RequestError.invalid_params(
+                {"reason": "RLM supports streamable HTTP MCP servers only"}
+            )
+        headers = {header.name: header.value for header in server.headers}
+        resolved[server.name] = (
+            {"url": server.url, "headers": headers} if headers else server.url
+        )
+    return resolved
+
+
+def _prompt_text(
+    prompt: list[
+        TextContentBlock
+        | ImageContentBlock
+        | AudioContentBlock
+        | ResourceContentBlock
+        | EmbeddedResourceContentBlock
+    ],
+) -> str:
+    if any(not isinstance(block, TextContentBlock) for block in prompt):
+        raise RequestError.invalid_params(
+            {"reason": "RLM currently accepts text prompt blocks only"}
+        )
+    text = "".join(block.text for block in prompt)
+    if not text:
+        raise RequestError.invalid_params({"reason": "prompt has no text"})
+    return text
+
+
+class RLMACPAgent(Agent):
+    """Expose persistent RLM engines as ACP sessions."""
+
+    def __init__(self) -> None:
+        self._client: Client
+        self._sessions: dict[str, _SessionState] = {}
+
+    def on_connect(self, conn: Client) -> None:
+        self._client = conn
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: ClientCapabilities | None = None,
+        client_info: Implementation | None = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        return InitializeResponse(
+            protocol_version=PROTOCOL_VERSION,
+            agent_capabilities=AgentCapabilities(
+                prompt_capabilities=PromptCapabilities(),
+                mcp_capabilities=McpCapabilities(http=True),
+                session_capabilities=SessionCapabilities(
+                    close=SessionCloseCapabilities()
+                ),
+            ),
+            agent_info=Implementation(name="rlm", title="RLM", version=version("rlm")),
+        )
+
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: list[HttpMcpServer | SseMcpServer | AcpMcpServer | McpServerStdio]
+        | None = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        if additional_directories:
+            raise RequestError.invalid_params(
+                {"reason": "RLM does not support additional session directories"}
+            )
+        session = Session()
+        session_id = session.dir.name
+        self._sessions[session_id] = _SessionState(
+            engine=RLMEngine(
+                cwd=cwd,
+                session=session,
+                mcp_servers=_mcp_servers(mcp_servers),
+            )
+        )
+        return NewSessionResponse(session_id=session_id)
+
+    async def prompt(
+        self,
+        session_id: str,
+        prompt: list[
+            TextContentBlock
+            | ImageContentBlock
+            | AudioContentBlock
+            | ResourceContentBlock
+            | EmbeddedResourceContentBlock
+        ],
+        **kwargs: Any,
+    ) -> PromptResponse:
+        state = self._sessions.get(session_id)
+        if state is None:
+            raise RequestError.resource_not_found(session_id)
+
+        async with state.lock:
+            task = asyncio.create_task(state.engine.prompt(_prompt_text(prompt)))
+            state.prompt_task = task
+            try:
+                result = await task
+            except asyncio.CancelledError:
+                state.engine.close()
+                self._sessions.pop(session_id, None)
+                return PromptResponse(stop_reason="cancelled")
+            except Exception:
+                state.engine.close()
+                self._sessions.pop(session_id, None)
+                raise
+            finally:
+                state.prompt_task = None
+
+        await self._client.session_update(
+            session_id=session_id,
+            update=update_agent_message(text_block(result.answer)),
+        )
+        stop_reason = (
+            "max_tokens" if state.engine.stop_reason == "token_budget" else "end_turn"
+        )
+        return PromptResponse(
+            stop_reason=stop_reason,
+            usage=Usage(
+                total_tokens=result.usage.total,
+                input_tokens=result.usage.prompt_tokens,
+                output_tokens=result.usage.completion_tokens,
+            ),
+        )
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        state = self._sessions.get(session_id)
+        if state is not None and state.prompt_task is not None:
+            state.prompt_task.cancel()
+
+    async def close_session(
+        self, session_id: str, **kwargs: Any
+    ) -> CloseSessionResponse:
+        state = self._sessions.pop(session_id, None)
+        if state is None:
+            raise RequestError.resource_not_found(session_id)
+        if state.prompt_task is not None:
+            state.prompt_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await state.prompt_task
+        state.engine.close()
+        return CloseSessionResponse()
+
+    async def shutdown(self) -> None:
+        for session_id in list(self._sessions):
+            await self.close_session(session_id)
+
+
+async def serve_acp() -> None:
+    """Serve RLM over ACP on stdin/stdout until the client disconnects."""
+    agent = RLMACPAgent()
+    try:
+        # agent-client-protocol 0.11 gates session/close routing behind this flag.
+        await run_agent(agent, use_unstable_protocol=True)
+    finally:
+        await agent.shutdown()

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -136,15 +136,19 @@ class RLMACPAgent(Agent):
             raise RequestError.invalid_params(
                 {"reason": "RLM does not support additional session directories"}
             )
+        resolved_mcp_servers = _mcp_servers(mcp_servers)
         session = Session()
         session_id = session.dir.name
-        self._sessions[session_id] = _SessionState(
-            engine=RLMEngine(
+        try:
+            engine = RLMEngine(
                 cwd=cwd,
                 session=session,
-                mcp_servers=_mcp_servers(mcp_servers),
+                mcp_servers=resolved_mcp_servers,
             )
-        )
+        except BaseException:
+            session.close()
+            raise
+        self._sessions[session_id] = _SessionState(engine=engine)
         return NewSessionResponse(session_id=session_id)
 
     async def prompt(

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from dataclasses import dataclass, field
 from importlib.metadata import version
 from typing import Any
@@ -51,6 +50,7 @@ class _SessionState:
     engine: RLMEngine
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     prompt_task: asyncio.Task | None = None
+    closing: bool = False
 
 
 def _mcp_servers(
@@ -164,6 +164,8 @@ class RLMACPAgent(Agent):
             raise RequestError.resource_not_found(session_id)
 
         async with state.lock:
+            if state.closing:
+                raise RequestError.resource_not_found(session_id)
             task = asyncio.create_task(state.engine.prompt(_prompt_text(prompt)))
             state.prompt_task = task
             try:
@@ -171,27 +173,30 @@ class RLMACPAgent(Agent):
             except asyncio.CancelledError:
                 return PromptResponse(stop_reason="cancelled")
             except Exception:
+                state.closing = True
                 state.engine.close()
                 self._sessions.pop(session_id, None)
                 raise
             finally:
                 state.prompt_task = None
 
-        await self._client.session_update(
-            session_id=session_id,
-            update=update_agent_message(text_block(result.answer)),
-        )
-        stop_reason = (
-            "max_tokens" if state.engine.stop_reason == "token_budget" else "end_turn"
-        )
-        return PromptResponse(
-            stop_reason=stop_reason,
-            usage=Usage(
-                total_tokens=result.usage.total,
-                input_tokens=result.usage.prompt_tokens,
-                output_tokens=result.usage.completion_tokens,
-            ),
-        )
+            await self._client.session_update(
+                session_id=session_id,
+                update=update_agent_message(text_block(result.answer)),
+            )
+            stop_reason = (
+                "max_tokens"
+                if state.engine.stop_reason == "token_budget"
+                else "end_turn"
+            )
+            return PromptResponse(
+                stop_reason=stop_reason,
+                usage=Usage(
+                    total_tokens=result.usage.total,
+                    input_tokens=result.usage.prompt_tokens,
+                    output_tokens=result.usage.completion_tokens,
+                ),
+            )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
         state = self._sessions.get(session_id)
@@ -204,11 +209,11 @@ class RLMACPAgent(Agent):
         state = self._sessions.pop(session_id, None)
         if state is None:
             raise RequestError.resource_not_found(session_id)
+        state.closing = True
         if state.prompt_task is not None:
             state.prompt_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await state.prompt_task
-        state.engine.close()
+        async with state.lock:
+            state.engine.close()
         return CloseSessionResponse()
 
     async def shutdown(self) -> None:

--- a/src/rlm/cli.py
+++ b/src/rlm/cli.py
@@ -34,6 +34,11 @@ def main():
         default=None,
         help="Extra instructions appended to the generated system prompt",
     )
+    parser.add_argument(
+        "--acp",
+        action="store_true",
+        help="Serve as an Agent Client Protocol agent over stdio",
+    )
     args = parser.parse_args()
 
     # Apply CLI overrides to env
@@ -44,7 +49,13 @@ def main():
     if args.append_to_system_prompt:
         os.environ["RLM_APPEND_TO_SYSTEM_PROMPT"] = args.append_to_system_prompt
 
-    if args.prompt:
+    if args.acp:
+        if args.prompt:
+            parser.error("a prompt cannot be supplied with --acp")
+        from rlm.acp import serve_acp
+
+        asyncio.run(serve_acp())
+    elif args.prompt:
         print(asyncio.run(rlm.run(args.prompt)).answer)
     else:
         _run_interactive()

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -277,6 +277,25 @@ class RLMEngine:
         try:
             result = await self._run_loop()
         except BaseException as exc:
+            attempted_turns = self._turn - turn_before
+            try:
+                self.session.log(
+                    {
+                        "type": "prompt_rollback",
+                        "start_turn": turn_before,
+                        "attempted_turns": attempted_turns,
+                        "reason": (
+                            "cancelled"
+                            if isinstance(exc, asyncio.CancelledError)
+                            else "error"
+                        ),
+                    }
+                )
+            except OSError:
+                logger.warning("rlm: failed to log prompt rollback", exc_info=True)
+            # Restore only the resumable conversation position. Usage, metrics,
+            # kernel/tool side effects, and the append-only audit log describe work
+            # that really ran and remain part of session accounting.
             self._messages[:] = messages_before
             self._branch_start_turn = branch_start_before
             self._turn = turn_before

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -267,6 +267,11 @@ class RLMEngine:
             messages_before = list(self._messages)
             self._messages.append({"role": "user", "content": prompt})
         branch_start_before = self._branch_start_turn
+        turn_before = self._turn
+        usage_before = TokenUsage(
+            prompt_tokens=self._total_usage.prompt_tokens,
+            completion_tokens=self._total_usage.completion_tokens,
+        )
 
         self._metrics.stop_reason = ""
         try:
@@ -274,9 +279,16 @@ class RLMEngine:
         except BaseException as exc:
             self._messages[:] = messages_before
             self._branch_start_turn = branch_start_before
+            self._turn = turn_before
             if isinstance(exc, asyncio.CancelledError):
                 self._metrics.stop_reason = "cancelled"
             raise
+        result.usage = TokenUsage(
+            prompt_tokens=self._total_usage.prompt_tokens - usage_before.prompt_tokens,
+            completion_tokens=(
+                self._total_usage.completion_tokens - usage_before.completion_tokens
+            ),
+        )
         self._last_answer = result.answer
         self._has_result = True
         return result

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -439,13 +439,28 @@ class RLMEngine:
             if tool is None:
                 tool_result = ToolOutcome(content=f"Error: unknown tool '{tool_name}'")
             else:
-                try:
-                    tool_result = await asyncio.to_thread(
+                tool_task = asyncio.create_task(
+                    asyncio.to_thread(
                         tool.execute, tool_args, self._tool_context(messages)
                     )
+                )
+                try:
+                    tool_result = await asyncio.shield(tool_task)
                 except asyncio.CancelledError:
-                    if self._repl is not None:
-                        self._repl.interrupt()
+                    repl = self._repl
+                    if repl is not None:
+                        repl.interrupt()
+                    try:
+                        while not tool_task.done():
+                            try:
+                                await asyncio.shield(tool_task)
+                            except asyncio.CancelledError:
+                                if repl is not None:
+                                    repl.interrupt()
+                        tool_task.result()
+                    finally:
+                        if repl is not None:
+                            repl.finish_interrupt()
                     raise
             duration = time.time() - t0
             for event in tool_result.metric_events:

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -308,6 +308,7 @@ class RLMEngine:
                 self._total_usage.completion_tokens - usage_before.completion_tokens
             ),
         )
+        result.turns = self._turn - turn_before
         self._last_answer = result.answer
         self._has_result = True
         return result

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -13,7 +13,13 @@ from pathlib import Path
 from openai import AsyncOpenAI, BadRequestError
 
 from rlm.client import call_with_retries, extract_usage, make_client
-from rlm.mcp import generate_mcp_skills, load_mcp_servers
+from rlm.mcp import (
+    MCP_CONFIG_ENV,
+    MCPServer,
+    dump_mcp_servers,
+    generate_mcp_skills,
+    load_mcp_servers,
+)
 from rlm.prompt import build_system_prompt
 from rlm.session import Session
 from rlm.skills import enable_builtin_skills
@@ -149,7 +155,7 @@ class RLMEngine:
         cwd: str | None = None,
         session: Session | None = None,
         client: AsyncOpenAI | None = None,
-        mcp_servers: dict[str, str] | None = None,
+        mcp_servers: dict[str, MCPServer] | None = None,
     ):
         self.model = model or os.environ.get("RLM_MODEL", "openai/gpt-5-mini")
         self.cwd = cwd or os.getcwd()
@@ -214,6 +220,15 @@ class RLMEngine:
         # report "turns since last compaction" when a compaction fires.
         self._branch_start_turn: int = 0
 
+        self._messages: list[dict] | None = None
+        self._active_tools: list[BuiltinTool] = []
+        self._active_tool_schemas: list[dict] = []
+        self._turn = 0
+        self._last_answer = ""
+        self._has_result = False
+        self._started = False
+        self._closed = False
+
     def _ensure_session(self):
         """Create session if not set."""
         if self.session is not None:
@@ -221,14 +236,43 @@ class RLMEngine:
         session_dir = os.environ.get("RLM_SESSION_DIR")
         self.session = Session(session_dir)
 
+    @property
+    def stop_reason(self) -> str:
+        """Reason the most recent prompt stopped."""
+        return self._metrics.stop_reason
+
     async def run(self, prompt: str) -> RLMResult:
         """Run a single agent loop to completion."""
+        try:
+            return await self.prompt(prompt)
+        finally:
+            self.close()
+
+    async def prompt(self, prompt: str) -> RLMResult:
+        """Run one user turn while preserving conversation and kernel state."""
+        if self._closed:
+            raise RuntimeError("RLM engine is closed")
+
         # Check depth limit
         if self.depth > self.max_depth:
             return RLMResult(
                 answer=f"[depth limit {self.max_depth} reached, cannot start]",
                 turns=0,
             )
+
+        if not self._started:
+            await self._start(prompt)
+        else:
+            self._messages.append({"role": "user", "content": prompt})
+
+        self._metrics.stop_reason = ""
+        result = await self._run_loop()
+        self._last_answer = result.answer
+        self._has_result = True
+        return result
+
+    async def _start(self, prompt: str) -> None:
+        """Initialize the session, tools, conversation, and persistent kernel."""
 
         self._ensure_session()
 
@@ -254,38 +298,42 @@ class RLMEngine:
                 ", ".join(mcp_skills),
             )
 
-        self._repl = IPythonREPL(cwd=self.cwd, session=self.session)
+        repl_env = (
+            {MCP_CONFIG_ENV: dump_mcp_servers(self.mcp_servers)}
+            if self.mcp_servers
+            else None
+        )
+        self._repl = IPythonREPL(cwd=self.cwd, session=self.session, env=repl_env)
         self._repl.start()
         self._known_children = {p.name for p in self.session.dir.glob("sub-*")}
 
-        try:
-            return await self._run_loop(prompt)
-        finally:
-            if self._repl is not None:
-                self._repl.shutdown()
-
-    async def _run_loop(self, prompt: str) -> RLMResult:
-        active_builtin_tools = get_active_builtin_tools()
-        active_tools = [tool.schema() for tool in active_builtin_tools]
+        self._active_tools = get_active_builtin_tools()
+        self._active_tool_schemas = [tool.schema() for tool in self._active_tools]
         messages_path = str(self.session.dir / "messages.jsonl")
-        system_prompt = self._load_system_prompt(messages_path, active_builtin_tools)
+        system_prompt = self._load_system_prompt(messages_path, self._active_tools)
 
-        messages = [
+        self._messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": prompt},
         ]
+        self._started = True
+
+    async def _run_loop(self) -> RLMResult:
+        messages = self._messages
+        if messages is None:
+            raise RuntimeError("RLM engine is not started")
 
         final_text = ""
-        turn = 0
 
-        for turn in itertools.count():
+        for turn in itertools.count(self._turn):
+            self._turn = turn + 1
             # Call LLM
             request_kwargs = {
                 "model": self.model,
                 "messages": messages,
             }
-            if active_tools:
-                request_kwargs["tools"] = active_tools
+            if self._active_tool_schemas:
+                request_kwargs["tools"] = self._active_tool_schemas
                 request_kwargs["parallel_tool_calls"] = False
             try:
                 response = await call_with_retries(
@@ -408,7 +456,9 @@ class RLMEngine:
                 and usage.prompt_tokens >= self.summarize_at_tokens
             ):
                 try:
-                    await self._compact_branch(messages, turn, active_tools)
+                    await self._compact_branch(
+                        messages, turn, self._active_tool_schemas
+                    )
                 except BadRequestError as e:
                     if not _is_request_too_large(e):
                         raise
@@ -420,18 +470,32 @@ class RLMEngine:
             answer=final_text,
             session_dir=self.session.dir,
             usage=self._total_usage,
-            turns=turn + 1,
-        )
-        self.session.finalize(
-            final_text,
-            usage={
-                "prompt_tokens": self._total_usage.prompt_tokens,
-                "completion_tokens": self._total_usage.completion_tokens,
-            },
-            turns=turn + 1,
-            metrics=self._metrics,
+            turns=self._turn,
         )
         return result
+
+    def close(self) -> None:
+        """Finalize artifacts and stop the persistent kernel."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self.session is not None:
+                if self._has_result:
+                    self.session.finalize(
+                        self._last_answer,
+                        usage={
+                            "prompt_tokens": self._total_usage.prompt_tokens,
+                            "completion_tokens": self._total_usage.completion_tokens,
+                        },
+                        turns=self._turn,
+                        metrics=self._metrics,
+                    )
+                else:
+                    self.session.close()
+        finally:
+            if self._repl is not None:
+                self._repl.shutdown()
 
     async def _compact_branch(
         self, messages: list[dict], turn: int, active_tools: list[dict]

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -271,10 +271,11 @@ class RLMEngine:
         self._metrics.stop_reason = ""
         try:
             result = await self._run_loop()
-        except asyncio.CancelledError:
+        except BaseException as exc:
             self._messages[:] = messages_before
             self._branch_start_turn = branch_start_before
-            self._metrics.stop_reason = "cancelled"
+            if isinstance(exc, asyncio.CancelledError):
+                self._metrics.stop_reason = "cancelled"
             raise
         self._last_answer = result.answer
         self._has_result = True
@@ -451,13 +452,19 @@ class RLMEngine:
                     if repl is not None:
                         repl.interrupt()
                     try:
-                        while not tool_task.done():
+                        while True:
                             try:
                                 await asyncio.shield(tool_task)
                             except asyncio.CancelledError:
                                 if repl is not None:
                                     repl.interrupt()
-                        tool_task.result()
+                                continue
+                            except Exception:
+                                logger.warning(
+                                    "rlm: tool failed while cancellation was settling",
+                                    exc_info=True,
+                                )
+                            break
                     finally:
                         if repl is not None:
                             repl.finish_interrupt()

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -183,8 +183,8 @@ class RLMEngine:
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
 
-        # Task MCP tool servers ({name: url}) to expose as IPython skills; kwarg wins,
-        # otherwise parse RLM_MCP_CONFIG (a standard mcpServers URL map).
+        # Task MCP tool servers to expose as IPython skills; kwarg wins, otherwise
+        # parse RLM_MCP_CONFIG (a standard mcpServers config).
         self.mcp_servers = (
             mcp_servers if mcp_servers is not None else load_mcp_servers()
         )
@@ -262,11 +262,20 @@ class RLMEngine:
 
         if not self._started:
             await self._start(prompt)
+            messages_before = self._messages[:1]
         else:
+            messages_before = list(self._messages)
             self._messages.append({"role": "user", "content": prompt})
+        branch_start_before = self._branch_start_turn
 
         self._metrics.stop_reason = ""
-        result = await self._run_loop()
+        try:
+            result = await self._run_loop()
+        except asyncio.CancelledError:
+            self._messages[:] = messages_before
+            self._branch_start_turn = branch_start_before
+            self._metrics.stop_reason = "cancelled"
+            raise
         self._last_answer = result.answer
         self._has_result = True
         return result
@@ -291,7 +300,9 @@ class RLMEngine:
         # (PTC). ipython is the sole builtin tool, so the kernel always starts.
         enable_builtin_skills(self.skills, self.session.dir)
         if self.mcp_servers:
-            mcp_skills = await generate_mcp_skills(self.mcp_servers, self.session.dir)
+            mcp_skills = await generate_mcp_skills(
+                self.mcp_servers, self.session.dir, self.cwd
+            )
             logger.info(
                 "rlm: exposed %d MCP tool(s) as skills - %s",
                 len(mcp_skills),
@@ -423,9 +434,14 @@ class RLMEngine:
             if tool is None:
                 tool_result = ToolOutcome(content=f"Error: unknown tool '{tool_name}'")
             else:
-                tool_result = await asyncio.to_thread(
-                    tool.execute, tool_args, self._tool_context(messages)
-                )
+                try:
+                    tool_result = await asyncio.to_thread(
+                        tool.execute, tool_args, self._tool_context(messages)
+                    )
+                except asyncio.CancelledError:
+                    if self._repl is not None:
+                        self._repl.interrupt()
+                    raise
             duration = time.time() - t0
             for event in tool_result.metric_events:
                 self._metrics.record(event)

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -315,19 +315,24 @@ class RLMEngine:
             else None
         )
         self._repl = IPythonREPL(cwd=self.cwd, session=self.session, env=repl_env)
-        self._repl.start()
-        self._known_children = {p.name for p in self.session.dir.glob("sub-*")}
+        try:
+            self._repl.start()
+            self._known_children = {p.name for p in self.session.dir.glob("sub-*")}
 
-        self._active_tools = get_active_builtin_tools()
-        self._active_tool_schemas = [tool.schema() for tool in self._active_tools]
-        messages_path = str(self.session.dir / "messages.jsonl")
-        system_prompt = self._load_system_prompt(messages_path, self._active_tools)
+            self._active_tools = get_active_builtin_tools()
+            self._active_tool_schemas = [tool.schema() for tool in self._active_tools]
+            messages_path = str(self.session.dir / "messages.jsonl")
+            system_prompt = self._load_system_prompt(messages_path, self._active_tools)
 
-        self._messages = [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": prompt},
-        ]
-        self._started = True
+            self._messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+            self._started = True
+        except BaseException:
+            self._repl.shutdown()
+            self._repl = None
+            raise
 
     async def _run_loop(self) -> RLMResult:
         messages = self._messages

--- a/src/rlm/mcp.py
+++ b/src/rlm/mcp.py
@@ -4,7 +4,7 @@ A v1 harness can wire task-specific tool servers to the agent over MCP. rlm has 
 client in its native tool-call loop; instead each MCP tool becomes a *skill* — a generated
 async function the agent calls straight from the IPython REPL (``await tools_add_event(...)``),
 the same programmatic tool-call (PTC) path as installed skills. The servers arrive as a
-standard ``mcpServers`` URL map in ``RLM_MCP_CONFIG`` (set by the verifiers rlm harness).
+standard ``mcpServers`` config in ``RLM_MCP_CONFIG`` (set by the verifiers rlm harness).
 
 Each tool is written to its own flat module in the session directory (added to the kernel's
 ``sys.path``); the module's ``run`` carries a signature built from the tool's input schema so
@@ -17,10 +17,13 @@ import inspect
 import json
 import os
 import re
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-from mcp import ClientSession
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import Tool
 
@@ -40,16 +43,26 @@ MCPServer = str | dict[str, Any]
 
 
 def load_mcp_servers() -> dict[str, MCPServer]:
-    """Parse ``RLM_MCP_CONFIG`` into normalized streamable HTTP servers."""
+    """Parse ``RLM_MCP_CONFIG`` into normalized HTTP or stdio servers."""
     raw = os.environ.get(MCP_CONFIG_ENV)
     servers = json.loads(raw)["mcpServers"] if raw else {}
-    return {
-        name: (
-            {"url": spec["url"], "headers": spec["headers"]}
-            if spec.get("headers")
-            else spec["url"]
+    return {name: _normalize_server(spec) for name, spec in servers.items()}
+
+
+def _normalize_server(server: MCPServer) -> MCPServer:
+    if isinstance(server, str):
+        return server
+    if "url" in server:
+        headers = dict(server.get("headers") or {})
+        return (
+            {"url": str(server["url"]), "headers": headers}
+            if headers
+            else str(server["url"])
         )
-        for name, spec in servers.items()
+    return {
+        "command": str(server["command"]),
+        "args": list(server.get("args") or []),
+        "env": dict(server.get("env") or {}),
     }
 
 
@@ -59,9 +72,11 @@ def _skill_name(server: str, tool: str) -> str:
     return f"_{ident}" if ident[:1].isdigit() else ident
 
 
-def _server_connection(server: MCPServer) -> tuple[str, dict[str, str]]:
+def _http_connection(server: MCPServer) -> tuple[str, dict[str, str]]:
     if isinstance(server, str):
         return server, {}
+    if "url" not in server:
+        raise TypeError("expected an HTTP MCP server")
     return str(server["url"]), dict(server.get("headers") or {})
 
 
@@ -69,40 +84,61 @@ def dump_mcp_servers(servers: dict[str, MCPServer]) -> str:
     """Serialize servers as a standard ``mcpServers`` configuration."""
     specs = {}
     for name, server in servers.items():
-        url, headers = _server_connection(server)
-        specs[name] = {"url": url, **({"headers": headers} if headers else {})}
+        normalized = _normalize_server(server)
+        if isinstance(normalized, str):
+            specs[name] = {"url": normalized}
+        else:
+            specs[name] = normalized
     return json.dumps({"mcpServers": specs})
 
 
-async def discover_tools(
-    servers: dict[str, MCPServer],
-) -> dict[str, tuple[str, Tool]]:
-    """List each server's tools using one discovery session per server."""
-    found: dict[str, tuple[str, Tool]] = {}
-    for server, spec in servers.items():
-        url, headers = _server_connection(spec)
+@asynccontextmanager
+async def _client_session(
+    server: MCPServer, cwd: str | None = None
+) -> AsyncIterator[ClientSession]:
+    normalized = _normalize_server(server)
+    if isinstance(normalized, str) or "url" in normalized:
+        url, headers = _http_connection(normalized)
         async with (
             streamablehttp_client(url, headers=headers or None) as (read, write, _),
             ClientSession(read, write) as session,
         ):
+            yield session
+        return
+
+    params = StdioServerParameters(
+        command=normalized["command"],
+        args=normalized["args"],
+        env=normalized["env"],
+        cwd=cwd,
+    )
+    async with (
+        stdio_client(params) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        yield session
+
+
+async def discover_tools(
+    servers: dict[str, MCPServer], cwd: str | None = None
+) -> dict[str, tuple[str, Tool]]:
+    """List each server's tools using one discovery session per server."""
+    found: dict[str, tuple[str, Tool]] = {}
+    for server, spec in servers.items():
+        async with _client_session(spec, cwd) as session:
             await session.initialize()
             for tool in (await session.list_tools()).tools:
                 found[_skill_name(server, tool.name)] = (server, tool)
     return found
 
 
-async def call_tool(
-    url: str, name: str, arguments: dict, headers: dict[str, str] | None = None
-) -> str:
-    """Call an MCP tool over streamable HTTP and return its text content.
+async def call_tool(server: MCPServer, name: str, arguments: dict) -> str:
+    """Call an MCP tool and return its text content.
 
     Raises ``RuntimeError`` on a tool-reported error, so a failed call surfaces as an
     exception in the REPL rather than a silently-wrong return value.
     """
-    async with (
-        streamablehttp_client(url, headers=headers) as (read, write, _),
-        ClientSession(read, write) as session,
-    ):
+    async with _client_session(server) as session:
         await session.initialize()
         result = await session.call_tool(name, arguments or {})
     text = "\n".join(
@@ -146,8 +182,7 @@ def make_skill(server: str, tool: Tool):
             spec = load_mcp_servers()[server]
         except KeyError as exc:
             raise RuntimeError(f"MCP server {server!r} is not configured") from exc
-        url, headers = _server_connection(spec)
-        return await call_tool(url, tool.name, kwargs, headers)
+        return await call_tool(spec, tool.name, kwargs)
 
     run.__signature__ = build_signature(tool.inputSchema)
     run.__doc__ = tool.description or f"MCP tool {tool.name!r}."
@@ -187,10 +222,10 @@ def write_skill_modules(
 
 
 async def generate_mcp_skills(
-    servers: dict[str, MCPServer], dest_dir: Path
+    servers: dict[str, MCPServer], dest_dir: Path, cwd: str | None = None
 ) -> list[str]:
     """Discover all tools on ``servers`` and write them as skill modules in ``dest_dir``."""
-    return write_skill_modules(await discover_tools(servers), dest_dir)
+    return write_skill_modules(await discover_tools(servers, cwd), dest_dir)
 
 
 def list_skill_modules(skills_dir: Path) -> list[str]:

--- a/src/rlm/mcp.py
+++ b/src/rlm/mcp.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
@@ -35,11 +36,21 @@ _JSON_TO_PY = {
 }
 
 
-def load_mcp_servers() -> dict[str, str]:
-    """Parse ``RLM_MCP_CONFIG`` (a standard ``mcpServers`` URL map) into ``{name: url}``."""
+MCPServer = str | dict[str, Any]
+
+
+def load_mcp_servers() -> dict[str, MCPServer]:
+    """Parse ``RLM_MCP_CONFIG`` into normalized streamable HTTP servers."""
     raw = os.environ.get(MCP_CONFIG_ENV)
     servers = json.loads(raw)["mcpServers"] if raw else {}
-    return {name: spec["url"] for name, spec in servers.items()}
+    return {
+        name: (
+            {"url": spec["url"], "headers": spec["headers"]}
+            if spec.get("headers")
+            else spec["url"]
+        )
+        for name, spec in servers.items()
+    }
 
 
 def _skill_name(server: str, tool: str) -> str:
@@ -48,28 +59,48 @@ def _skill_name(server: str, tool: str) -> str:
     return f"_{ident}" if ident[:1].isdigit() else ident
 
 
-async def discover_tools(servers: dict[str, str]) -> dict[str, tuple[str, Tool]]:
-    """List each server's tools as ``{skill_name: (url, Tool)}`` (one session per server)."""
+def _server_connection(server: MCPServer) -> tuple[str, dict[str, str]]:
+    if isinstance(server, str):
+        return server, {}
+    return str(server["url"]), dict(server.get("headers") or {})
+
+
+def dump_mcp_servers(servers: dict[str, MCPServer]) -> str:
+    """Serialize servers as a standard ``mcpServers`` configuration."""
+    specs = {}
+    for name, server in servers.items():
+        url, headers = _server_connection(server)
+        specs[name] = {"url": url, **({"headers": headers} if headers else {})}
+    return json.dumps({"mcpServers": specs})
+
+
+async def discover_tools(
+    servers: dict[str, MCPServer],
+) -> dict[str, tuple[str, Tool]]:
+    """List each server's tools using one discovery session per server."""
     found: dict[str, tuple[str, Tool]] = {}
-    for server, url in servers.items():
+    for server, spec in servers.items():
+        url, headers = _server_connection(spec)
         async with (
-            streamablehttp_client(url) as (read, write, _),
+            streamablehttp_client(url, headers=headers or None) as (read, write, _),
             ClientSession(read, write) as session,
         ):
             await session.initialize()
             for tool in (await session.list_tools()).tools:
-                found[_skill_name(server, tool.name)] = (url, tool)
+                found[_skill_name(server, tool.name)] = (server, tool)
     return found
 
 
-async def call_tool(url: str, name: str, arguments: dict) -> str:
+async def call_tool(
+    url: str, name: str, arguments: dict, headers: dict[str, str] | None = None
+) -> str:
     """Call an MCP tool over streamable HTTP and return its text content.
 
     Raises ``RuntimeError`` on a tool-reported error, so a failed call surfaces as an
     exception in the REPL rather than a silently-wrong return value.
     """
     async with (
-        streamablehttp_client(url) as (read, write, _),
+        streamablehttp_client(url, headers=headers) as (read, write, _),
         ClientSession(read, write) as session,
     ):
         await session.initialize()
@@ -102,16 +133,21 @@ def build_signature(schema: dict) -> inspect.Signature:
     return inspect.Signature(params)
 
 
-def make_skill(url: str, tool: Tool):
+def make_skill(server: str, tool: Tool):
     """Build the async ``run`` for a generated skill module from an MCP ``Tool``.
 
-    Generated modules are a single statement (``run = make_skill(url, Tool(...))``). The
+    Generated modules are a single statement (``run = make_skill(server, Tool(...))``). The
     returned coroutine forwards keyword args to the tool; its ``__signature__`` and
     ``__doc__`` come from the tool so ``help()`` / ``inspect.signature`` expose the real API.
     """
 
     async def run(**kwargs):
-        return await call_tool(url, tool.name, kwargs)
+        try:
+            spec = load_mcp_servers()[server]
+        except KeyError as exc:
+            raise RuntimeError(f"MCP server {server!r} is not configured") from exc
+        url, headers = _server_connection(spec)
+        return await call_tool(url, tool.name, kwargs, headers)
 
     run.__signature__ = build_signature(tool.inputSchema)
     run.__doc__ = tool.description or f"MCP tool {tool.name!r}."
@@ -125,7 +161,7 @@ from mcp.types import Tool
 
 from rlm.mcp import make_skill
 
-run = make_skill({url!r}, Tool.model_validate({tool!r}))
+run = make_skill({server!r}, Tool.model_validate({tool!r}))
 '''
 
 
@@ -137,20 +173,22 @@ def write_skill_modules(
     Returns the generated skill names (importable once ``dest_dir`` is on ``sys.path``).
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
-    for name, (url, tool) in found.items():
+    for name, (server, tool) in found.items():
         summary = next(
             iter((tool.description or "").splitlines()), f"MCP tool {tool.name}."
         )
         source = _MODULE_TEMPLATE.format(
             summary=summary.replace('"""', "'''"),
-            url=url,
+            server=server,
             tool=tool.model_dump(mode="json"),
         )
         (dest_dir / f"{name}.py").write_text(source)
     return list(found)
 
 
-async def generate_mcp_skills(servers: dict[str, str], dest_dir: Path) -> list[str]:
+async def generate_mcp_skills(
+    servers: dict[str, MCPServer], dest_dir: Path
+) -> list[str]:
     """Discover all tools on ``servers`` and write them as skill modules in ``dest_dir``."""
     return write_skill_modules(await discover_tools(servers), dest_dir)
 

--- a/src/rlm/mcp.py
+++ b/src/rlm/mcp.py
@@ -132,13 +132,18 @@ async def discover_tools(
     return found
 
 
-async def call_tool(server: MCPServer, name: str, arguments: dict) -> str:
+async def call_tool(
+    server: MCPServer,
+    name: str,
+    arguments: dict,
+    cwd: str | None = None,
+) -> str:
     """Call an MCP tool and return its text content.
 
     Raises ``RuntimeError`` on a tool-reported error, so a failed call surfaces as an
     exception in the REPL rather than a silently-wrong return value.
     """
-    async with _client_session(server) as session:
+    async with _client_session(server, cwd) as session:
         await session.initialize()
         result = await session.call_tool(name, arguments or {})
     text = "\n".join(
@@ -169,7 +174,7 @@ def build_signature(schema: dict) -> inspect.Signature:
     return inspect.Signature(params)
 
 
-def make_skill(server: str, tool: Tool):
+def make_skill(server: str, tool: Tool, cwd: str | None = None):
     """Build the async ``run`` for a generated skill module from an MCP ``Tool``.
 
     Generated modules are a single statement (``run = make_skill(server, Tool(...))``). The
@@ -182,7 +187,7 @@ def make_skill(server: str, tool: Tool):
             spec = load_mcp_servers()[server]
         except KeyError as exc:
             raise RuntimeError(f"MCP server {server!r} is not configured") from exc
-        return await call_tool(spec, tool.name, kwargs)
+        return await call_tool(spec, tool.name, kwargs, cwd)
 
     run.__signature__ = build_signature(tool.inputSchema)
     run.__doc__ = tool.description or f"MCP tool {tool.name!r}."
@@ -196,12 +201,14 @@ from mcp.types import Tool
 
 from rlm.mcp import make_skill
 
-run = make_skill({server!r}, Tool.model_validate({tool!r}))
+run = make_skill({server!r}, Tool.model_validate({tool!r}), cwd={cwd!r})
 '''
 
 
 def write_skill_modules(
-    found: dict[str, tuple[str, Tool]], dest_dir: Path
+    found: dict[str, tuple[str, Tool]],
+    dest_dir: Path,
+    cwd: str | None = None,
 ) -> list[str]:
     """Write one importable ``<skill>.py`` per discovered tool into ``dest_dir``.
 
@@ -216,6 +223,7 @@ def write_skill_modules(
             summary=summary.replace('"""', "'''"),
             server=server,
             tool=tool.model_dump(mode="json"),
+            cwd=cwd,
         )
         (dest_dir / f"{name}.py").write_text(source)
     return list(found)
@@ -225,7 +233,7 @@ async def generate_mcp_skills(
     servers: dict[str, MCPServer], dest_dir: Path, cwd: str | None = None
 ) -> list[str]:
     """Discover all tools on ``servers`` and write them as skill modules in ``dest_dir``."""
-    return write_skill_modules(await discover_tools(servers, cwd), dest_dir)
+    return write_skill_modules(await discover_tools(servers, cwd), dest_dir, cwd)
 
 
 def list_skill_modules(skills_dir: Path) -> list[str]:

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -137,6 +137,7 @@ class IPythonREPL:
         self._km = None
         self._kc = None
         self._lock = threading.Lock()
+        self._interrupt_requested = threading.Event()
 
     def start(self):
         """Start the IPython kernel."""
@@ -267,9 +268,14 @@ if {allow_recursion!r}:
         self._inject_startup()
 
     def interrupt(self):
-        """Interrupt a running cell, if any."""
+        """Request interruption and recovery of a running cell."""
+        self._interrupt_requested.set()
         if self._km:
             self._km.interrupt_kernel()
+
+    def finish_interrupt(self):
+        """Clear an interrupt after the execution worker has settled."""
+        self._interrupt_requested.clear()
 
     def _interrupt_and_recover(self):
         """Interrupt the running cell and restart the kernel if needed."""
@@ -280,7 +286,12 @@ if {allow_recursion!r}:
     def execute(self, code: str, timeout: int | None = None) -> str:
         """Execute code and return combined output."""
         with self._lock:
-            return self._execute_locked(code, timeout)
+            try:
+                if self._interrupt_requested.is_set():
+                    return ""
+                return self._execute_locked(code, timeout)
+            finally:
+                self._interrupt_requested.clear()
 
     def _execute_locked(self, code: str, timeout: int | None) -> str:
         msg_id = self._kc.execute(code)
@@ -289,24 +300,24 @@ if {allow_recursion!r}:
         outputs: list[str] = []
         try:
             while True:
+                if self._interrupt_requested.is_set():
+                    self._interrupt_and_recover()
+                    break
                 if deadline is None:
-                    wait_timeout = None
+                    wait_timeout = 0.1
                 else:
-                    wait_timeout = deadline - time.monotonic()
-                    if wait_timeout <= 0:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
                         self._interrupt_and_recover()
                         outputs.append(
                             f"\n[execution timed out after {timeout}s and was interrupted]"
                         )
                         break
+                    wait_timeout = min(remaining, 0.1)
                 try:
                     msg = self._kc.get_iopub_msg(timeout=wait_timeout)
                 except Empty:
-                    self._interrupt_and_recover()
-                    outputs.append(
-                        f"\n[execution timed out after {timeout}s and was interrupted]"
-                    )
-                    break
+                    continue
 
                 if msg["parent_header"].get("msg_id") != msg_id:
                     continue
@@ -328,7 +339,8 @@ if {allow_recursion!r}:
                     break
         finally:
             try:
-                self._kc.get_shell_msg(timeout=5)
+                timeout = 0.1 if self._interrupt_requested.is_set() else 5
+                self._kc.get_shell_msg(timeout=timeout)
             except Exception:
                 pass
 

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -125,9 +125,15 @@ class IpythonTool:
 class IPythonREPL:
     """Persistent IPython kernel communicating via Jupyter protocol."""
 
-    def __init__(self, cwd: str, session: "Session | None" = None):
+    def __init__(
+        self,
+        cwd: str,
+        session: "Session | None" = None,
+        env: dict[str, str] | None = None,
+    ):
         self.cwd = cwd
         self.session = session
+        self.env = env or {}
         self._km = None
         self._kc = None
         self._lock = threading.Lock()
@@ -144,7 +150,7 @@ class IPythonREPL:
             "-f",
             "{connection_file}",
         ]
-        self._km.start_kernel(cwd=self.cwd)
+        self._km.start_kernel(cwd=self.cwd, env={**os.environ, **self.env})
         self._kc = self._km.client()
         self._kc.start_channels()
         self._kc.wait_for_ready(timeout=30)

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -266,6 +266,11 @@ if {allow_recursion!r}:
         self._kc.wait_for_ready(timeout=30)
         self._inject_startup()
 
+    def interrupt(self):
+        """Interrupt a running cell, if any."""
+        if self._km:
+            self._km.interrupt_kernel()
+
     def _interrupt_and_recover(self):
         """Interrupt the running cell and restart the kernel if needed."""
         self._km.interrupt_kernel()

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -155,7 +155,7 @@ class RLMMetrics:
     sub_rlm_num_ptc_calls_python: int = 0
     sub_rlm_num_ptc_calls_bash: int = 0
 
-    stop_reason: str = ""  # "done", "token_budget", "request_too_large"
+    stop_reason: str = ""  # "done", "token_budget", "request_too_large", "cancelled"
 
     # Internal counters for derived metrics
     _ipython_call_count: int = field(default=0, repr=False)

--- a/tests/fixtures/mcp_stdio.py
+++ b/tests/fixtures/mcp_stdio.py
@@ -9,7 +9,8 @@ server = FastMCP("stdio-test")
 
 @server.tool()
 def echo(text: str) -> str:
-    return f"{os.environ['TEST_PREFIX']}:{text}"
+    inherited = all(name in os.environ for name in ("HOME", "PATH"))
+    return f"{os.environ['TEST_PREFIX']}:{inherited}:{text}"
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/mcp_stdio.py
+++ b/tests/fixtures/mcp_stdio.py
@@ -1,0 +1,16 @@
+"""Small stdio MCP server used by the transport integration test."""
+
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+server = FastMCP("stdio-test")
+
+
+@server.tool()
+def echo(text: str) -> str:
+    return f"{os.environ['TEST_PREFIX']}:{text}"
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")

--- a/tests/fixtures/mcp_stdio.py
+++ b/tests/fixtures/mcp_stdio.py
@@ -10,7 +10,7 @@ server = FastMCP("stdio-test")
 @server.tool()
 def echo(text: str) -> str:
     inherited = all(name in os.environ for name in ("HOME", "PATH"))
-    return f"{os.environ['TEST_PREFIX']}:{inherited}:{text}"
+    return f"{os.environ['TEST_PREFIX']}:{inherited}:{os.getcwd()}:{text}"
 
 
 if __name__ == "__main__":

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -171,6 +171,20 @@ async def test_engine_failed_prompt_can_be_retried(session):
 
     assert result.answer == "continued"
     assert result.turns == 1
+    meta = json.loads((Path(session.dir) / "meta.json").read_text())
+    assert meta["usage"] == {"prompt_tokens": 2, "completion_tokens": 2}
+    log = [
+        json.loads(line)
+        for line in (Path(session.dir) / "messages.jsonl").read_text().splitlines()
+    ]
+    assert [entry["type"] for entry in log] == [
+        "assistant",
+        "prompt_rollback",
+        "assistant",
+        "done",
+    ]
+    assert log[1]["attempted_turns"] == 1
+    assert log[1]["reason"] == "error"
     assert client.calls[-1]["messages"][-2:] == [
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1,0 +1,166 @@
+"""Native ACP transport and persistent engine lifecycle."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from acp import PROTOCOL_VERSION, spawn_agent_process, text_block
+from acp.schema import HttpHeader, HttpMcpServer
+
+from conftest import DummyClient, DummyMessage, DummyToolCall
+from rlm.acp import RLMACPAgent
+from rlm.engine import RLMEngine
+from rlm.types import RLMResult, TokenUsage
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, Any]] = []
+
+    async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
+        self.updates.append((session_id, update))
+
+
+class _Engine:
+    instances: list[_Engine] = []
+
+    def __init__(
+        self,
+        *,
+        cwd: str,
+        session,
+        mcp_servers: dict[str, Any],
+    ) -> None:
+        self.cwd = cwd
+        self.session = session
+        self.mcp_servers = mcp_servers
+        self.prompts: list[str] = []
+        self.closed = False
+        self.stop_reason = "done"
+        self.instances.append(self)
+
+    async def prompt(self, prompt: str) -> RLMResult:
+        self.prompts.append(prompt)
+        return RLMResult(
+            answer=f"reply:{prompt}",
+            usage=TokenUsage(prompt_tokens=3, completion_tokens=2),
+            turns=len(self.prompts),
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+async def test_engine_prompt_preserves_conversation(session):
+    client = DummyClient(
+        [DummyMessage(content="first"), DummyMessage(content="second")]
+    )
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+
+    try:
+        first = await engine.prompt("one")
+        second = await engine.prompt("two")
+    finally:
+        engine.close()
+
+    assert first.answer == "first"
+    assert second.answer == "second"
+    assert client.calls[1]["messages"][-4:] == [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "first"},
+        {"role": "user", "content": "two"},
+        {"role": "assistant", "content": "second"},
+    ]
+    meta = json.loads((Path(session.dir) / "meta.json").read_text())
+    assert meta["turns"] == 2
+    assert meta["answer_preview"] == "second"
+
+
+async def test_engine_prompt_preserves_ipython_kernel(session):
+    client = DummyClient(
+        [
+            DummyMessage(tool_calls=[DummyToolCall("ipython", {"code": "x = 41"})]),
+            DummyMessage(content="stored"),
+            DummyMessage(
+                tool_calls=[DummyToolCall("ipython", {"code": "print(x + 1)"})]
+            ),
+            DummyMessage(content="done"),
+        ]
+    )
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+
+    try:
+        await engine.prompt("remember a value")
+        result = await engine.prompt("use that value")
+    finally:
+        engine.close()
+
+    tool_messages = [
+        message for message in client.calls[-1]["messages"] if message["role"] == "tool"
+    ]
+    assert result.answer == "done"
+    assert tool_messages[-1]["content"].strip() == "42"
+
+
+async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    client = _Client()
+    agent = RLMACPAgent()
+    agent.on_connect(client)  # type: ignore[arg-type]
+
+    initialized = await agent.initialize(PROTOCOL_VERSION)
+    assert initialized.agent_capabilities.mcp_capabilities.http is True
+    assert initialized.agent_capabilities.load_session is False
+
+    created = await agent.new_session(
+        str(tmp_path),
+        mcp_servers=[
+            HttpMcpServer(
+                type="http",
+                name="tools",
+                url="http://127.0.0.1:8000/mcp",
+                headers=[HttpHeader(name="Authorization", value="Bearer task")],
+            )
+        ],
+    )
+    first = await agent.prompt(created.session_id, [text_block("one")])
+    second = await agent.prompt(created.session_id, [text_block("two")])
+
+    engine = _Engine.instances[0]
+    assert engine.prompts == ["one", "two"]
+    assert engine.mcp_servers == {
+        "tools": {
+            "url": "http://127.0.0.1:8000/mcp",
+            "headers": {"Authorization": "Bearer task"},
+        }
+    }
+    assert [update.content.text for _, update in client.updates] == [
+        "reply:one",
+        "reply:two",
+    ]
+    assert first.usage.total_tokens == 5
+    assert second.stop_reason == "end_turn"
+
+    await agent.close_session(created.session_id)
+    assert engine.closed is True
+
+
+async def test_acp_stdio_lifecycle(tmp_path):
+    executable = str(Path(sys.executable).parent / "rlm")
+    env = {**os.environ, "RLM_HOME": str(tmp_path / "rlm")}
+
+    async with spawn_agent_process(_Client(), executable, "--acp", env=env) as (
+        connection,
+        _process,
+    ):
+        initialized = await connection.initialize(PROTOCOL_VERSION)
+        created = await connection.new_session(cwd=str(tmp_path), mcp_servers=[])
+        await connection.close_session(created.session_id)
+
+    assert initialized.agent_info.name == "rlm"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -78,6 +78,9 @@ async def test_engine_prompt_preserves_conversation(session):
 
     assert first.answer == "first"
     assert second.answer == "second"
+    assert first.usage == TokenUsage(prompt_tokens=1, completion_tokens=1)
+    assert second.usage == TokenUsage(prompt_tokens=1, completion_tokens=1)
+    assert engine._total_usage == TokenUsage(prompt_tokens=2, completion_tokens=2)
     assert client.calls[1]["messages"][-4:] == [
         {"role": "user", "content": "one"},
         {"role": "assistant", "content": "first"},
@@ -142,6 +145,7 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
         engine.close()
 
     assert result.answer == "continued"
+    assert result.turns == 1
     assert client.calls[-1]["messages"][-2:] == [
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},
@@ -166,6 +170,7 @@ async def test_engine_failed_prompt_can_be_retried(session):
         engine.close()
 
     assert result.answer == "continued"
+    assert result.turns == 1
     assert client.calls[-1]["messages"][-2:] == [
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from acp import PROTOCOL_VERSION, spawn_agent_process, text_block
+from acp import PROTOCOL_VERSION, RequestError, spawn_agent_process, text_block
 from acp.schema import EnvVariable, HttpHeader, HttpMcpServer, McpServerStdio
 import pytest
 
@@ -145,6 +145,55 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
     ]
 
 
+async def test_engine_cancelled_tool_recovers_kernel(session, tmp_path):
+    started = tmp_path / "tool-started"
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": (
+                                "from pathlib import Path; import time; "
+                                f"kept = 41; Path({str(started)!r}).touch(); "
+                                "time.sleep(30)"
+                            )
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(
+                tool_calls=[DummyToolCall("ipython", {"code": "print(kept + 1)"})]
+            ),
+            DummyMessage(content="continued"),
+        ]
+    )
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+
+    pending = asyncio.create_task(engine.prompt("cancel the tool"))
+    for _ in range(100):
+        if started.exists():
+            break
+        await asyncio.sleep(0.05)
+    assert started.exists()
+
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(pending, timeout=10)
+
+    try:
+        result = await engine.prompt("continue")
+    finally:
+        engine.close()
+
+    tool_messages = [
+        message for message in client.calls[-1]["messages"] if message["role"] == "tool"
+    ]
+    assert result.answer == "continued"
+    assert tool_messages[-1]["content"].strip() == "42"
+
+
 async def test_engine_failed_start_cleans_kernel_before_retry(
     monkeypatch, session, tmp_path
 ):
@@ -264,6 +313,33 @@ async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
     assert engine.prompts == ["wait", "after"]
 
     await agent.close_session(created.session_id)
+
+
+async def test_acp_close_rejects_queued_prompt(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+    engine = _Engine.instances[0]
+
+    running = asyncio.create_task(
+        agent.prompt(created.session_id, [text_block("wait")])
+    )
+    await engine.prompt_started.wait()
+    queued = asyncio.create_task(
+        agent.prompt(created.session_id, [text_block("after")])
+    )
+    await asyncio.sleep(0)
+
+    await agent.close_session(created.session_id)
+
+    assert (await running).stop_reason == "cancelled"
+    with pytest.raises(RequestError):
+        await queued
+    assert engine.prompts == ["wait"]
+    assert engine.closed is True
 
 
 async def test_acp_stdio_lifecycle(tmp_path):

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -9,7 +10,8 @@ from pathlib import Path
 from typing import Any
 
 from acp import PROTOCOL_VERSION, spawn_agent_process, text_block
-from acp.schema import HttpHeader, HttpMcpServer
+from acp.schema import EnvVariable, HttpHeader, HttpMcpServer, McpServerStdio
+import pytest
 
 from conftest import DummyClient, DummyMessage, DummyToolCall
 from rlm.acp import RLMACPAgent
@@ -39,12 +41,16 @@ class _Engine:
         self.session = session
         self.mcp_servers = mcp_servers
         self.prompts: list[str] = []
+        self.prompt_started = asyncio.Event()
         self.closed = False
         self.stop_reason = "done"
         self.instances.append(self)
 
     async def prompt(self, prompt: str) -> RLMResult:
         self.prompts.append(prompt)
+        self.prompt_started.set()
+        if prompt == "wait":
+            await asyncio.Future()
         return RLMResult(
             answer=f"reply:{prompt}",
             usage=TokenUsage(prompt_tokens=3, completion_tokens=2),
@@ -106,6 +112,39 @@ async def test_engine_prompt_preserves_ipython_kernel(session):
     assert tool_messages[-1]["content"].strip() == "42"
 
 
+async def test_engine_cancelled_prompt_can_be_retried(session):
+    client = DummyClient([DummyMessage(content="continued")])
+    create = client.create
+    prompt_started = asyncio.Event()
+
+    async def block_first_prompt(**kwargs):
+        if not prompt_started.is_set():
+            client.calls.append(kwargs)
+            prompt_started.set()
+            await asyncio.Future()
+        return await create(**kwargs)
+
+    client.create = block_first_prompt
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+
+    pending = asyncio.create_task(engine.prompt("cancel me"))
+    await prompt_started.wait()
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+
+    try:
+        result = await engine.prompt("continue")
+    finally:
+        engine.close()
+
+    assert result.answer == "continued"
+    assert client.calls[-1]["messages"][-2:] == [
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "continued"},
+    ]
+
+
 async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     _Engine.instances.clear()
     monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
@@ -126,7 +165,13 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
                 name="tools",
                 url="http://127.0.0.1:8000/mcp",
                 headers=[HttpHeader(name="Authorization", value="Bearer task")],
-            )
+            ),
+            McpServerStdio(
+                name="local",
+                command="/usr/bin/tool-server",
+                args=["--stdio"],
+                env=[EnvVariable(name="TOKEN", value="task-secret")],
+            ),
         ],
     )
     first = await agent.prompt(created.session_id, [text_block("one")])
@@ -138,7 +183,12 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
         "tools": {
             "url": "http://127.0.0.1:8000/mcp",
             "headers": {"Authorization": "Bearer task"},
-        }
+        },
+        "local": {
+            "command": "/usr/bin/tool-server",
+            "args": ["--stdio"],
+            "env": {"TOKEN": "task-secret"},
+        },
     }
     assert [update.content.text for _, update in client.updates] == [
         "reply:one",
@@ -149,6 +199,30 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
 
     await agent.close_session(created.session_id)
     assert engine.closed is True
+
+
+async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+    engine = _Engine.instances[0]
+
+    pending = asyncio.create_task(
+        agent.prompt(created.session_id, [text_block("wait")])
+    )
+    await engine.prompt_started.wait()
+    await agent.cancel(created.session_id)
+
+    assert (await pending).stop_reason == "cancelled"
+    assert engine.closed is False
+    resumed = await agent.prompt(created.session_id, [text_block("after")])
+    assert resumed.stop_reason == "end_turn"
+    assert engine.prompts == ["wait", "after"]
+
+    await agent.close_session(created.session_id)
 
 
 async def test_acp_stdio_lifecycle(tmp_path):

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +52,8 @@ class _Engine:
         self.prompt_started.set()
         if prompt == "wait":
             await asyncio.Future()
+        if prompt == "fail":
+            raise RuntimeError("transient failure")
         return RLMResult(
             answer=f"reply:{prompt}",
             usage=TokenUsage(prompt_tokens=3, completion_tokens=2),
@@ -139,6 +142,92 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
         engine.close()
 
     assert result.answer == "continued"
+    assert client.calls[-1]["messages"][-2:] == [
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "continued"},
+    ]
+
+
+async def test_engine_failed_prompt_can_be_retried(session):
+    client = DummyClient(
+        [
+            DummyMessage(tool_calls=[DummyToolCall("boom", {})]),
+            DummyMessage(content="continued"),
+        ]
+    )
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await engine.prompt("fail")
+
+    try:
+        result = await engine.prompt("continue")
+    finally:
+        engine.close()
+
+    assert result.answer == "continued"
+    assert client.calls[-1]["messages"][-2:] == [
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "continued"},
+    ]
+
+
+async def test_engine_cancel_masks_tool_cleanup_error(monkeypatch, session):
+    started = threading.Event()
+    interrupted = threading.Event()
+
+    class FailingTool:
+        def execute(self, args, context):
+            started.set()
+            assert interrupted.wait(timeout=5)
+            raise RuntimeError("interrupted tool failed")
+
+    class FakeREPL:
+        def __init__(self):
+            self.finished = False
+            self.stopped = False
+
+        def interrupt(self):
+            interrupted.set()
+
+        def finish_interrupt(self):
+            self.finished = True
+
+        def shutdown(self):
+            self.stopped = True
+
+    monkeypatch.setattr("rlm.engine.get_builtin_tool", lambda name: FailingTool())
+    client = DummyClient(
+        [
+            DummyMessage(tool_calls=[DummyToolCall("failing", {})]),
+            DummyMessage(content="continued"),
+        ]
+    )
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+    repl = FakeREPL()
+    engine._started = True
+    engine._messages = [{"role": "system", "content": "system"}]
+    engine._repl = repl  # type: ignore[assignment]
+
+    pending = asyncio.create_task(engine.prompt("cancel"))
+    for _ in range(100):
+        if started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert started.is_set()
+
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+
+    try:
+        result = await engine.prompt("continue")
+    finally:
+        engine.close()
+
+    assert result.answer == "continued"
+    assert repl.finished is True
+    assert repl.stopped is True
     assert client.calls[-1]["messages"][-2:] == [
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},
@@ -311,6 +400,26 @@ async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
     resumed = await agent.prompt(created.session_id, [text_block("after")])
     assert resumed.stop_reason == "end_turn"
     assert engine.prompts == ["wait", "after"]
+
+    await agent.close_session(created.session_id)
+
+
+async def test_acp_failed_prompt_keeps_session_reusable(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+    engine = _Engine.instances[0]
+
+    with pytest.raises(RuntimeError, match="transient failure"):
+        await agent.prompt(created.session_id, [text_block("fail")])
+
+    resumed = await agent.prompt(created.session_id, [text_block("after")])
+    assert resumed.stop_reason == "end_turn"
+    assert engine.prompts == ["fail", "after"]
+    assert engine.closed is False
 
     await agent.close_session(created.session_id)
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -145,6 +145,47 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
     ]
 
 
+async def test_engine_failed_start_cleans_kernel_before_retry(
+    monkeypatch, session, tmp_path
+):
+    repls = []
+
+    class FakeREPL:
+        def __init__(self, **kwargs):
+            self.started = False
+            self.stopped = False
+            repls.append(self)
+
+        def start(self):
+            self.started = True
+
+        def shutdown(self):
+            self.stopped = True
+
+    monkeypatch.setattr("rlm.engine.IPythonREPL", FakeREPL)
+    system_prompt = tmp_path / "system.txt"
+    client = DummyClient([DummyMessage(content="continued")])
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        system_prompt_path=str(system_prompt),
+    )
+
+    with pytest.raises(FileNotFoundError):
+        await engine.prompt("first")
+    assert repls[0].started is True
+    assert repls[0].stopped is True
+    assert engine._repl is None
+
+    system_prompt.write_text("system")
+    result = await engine.prompt("retry")
+    engine.close()
+
+    assert result.answer == "continued"
+    assert len(repls) == 2
+    assert repls[1].stopped is True
+
+
 async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     _Engine.instances.clear()
     monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -17,6 +17,7 @@ import pytest
 from conftest import DummyClient, DummyMessage, DummyToolCall
 from rlm.acp import RLMACPAgent
 from rlm.engine import RLMEngine
+from rlm.session import Session
 from rlm.types import RLMResult, TokenUsage
 
 
@@ -78,6 +79,8 @@ async def test_engine_prompt_preserves_conversation(session):
 
     assert first.answer == "first"
     assert second.answer == "second"
+    assert first.turns == 1
+    assert second.turns == 1
     assert first.usage == TokenUsage(prompt_tokens=1, completion_tokens=1)
     assert second.usage == TokenUsage(prompt_tokens=1, completion_tokens=1)
     assert engine._total_usage == TokenUsage(prompt_tokens=2, completion_tokens=2)
@@ -341,6 +344,24 @@ async def test_engine_failed_start_cleans_kernel_before_retry(
     assert result.answer == "continued"
     assert len(repls) == 2
     assert repls[1].stopped is True
+
+
+async def test_acp_failed_session_creation_closes_session(monkeypatch, tmp_path):
+    session = Session(tmp_path / "session")
+
+    class FailingEngine:
+        def __init__(self, **kwargs):
+            raise RuntimeError("engine init failed")
+
+    monkeypatch.setattr("rlm.acp.Session", lambda: session)
+    monkeypatch.setattr("rlm.acp.RLMEngine", FailingEngine)
+    agent = RLMACPAgent()
+
+    with pytest.raises(RuntimeError, match="engine init failed"):
+        await agent.new_session(str(tmp_path))
+
+    assert session._msg_file.closed is True
+    assert agent._sessions == {}
 
 
 async def test_acp_session_reuses_engine(monkeypatch, tmp_path):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import json
 import sys
 
 from mcp.types import Tool
@@ -32,9 +33,25 @@ def test_load_mcp_servers(monkeypatch):
 
     monkeypatch.setenv(
         mcp.MCP_CONFIG_ENV,
-        '{"mcpServers": {"tools": {"url": "http://h/mcp"}, "web": {"url": "http://h/web"}}}',
+        '{"mcpServers": {"tools": {"url": "http://h/mcp"}, "web": {"url": "http://h/web", "headers": {"Authorization": "secret"}}}}',
     )
-    assert mcp.load_mcp_servers() == {"tools": "http://h/mcp", "web": "http://h/web"}
+    servers = mcp.load_mcp_servers()
+    assert servers == {
+        "tools": "http://h/mcp",
+        "web": {
+            "url": "http://h/web",
+            "headers": {"Authorization": "secret"},
+        },
+    }
+    assert json.loads(mcp.dump_mcp_servers(servers)) == {
+        "mcpServers": {
+            "tools": {"url": "http://h/mcp"},
+            "web": {
+                "url": "http://h/web",
+                "headers": {"Authorization": "secret"},
+            },
+        }
+    }
 
 
 def test_skill_name():
@@ -58,9 +75,7 @@ def test_write_skill_modules(tmp_path):
     tool = Tool(
         name="add_event", description="Add an event.\ndetails", inputSchema=SCHEMA
     )
-    names = mcp.write_skill_modules(
-        {"tools_add_event": ("http://h/mcp", tool)}, tmp_path
-    )
+    names = mcp.write_skill_modules({"tools_add_event": ("tools", tool)}, tmp_path)
     assert names == ["tools_add_event"]
     # the directory is the source of truth — the modules are readable back from it.
     assert mcp.list_skill_modules(tmp_path) == ["tools_add_event"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -65,16 +65,30 @@ def test_load_mcp_servers(monkeypatch):
     }
 
 
-async def test_stdio_transport():
+async def test_stdio_transport(monkeypatch, tmp_path):
+    server_cwd = tmp_path / "server"
+    server_cwd.mkdir()
+    caller_cwd = tmp_path / "caller"
+    caller_cwd.mkdir()
     server = {
         "command": sys.executable,
         "args": [str(Path(__file__).parent / "fixtures" / "mcp_stdio.py")],
         "env": {"TEST_PREFIX": "stdio"},
     }
-    found = await mcp.discover_tools({"local": server})
+    found = await mcp.discover_tools({"local": server}, str(server_cwd))
+    skills_dir = tmp_path / "skills"
+    mcp.write_skill_modules(found, skills_dir, str(server_cwd))
+    monkeypatch.setenv(mcp.MCP_CONFIG_ENV, mcp.dump_mcp_servers({"local": server}))
+    monkeypatch.chdir(caller_cwd)
 
     assert list(found) == ["local_echo"]
-    assert await mcp.call_tool(server, "echo", {"text": "hello"}) == "stdio:True:hello"
+    sys.path.insert(0, str(skills_dir))
+    try:
+        skill = importlib.import_module("local_echo")
+        assert await skill.run(text="hello") == f"stdio:True:{server_cwd}:hello"
+    finally:
+        sys.path.remove(str(skills_dir))
+        sys.modules.pop("local_echo", None)
 
 
 def test_skill_name():

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -74,7 +74,7 @@ async def test_stdio_transport():
     found = await mcp.discover_tools({"local": server})
 
     assert list(found) == ["local_echo"]
-    assert await mcp.call_tool(server, "echo", {"text": "hello"}) == "stdio:hello"
+    assert await mcp.call_tool(server, "echo", {"text": "hello"}) == "stdio:True:hello"
 
 
 def test_skill_name():

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,8 +1,8 @@
 """Tests for MCP-tools-as-skills (``rlm.mcp``).
 
-Covers the pure logic: config parsing, JSON-schema → signature rendering, and generation
-of importable skill modules. The live MCP round-trip (kernel pre-import + streamable-HTTP
-call) is exercised end-to-end by the general-agent-v1 eval, not here.
+Covers config parsing, JSON-schema → signature rendering, generation of importable skill
+modules, and a live stdio transport round-trip. The streamable-HTTP path is exercised
+end-to-end by the general-agent-v1 eval.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ import importlib
 import inspect
 import json
 import sys
+from pathlib import Path
 
 from mcp.types import Tool
 
@@ -33,7 +34,7 @@ def test_load_mcp_servers(monkeypatch):
 
     monkeypatch.setenv(
         mcp.MCP_CONFIG_ENV,
-        '{"mcpServers": {"tools": {"url": "http://h/mcp"}, "web": {"url": "http://h/web", "headers": {"Authorization": "secret"}}}}',
+        '{"mcpServers": {"tools": {"url": "http://h/mcp"}, "web": {"url": "http://h/web", "headers": {"Authorization": "secret"}}, "local": {"command": "/bin/server", "args": ["--stdio"], "env": {"TOKEN": "secret"}}}}',
     )
     servers = mcp.load_mcp_servers()
     assert servers == {
@@ -41,6 +42,11 @@ def test_load_mcp_servers(monkeypatch):
         "web": {
             "url": "http://h/web",
             "headers": {"Authorization": "secret"},
+        },
+        "local": {
+            "command": "/bin/server",
+            "args": ["--stdio"],
+            "env": {"TOKEN": "secret"},
         },
     }
     assert json.loads(mcp.dump_mcp_servers(servers)) == {
@@ -50,8 +56,25 @@ def test_load_mcp_servers(monkeypatch):
                 "url": "http://h/web",
                 "headers": {"Authorization": "secret"},
             },
+            "local": {
+                "command": "/bin/server",
+                "args": ["--stdio"],
+                "env": {"TOKEN": "secret"},
+            },
         }
     }
+
+
+async def test_stdio_transport():
+    server = {
+        "command": sys.executable,
+        "args": [str(Path(__file__).parent / "fixtures" / "mcp_stdio.py")],
+        "env": {"TEST_PREFIX": "stdio"},
+    }
+    found = await mcp.discover_tools({"local": server})
+
+    assert list(found) == ["local_echo"]
+    assert await mcp.call_tool(server, "echo", {"text": "hello"}) == "stdio:hello"
 
 
 def test_skill_name():

--- a/uv.lock
+++ b/uv.lock
@@ -1,17 +1,27 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/93/396d02c91b387b2678f23081869ca47bd495fc6c78789022c683180cf5f1/agent_client_protocol-0.11.0.tar.gz", hash = "sha256:8920a3b27bdcc852fd7c73066f47ab53257dbfbe57b505e20a40c69f80a5391c", size = 87402, upload-time = "2026-07-05T17:07:56.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/48/a1367dded7765f5489f9840389949d5aeac53a73aeb1b4e6c0ab61e1617a/agent_client_protocol-0.11.0-py3-none-any.whl", hash = "sha256:2d8570cd4911f8af9fbab4808f7b05f09204a756f346c7409ecdcae3f37cdb2f", size = 68089, upload-time = "2026-07-05T17:07:55.518Z" },
 ]
 
 [[package]]
@@ -448,7 +458,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -577,20 +587,21 @@ name = "ipython"
 version = "8.39.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -603,21 +614,20 @@ version = "9.10.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version == '3.11.*'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version == '3.11.*'" },
-    { name = "jedi", marker = "python_full_version == '3.11.*'" },
-    { name = "matplotlib-inline", marker = "python_full_version == '3.11.*'" },
-    { name = "pexpect", marker = "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "stack-data", marker = "python_full_version == '3.11.*'" },
-    { name = "traitlets", marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -630,23 +640,21 @@ version = "9.12.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -658,7 +666,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1009,7 +1017,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -1075,14 +1084,11 @@ version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -1192,13 +1198,14 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1257,19 +1264,16 @@ version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -1336,7 +1340,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1721,9 +1725,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
     { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
     { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
-    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -1898,6 +1899,7 @@ name = "rlm"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "beautifulsoup4" },
     { name = "httpx" },
     { name = "ipykernel" },
@@ -1930,6 +1932,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-client-protocol", specifier = "==0.11.0" },
     { name = "beautifulsoup4" },
     { name = "httpx" },
     { name = "ipykernel" },
@@ -1962,7 +1965,8 @@ name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
@@ -2088,14 +2092,11 @@ version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [
@@ -2187,35 +2188,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
     { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
     { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
-    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
-    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
-    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
-    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
-    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
-    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
-    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
-    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
-    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
-    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
     { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
     { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
     { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
@@ -2260,10 +2232,11 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2320,17 +2293,14 @@ version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2625,8 +2595,8 @@ name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
-    { name = "h11", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }


### PR DESCRIPTION
## Summary

- expose `rlm --acp` as a native ACP stdio agent
- retain model conversation and the live IPython kernel across repeated `session/prompt` calls
- support text prompts, reusable cancellation, `session/close`, and stdio or streamable HTTP MCP servers
- propagate HTTP headers and stdio environment variables without writing credentials into generated skill modules
- add a persistent `RLMEngine.prompt()` / `close()` lifecycle while preserving one-shot `run()`

RLM intentionally does not advertise `session/load`: an arbitrary live Python kernel cannot be reconstructed after the ACP process exits, so the client must keep the agent process alive for the session lifetime.

## Test plan

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/` (99 passed)
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .`
- real ACP stdio lifecycle, stdio MCP discovery/invocation, kernel persistence, cancellation recovery/reuse, queued-prompt exclusion during close, and failed-start cleanup covered by `tests/test_acp.py` and `tests/test_mcp.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New long-lived session semantics, cancellation/rollback paths, and MCP credential handling via env affect integration clients and harnesses; well covered by new tests but behavior changes are non-trivial for hosts relying on one-shot `run()`.
> 
> **Overview**
> Adds **`rlm --acp`**, a stdio [Agent Client Protocol](https://agentclientprotocol.com/) agent backed by **`RLMACPAgent`**: one session maps to one **`RLMEngine`**, with **`session/prompt`**, **cancel**, and **`session/close`** (no **`session/load`**). MCP servers from the client are mapped to HTTP (with optional headers) or stdio.
> 
> **`RLMEngine`** gains a **multi-turn lifecycle**: **`prompt()`** keeps the message history and IPython kernel between turns; **`run()`** still runs one shot then **`close()`**. Failed or cancelled turns **roll back** resumable conversation state (with **`prompt_rollback`** logging) while tool/kernel side effects may remain; cancellation **interrupts** in-flight tools and the REPL.
> 
> **MCP** config is no longer URL-only: **`RLM_MCP_CONFIG`** / **`mcp_servers`** support **stdio** servers and **HTTP headers**; generated skills resolve servers from env (not embedded URLs). The kernel receives serialized MCP config via **`RLM_MCP_CONFIG`**.
> 
> Dependency: **`agent-client-protocol==0.11.0`**; Python **`>=3.10,<3.15`**. README and tests cover ACP lifecycle, persistence, cancel/retry, and stdio MCP round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b343953bc451f8f7061ab65f162438b1d313d2df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

