### PR TITLE
feat: RLM_MAX_COMPACTIONS cap on auto-compaction

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -168,6 +168,12 @@ class RLMEngine:
             env_value = summarize_at_tokens
         self.summarize_at_tokens = _parse_summarize_at_tokens(env_value)
 
+        # Cap on auto-compactions (RLM_MAX_COMPACTIONS): once reached, the branch is
+        # never compacted again and the context grows to the model's natural limit.
+        # Unset or <= 0 means unlimited.
+        _max_compactions = int(os.environ.get("RLM_MAX_COMPACTIONS", "0"))
+        self.max_compactions = _max_compactions if _max_compactions > 0 else None
+
         self.system_prompt_path = system_prompt_path or os.environ.get(
             "RLM_SYSTEM_PROMPT_PATH"
         )
@@ -402,10 +408,16 @@ class RLMEngine:
             # Auto-compaction: if this turn's prompt_tokens reached the
             # configured threshold, ask the model for a handoff summary and
             # rebuild the branch around it. Fires at most once per loop
-            # iteration; the compaction op takes its own LLM call.
+            # iteration; the compaction op takes its own LLM call. A
+            # max_compactions cap, once hit, disables further compaction so
+            # the context grows to the model's natural limit.
             if (
                 self.summarize_at_tokens is not None
                 and usage.prompt_tokens >= self.summarize_at_tokens
+                and (
+                    self.max_compactions is None
+                    or self._metrics.num_compactions < self.max_compactions
+                )
             ):
                 try:
                     await self._compact_branch(messages, turn, active_tools)


### PR DESCRIPTION
Adds an `RLM_MAX_COMPACTIONS` env var: once a branch has compacted that many times, auto-compaction disables and the context grows to the model's natural limit — restoring the context-length stop that `RLM_SUMMARIZE_AT_TOKENS` otherwise removes (unbounded recompaction converts trained persistence into wall-clock timeouts on evals). Unset or `<= 0` keeps current unlimited behavior. Gates on the existing `RLMMetrics.num_compactions` counter.

Companion verifiers PR plumbs a `max_compactions` harness config field through to this env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change to the agent loop’s compaction policy; no auth, data, or API surface changes beyond env configuration.
> 
> **Overview**
> Adds **`RLM_MAX_COMPACTIONS`** so auto-compaction can stop after a fixed number of rounds per branch. **`RLMEngine`** reads the env var at init (`<= 0` or unset → unlimited, same as today).
> 
> The existing auto-compaction gate in **`_run_loop`** now also requires **`num_compactions < max_compactions`** before calling **`_compact_branch`**. After the cap is hit, context is no longer summarized at **`RLM_SUMMARIZE_AT_TOKENS`** and can grow until the model or request limits apply—addressing unbounded recompaction on long evals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2af32c59b7bd9e2b384b896337e98368259360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->