### PR TITLE
fix: use IPC transport for the IPython kernel

### DIFF
--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -146,12 +146,9 @@ class IPythonREPL:
         """Start the IPython kernel."""
         from jupyter_client import KernelManager
 
-        # IPC (Unix domain sockets) instead of the default TCP: kernel and
-        # client are always on the same host, and ipykernel >= 7.3 warns
-        # about unencrypted TCP transport. The socket path must be absolute
-        # (a relative path resolves against each process's own cwd) and
-        # short (macOS caps Unix socket paths at 104 bytes), so use a
-        # dedicated temp dir rather than the session dir.
+        # IPC instead of the default TCP (ipykernel >= 7.3 warns about
+        # unencrypted TCP). The socket path must be absolute and short
+        # (macOS caps Unix socket paths at 104 bytes), hence a temp dir.
         self._ipc_dir = tempfile.mkdtemp(prefix="rlm-ipc-")
         self._km = KernelManager(
             transport="ipc", ip=os.path.join(self._ipc_dir, "kernel")

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -6,7 +6,9 @@ import copy
 import os
 from queue import Empty
 import re
+import shutil
 import sys
+import tempfile
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -136,6 +138,7 @@ class IPythonREPL:
         self.env = env or {}
         self._km = None
         self._kc = None
+        self._ipc_dir = None
         self._lock = threading.Lock()
         self._interrupt_requested = threading.Event()
 
@@ -143,7 +146,16 @@ class IPythonREPL:
         """Start the IPython kernel."""
         from jupyter_client import KernelManager
 
-        self._km = KernelManager()
+        # IPC (Unix domain sockets) instead of the default TCP: kernel and
+        # client are always on the same host, and ipykernel >= 7.3 warns
+        # about unencrypted TCP transport. The socket path must be absolute
+        # (a relative path resolves against each process's own cwd) and
+        # short (macOS caps Unix socket paths at 104 bytes), so use a
+        # dedicated temp dir rather than the session dir.
+        self._ipc_dir = tempfile.mkdtemp(prefix="rlm-ipc-")
+        self._km = KernelManager(
+            transport="ipc", ip=os.path.join(self._ipc_dir, "kernel")
+        )
         self._km.kernel_spec.argv = [
             sys.executable,
             "-m",
@@ -354,3 +366,6 @@ if {allow_recursion!r}:
         if self._km:
             self._km.shutdown_kernel(now=True)
             self._km = None
+        if self._ipc_dir:
+            shutil.rmtree(self._ipc_dir, ignore_errors=True)
+            self._ipc_dir = None


### PR DESCRIPTION
## Summary
- Switch the `IPythonREPL` `KernelManager` from the default TCP transport to IPC (Unix domain sockets). ipykernel ≥ 7.3 logs a warning on every kernel start when ZMQ is bound over TCP without CurveZMQ keys ("Kernel is running over TCP without encryption ... susceptible to eavesdropping"); kernel and client always run on the same host, so IPC is the native fix and removes the loopback-TCP surface entirely.
- Pass an explicit absolute socket path: jupyter_client's default IPC path is the relative `kernel-ipc`, which kernel and client resolve against their own (different) working directories, so they never connect and startup hangs.
- Place the sockets in a dedicated short temp dir (`rlm-ipc-*`) rather than the session dir, since macOS caps Unix socket paths at 104 bytes; the dir is removed in `shutdown()`.

## Verification
Before (ipykernel 7.3.0, TCP): every kernel start logs
`[IPKernelApp] WARNING | Kernel is running over TCP without encryption. ...`

After (ipykernel 7.3.0, IPC): no warning; execute, kernel restart, and shutdown cleanup verified end-to-end. Full test suite passes (`uv run pytest tests/`, 100 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local-only transport change for the co-located Jupyter kernel with cleanup on shutdown; no auth, data, or API surface changes.
> 
> **Overview**
> **`IPythonREPL`** now starts **`KernelManager`** with **`transport="ipc"`** and an absolute socket under a dedicated **`rlm-ipc-*`** temp directory, instead of the default loopback TCP binding that triggers ipykernel ≥7.3 unencrypted-TCP warnings.
> 
> The explicit path avoids the default relative **`kernel-ipc`** name, which kernel and client resolve from different working directories and can hang startup. **`shutdown()`** removes the IPC temp dir via **`shutil.rmtree`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322392d8c2fe1236903fba3c15ffe734855b5799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->