### PR TITLE
Isolate IPython kernel output from ACP stdio

### DIFF
--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -7,6 +7,7 @@ import os
 from queue import Empty
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import threading
@@ -160,7 +161,12 @@ class IPythonREPL:
             "-f",
             "{connection_file}",
         ]
-        self._km.start_kernel(cwd=self.cwd, env={**os.environ, **self.env})
+        self._km.start_kernel(
+            cwd=self.cwd,
+            env={**os.environ, **self.env},
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         self._kc = self._km.client()
         self._kc.start_channels()
         self._kc.wait_for_ready(timeout=30)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -70,3 +70,25 @@ async def test_tool_raises(session):
 
     with pytest.raises(RuntimeError, match="boom"):
         await engine.run(prompt)
+
+
+def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
+    """Kernel writes outside IOPub must not corrupt an enclosing ACP transport."""
+    from rlm.tools.ipython import IPythonREPL
+
+    repl = IPythonREPL(cwd=str(session.dir), session=session)
+    repl.start()
+    try:
+        result = repl.execute(
+            "import os; "
+            "stdout_written = os.write(1, b'123\\n'); "
+            "stderr_written = os.write(2, b'kernel stderr\\n'); "
+            "print(stdout_written, stderr_written)"
+        )
+    finally:
+        repl.shutdown()
+
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert result.strip() == "4 14"


### PR DESCRIPTION
## Problem

When RLM runs over ACP, its stdout is the JSON-RPC transport. The IPython kernel currently inherits that descriptor, so a raw write from the kernel or one of its child processes can enter the ACP stream.

A payload such as `123\n` is valid JSON but not a JSON-RPC object. The ACP receive loop parses it as an integer, fails when it calls `.get()`, and rejects the active prompt with `ConnectionError: Connection closed` while the RLM process keeps running.

## Fix

Start the IPython kernel with stdout and stderr redirected to `DEVNULL`. Normal cell output still reaches RLM over Jupyter IOPub; only writes that bypass Jupyter are discarded.

## Reproduction

On current `main`, start a real `IPythonREPL` under an ACP agent and execute:

```python
import os
os.write(1, b"123\n")
```

The inherited fd writes `123\n` into ACP stdout. A pending `session/prompt` then fails with:

```text
AttributeError: 'int' object has no attribute 'get'
ConnectionError: Connection closed
```

The regression test exercises the same low-level stdout and stderr writes and verifies that neither reaches the parent process while normal `print()` output remains available through IOPub.

## Verification

- `uv run pytest` — 101 passed
- `uv run ruff check src tests`
- `uv build`
- Actual Verifiers ACP runner reproduction: fails with `Connection closed` before this patch and returns `done` after it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to kernel subprocess startup; normal tool output path is unchanged via IOPub.
> 
> **Overview**
> **Prevents IPython kernel processes from writing to the parent’s stdout/stderr**, which breaks ACP when RLM’s stdout is the JSON-RPC stream.
> 
> `IPythonREPL.start()` now passes `stdout=subprocess.DEVNULL` and `stderr=subprocess.DEVNULL` into `KernelManager.start_kernel()`. Cell output still flows through Jupyter IOPub; only raw fd writes that bypass Jupyter are dropped.
> 
> Adds `test_ipython_kernel_does_not_inherit_parent_stdio`, which runs low-level `os.write` on fds 1 and 2 and asserts the parent captures nothing while normal `print()` output still comes back through the REPL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3618ec41559f5c5853779e139d02ce592ddfedba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->