### PR TITLE
fix: preserve recursive sub-agent metrics and PTC counts

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -340,7 +340,6 @@ class RLMEngine:
             prompt_preview=prompt[:200],
             cwd=self.cwd,
         )
-        self.session.checkpoint_metrics(self._metrics)
 
         # Skills the kernel pre-imports, all written into the session dir (the REPL and prompt
         # read them back from there): enabled built-in skills (rlm.skills) + any wired MCP tools
@@ -518,7 +517,6 @@ class RLMEngine:
                     if settled_result is not None:
                         for event in settled_result.metric_events:
                             self._metrics.record(event)
-                        self.session.checkpoint_metrics(self._metrics)
                     raise
             duration = time.time() - t0
             for event in tool_result.metric_events:
@@ -540,8 +538,6 @@ class RLMEngine:
 
             # Detect new child sessions spawned via rlm()
             self._detect_new_children()
-
-            self.session.checkpoint_metrics(self._metrics)
 
             # Auto-compaction: if this turn's prompt_tokens reached the
             # configured threshold, ask the model for a handoff summary and
@@ -599,7 +595,6 @@ class RLMEngine:
                     metrics=self._metrics,
                 )
             else:
-                self.session.checkpoint_metrics(self._metrics, status="incomplete")
                 self.session.close()
 
     async def _compact_branch(
@@ -685,7 +680,6 @@ class RLMEngine:
         )
         self._branch_start_turn = turn + 1
         self._metrics.turns_since_last_compaction = 0
-        self.session.checkpoint_metrics(self._metrics)
 
     def _load_system_prompt(
         self, messages_path: str, active_tools: list[BuiltinTool]

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -32,6 +32,7 @@ from rlm.tools import (
     discover_skills,
     get_active_builtin_tools,
     get_builtin_tool,
+    get_installed_skills,
 )
 from rlm.types import CompactionApplied, RLMMetrics, RLMResult, TokenUsage
 
@@ -259,12 +260,18 @@ class RLMEngine:
         if self._closed:
             raise RuntimeError("RLM engine is closed")
 
-        # Check depth limit
         if self.depth > self.max_depth:
+            answer = f"[depth limit {self.max_depth} reached, cannot start]"
+            self._metrics.stop_reason = "depth_limit"
+            self._last_answer = answer
+            self._has_result = True
             return RLMResult(
-                answer=f"[depth limit {self.max_depth} reached, cannot start]",
+                answer=answer,
                 turns=0,
+                session_dir=self.session.dir if self.session is not None else None,
             )
+
+        self._has_result = False
 
         if not self._started:
             await self._start(prompt)
@@ -333,6 +340,7 @@ class RLMEngine:
             prompt_preview=prompt[:200],
             cwd=self.cwd,
         )
+        self.session.checkpoint_metrics(self._metrics)
 
         # Skills the kernel pre-imports, all written into the session dir (the REPL and prompt
         # read them back from there): enabled built-in skills (rlm.skills) + any wired MCP tools
@@ -487,12 +495,13 @@ class RLMEngine:
                     tool_result = await asyncio.shield(tool_task)
                 except asyncio.CancelledError:
                     repl = self._repl
+                    settled_result = None
                     if repl is not None:
                         repl.interrupt()
                     try:
                         while True:
                             try:
-                                await asyncio.shield(tool_task)
+                                settled_result = await asyncio.shield(tool_task)
                             except asyncio.CancelledError:
                                 if repl is not None:
                                     repl.interrupt()
@@ -506,6 +515,10 @@ class RLMEngine:
                     finally:
                         if repl is not None:
                             repl.finish_interrupt()
+                    if settled_result is not None:
+                        for event in settled_result.metric_events:
+                            self._metrics.record(event)
+                        self.session.checkpoint_metrics(self._metrics)
                     raise
             duration = time.time() - t0
             for event in tool_result.metric_events:
@@ -528,9 +541,6 @@ class RLMEngine:
             # Detect new child sessions spawned via rlm()
             self._detect_new_children()
 
-            # Checkpoint metrics every turn: finalize() only runs on a clean
-            # exit, so without this a rollout killed mid-run (harness RPC
-            # failure, timeout, SIGKILL) loses the whole metric family.
             self.session.checkpoint_metrics(self._metrics)
 
             # Auto-compaction: if this turn's prompt_tokens reached the
@@ -571,28 +581,26 @@ class RLMEngine:
         if self._closed:
             return
         self._closed = True
-        try:
-            if self.session is not None:
-                if self._has_result:
-                    self.session.finalize(
-                        self._last_answer,
-                        usage={
-                            "prompt_tokens": self._total_usage.prompt_tokens,
-                            "completion_tokens": self._total_usage.completion_tokens,
-                        },
-                        turns=self._turn,
-                        metrics=self._metrics,
-                    )
-                else:
-                    # No result — persist whatever metrics accumulated before
-                    # closing, marked incomplete, instead of dropping them.
-                    self.session.checkpoint_metrics(
-                        self._metrics, status="incomplete"
-                    )
-                    self.session.close()
-        finally:
-            if self._repl is not None:
+        if self._repl is not None:
+            try:
                 self._repl.shutdown()
+            except Exception:
+                logger.warning("rlm: failed to stop IPython kernel", exc_info=True)
+            self._repl = None
+        if self.session is not None:
+            if self._has_result:
+                self.session.finalize(
+                    self._last_answer,
+                    usage={
+                        "prompt_tokens": self._total_usage.prompt_tokens,
+                        "completion_tokens": self._total_usage.completion_tokens,
+                    },
+                    turns=self._turn,
+                    metrics=self._metrics,
+                )
+            else:
+                self.session.checkpoint_metrics(self._metrics, status="incomplete")
+                self.session.close()
 
     async def _compact_branch(
         self, messages: list[dict], turn: int, active_tools: list[dict]
@@ -618,7 +626,7 @@ class RLMEngine:
         # checkpoint prompt — otherwise the prompt's own chars get
         # counted as "dropped conversation content", inflating the
         # metric and the session log's dropped_chars field.
-        dropped_chars = _count_messages_chars(messages[2:])
+        dropped_chars = _count_messages_chars(messages[1:])
         turns_since_last = turn + 1 - self._branch_start_turn
 
         # Append the checkpoint prompt and ask the model for a text-only
@@ -677,6 +685,7 @@ class RLMEngine:
         )
         self._branch_start_turn = turn + 1
         self._metrics.turns_since_last_compaction = 0
+        self.session.checkpoint_metrics(self._metrics)
 
     def _load_system_prompt(
         self, messages_path: str, active_tools: list[BuiltinTool]
@@ -690,6 +699,7 @@ class RLMEngine:
             messages_path,
             allow_recursion=self.depth < self.max_depth,
             active_tools=active_tools,
+            cli_skills=get_installed_skills(),
         )
         if self.append_to_system_prompt:
             system_prompt += "\n\n" + self.append_to_system_prompt

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -528,6 +528,11 @@ class RLMEngine:
             # Detect new child sessions spawned via rlm()
             self._detect_new_children()
 
+            # Checkpoint metrics every turn: finalize() only runs on a clean
+            # exit, so without this a rollout killed mid-run (harness RPC
+            # failure, timeout, SIGKILL) loses the whole metric family.
+            self.session.checkpoint_metrics(self._metrics)
+
             # Auto-compaction: if this turn's prompt_tokens reached the
             # configured threshold, ask the model for a handoff summary and
             # rebuild the branch around it. Fires at most once per loop
@@ -579,6 +584,11 @@ class RLMEngine:
                         metrics=self._metrics,
                     )
                 else:
+                    # No result — persist whatever metrics accumulated before
+                    # closing, marked incomplete, instead of dropping them.
+                    self.session.checkpoint_metrics(
+                        self._metrics, status="incomplete"
+                    )
                     self.session.close()
         finally:
             if self._repl is not None:

--- a/src/rlm/mcp.py
+++ b/src/rlm/mcp.py
@@ -128,7 +128,14 @@ async def discover_tools(
         async with _client_session(spec, cwd) as session:
             await session.initialize()
             for tool in (await session.list_tools()).tools:
-                found[_skill_name(server, tool.name)] = (server, tool)
+                skill_name = _skill_name(server, tool.name)
+                if skill_name in found:
+                    previous_server, previous_tool = found[skill_name]
+                    raise ValueError(
+                        f"MCP tool name collision for {skill_name!r}: "
+                        f"{previous_server}.{previous_tool.name} and {server}.{tool.name}"
+                    )
+                found[skill_name] = (server, tool)
     return found
 
 

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -88,6 +88,7 @@ def build_system_prompt(
     *,
     allow_recursion: bool,
     active_tools: list[BuiltinTool],
+    cli_skills: list[str] | None = None,
 ) -> str:
     """Build the system prompt.
 
@@ -119,10 +120,12 @@ def build_system_prompt(
             "Each skill is an async function by the same name. "
             "Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`."
         )
-        skill_lines.append(
-            "Each skill is also available as a shell command by the same name: `<skill> ...`. "
-            "Discover its CLI usage with `<skill> --help`."
-        )
+        if cli_skills:
+            commands = ", ".join(f"`{skill}`" for skill in cli_skills)
+            skill_lines.append(
+                f"Skills with shell commands: {commands}. "
+                "Discover CLI usage with `<skill> --help`."
+            )
         if "edit" in installed_skills:
             skill_lines.append(EDIT_SKILL_PROMPT)
         if "search" in installed_skills:

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -68,16 +68,24 @@ class Session:
         self.log({"type": "sub_spawn", "child_dir": child_name, "command": command})
 
     def aggregate_child_metrics(self) -> ChildSessionAggregate:
-        """Walk sub-*/meta.json and bundle their programmatic tool-call stats."""
+        """Aggregate programmatic tool-call stats across all recursive descendants.
+
+        Counts from each descendant's per-call ``programmatic_tool_calls.jsonl``
+        rather than its ``meta.json``: meta stats are only written by a child's
+        own ``finalize()``, so a sub-agent that never completes (parent rollout
+        ended first, ``asyncio.gather`` cancelled, crash) would silently drop
+        every call it made. The per-call log is appended from inside the kernel
+        wrapper and survives any exit; ``from_log`` already tolerates
+        partially-written lines.
+        """
         aggregate = ChildSessionAggregate()
-        for child_dir in self.dir.glob("sub-*"):
-            meta_path = child_dir / "meta.json"
-            try:
-                with open(meta_path) as f:
-                    meta = json.load(f)
-            except FileNotFoundError:
-                continue
-            aggregate.absorb(ProgrammaticToolCallStats.from_meta(meta))
+        for child_dir in sorted(p for p in self.dir.rglob("sub-*") if p.is_dir()):
+            aggregate.num_sessions += 1
+            aggregate.absorb(
+                ProgrammaticToolCallStats.from_log(
+                    child_dir / "programmatic_tool_calls.jsonl"
+                )
+            )
         return aggregate
 
     def finalize(
@@ -94,21 +102,38 @@ class Session:
         if usage:
             meta_update["usage"] = usage
         if metrics is not None:
-            direct_tool_stats = ProgrammaticToolCallStats.from_log(
-                self.dir / "programmatic_tool_calls.jsonl"
-            )
-            child = self.aggregate_child_metrics()
-
-            metrics.apply_programmatic_tool_call_stats(
-                direct_tool_stats, child.tool_call_stats
-            )
-
-            meta_update["metrics"] = metrics.to_dict()
-            meta_update["programmatic_tool_call_stats"] = direct_tool_stats.merge(
-                child.tool_call_stats
-            ).to_dict()
+            meta_update.update(self._metrics_meta(metrics))
         self.write_meta(**meta_update)
         self._msg_file.close()
+
+    def _metrics_meta(self, metrics) -> dict:
+        """Assemble the metrics fields for meta.json from live stats on disk."""
+        direct_tool_stats = ProgrammaticToolCallStats.from_log(
+            self.dir / "programmatic_tool_calls.jsonl"
+        )
+        child = self.aggregate_child_metrics()
+        metrics.apply_programmatic_tool_call_stats(
+            direct_tool_stats, child.tool_call_stats, child.num_sessions
+        )
+        return {
+            "metrics": metrics.to_dict(),
+            "programmatic_tool_call_stats": direct_tool_stats.merge(
+                child.tool_call_stats
+            ).to_dict(),
+        }
+
+    def checkpoint_metrics(self, metrics, status: str | None = None) -> None:
+        """Persist current metrics to meta.json mid-run.
+
+        Called once per turn so a rollout killed at any point (harness RPC
+        failure, timeout, SIGKILL) still leaves its latest metrics on disk —
+        ``finalize()`` only runs on a clean exit, which is exactly when
+        metrics are least at risk.
+        """
+        meta_update = self._metrics_meta(metrics)
+        if status is not None:
+            meta_update["status"] = status
+        self.write_meta(**meta_update)
 
     @staticmethod
     def child_dir(parent_dir: Path | str) -> Path:

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -68,16 +68,7 @@ class Session:
         self.log({"type": "sub_spawn", "child_dir": child_name, "command": command})
 
     def aggregate_child_metrics(self) -> ChildSessionAggregate:
-        """Aggregate programmatic tool-call stats across all recursive descendants.
-
-        Counts from each descendant's per-call ``programmatic_tool_calls.jsonl``
-        rather than its ``meta.json``: meta stats are only written by a child's
-        own ``finalize()``, so a sub-agent that never completes (parent rollout
-        ended first, ``asyncio.gather`` cancelled, crash) would silently drop
-        every call it made. The per-call log is appended from inside the kernel
-        wrapper and survives any exit; ``from_log`` already tolerates
-        partially-written lines.
-        """
+        """Aggregate call logs across all recursive descendant sessions."""
         aggregate = ChildSessionAggregate()
         for child_dir in sorted(p for p in self.dir.rglob("sub-*") if p.is_dir()):
             aggregate.num_sessions += 1
@@ -123,13 +114,7 @@ class Session:
         }
 
     def checkpoint_metrics(self, metrics, status: str | None = None) -> None:
-        """Persist current metrics to meta.json mid-run.
-
-        Called once per turn so a rollout killed at any point (harness RPC
-        failure, timeout, SIGKILL) still leaves its latest metrics on disk —
-        ``finalize()`` only runs on a clean exit, which is exactly when
-        metrics are least at risk.
-        """
+        """Persist a recoverable snapshot of current metrics to meta.json."""
         meta_update = self._metrics_meta(metrics)
         if status is not None:
             meta_update["status"] = status

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -113,13 +113,6 @@ class Session:
             ).to_dict(),
         }
 
-    def checkpoint_metrics(self, metrics, status: str | None = None) -> None:
-        """Persist a recoverable snapshot of current metrics to meta.json."""
-        meta_update = self._metrics_meta(metrics)
-        if status is not None:
-            meta_update["status"] = status
-        self.write_meta(**meta_update)
-
     @staticmethod
     def child_dir(parent_dir: Path | str) -> Path:
         """Create and return a new child session directory under parent_dir."""

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -161,9 +161,15 @@ class IPythonREPL:
             "-f",
             "{connection_file}",
         ]
+        kernel_env = {**os.environ, **self.env}
+        launcher = shutil.which(sys.argv[0]) or os.path.abspath(sys.argv[0])
+        launcher_dir = os.path.dirname(os.path.abspath(launcher))
+        path_entries = kernel_env.get("PATH", "").split(os.pathsep)
+        if launcher_dir not in path_entries:
+            kernel_env["PATH"] = os.pathsep.join([launcher_dir, *path_entries])
         self._km.start_kernel(
             cwd=self.cwd,
-            env={**os.environ, **self.env},
+            env=kernel_env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )

--- a/src/rlm/tools/skills.py
+++ b/src/rlm/tools/skills.py
@@ -36,14 +36,13 @@ def get_installed_skills() -> list[str]:
 
 
 def discover_skills(session_dir: Path | None = None) -> list[str]:
-    """All skill module names the kernel should pre-import — from two sources.
-
-    Pip-installed ``rlm-skill-*`` distributions are found via distribution metadata, so they
-    resolve wherever they were installed from (``/task/rlm-skills``, the test venv, ...) and
-    keep their shell CLIs. MCP tool skills are flat modules generated into ``session_dir``
-    (see ``rlm.mcp``); these can't be discovered the same way, so the dir is walked directly.
-    """
-    skills = get_installed_skills()
-    if session_dir is not None:
-        skills += list_skill_modules(session_dir)
-    return skills
+    """Return unambiguous installed and session-local skill module names."""
+    installed = get_installed_skills()
+    generated = list_skill_modules(session_dir) if session_dir is not None else []
+    collisions = sorted(set(installed) & set(generated))
+    if collisions:
+        names = ", ".join(collisions)
+        raise ValueError(
+            f"skill name collision between installed and generated: {names}"
+        )
+    return [*installed, *generated]

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -117,6 +117,8 @@ class ChildSessionAggregate:
     tool_call_stats: ProgrammaticToolCallStats = field(
         default_factory=ProgrammaticToolCallStats
     )
+    num_sessions: int = 0
+    """Recursive count of descendant sub-agent sessions (spawned via rlm())."""
 
     def absorb(self, tool_stats: ProgrammaticToolCallStats) -> None:
         """Combine a child session's stats into this aggregate."""
@@ -152,6 +154,7 @@ class RLMMetrics:
     # they run within a single tool call and never reach the API proxy).
     num_ptc_calls_python: int = 0
     num_ptc_calls_bash: int = 0
+    sub_rlm_num_calls: int = 0
     sub_rlm_num_ptc_calls_python: int = 0
     sub_rlm_num_ptc_calls_bash: int = 0
 
@@ -170,9 +173,11 @@ class RLMMetrics:
         self,
         direct: ProgrammaticToolCallStats,
         child: ProgrammaticToolCallStats,
+        num_child_sessions: int = 0,
     ) -> None:
         self.num_ptc_calls_python = direct.python_total
         self.num_ptc_calls_bash = direct.bash_total
+        self.sub_rlm_num_calls = num_child_sessions
         self.sub_rlm_num_ptc_calls_python = child.python_total
         self.sub_rlm_num_ptc_calls_bash = child.bash_total
 

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -38,7 +38,7 @@ BuiltinMetricEvent = IpythonExecuted | CompactionApplied
 
 @dataclass
 class ProgrammaticToolCallStats:
-    """Programmatic tool-call counts (skill CLIs invoked from the ipython REPL)."""
+    """Programmatic tool-call invocation attempts from the IPython REPL."""
 
     python_total: int = 0
     bash_total: int = 0
@@ -62,6 +62,8 @@ class ProgrammaticToolCallStats:
                 try:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
                     continue
                 tool = entry.get("tool")
                 source = entry.get("source")
@@ -158,7 +160,7 @@ class RLMMetrics:
     sub_rlm_num_ptc_calls_python: int = 0
     sub_rlm_num_ptc_calls_bash: int = 0
 
-    stop_reason: str = ""  # "done", "token_budget", "request_too_large", "cancelled"
+    stop_reason: str = ""
 
     # Internal counters for derived metrics
     _ipython_call_count: int = field(default=0, repr=False)

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -155,30 +155,7 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
     ]
 
 
-async def test_engine_checkpoints_metrics_before_first_model_response(session):
-    client = DummyClient([])
-    prompt_started = asyncio.Event()
-
-    async def block_prompt(**kwargs):
-        prompt_started.set()
-        await asyncio.Future()
-
-    client.create = block_prompt
-    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
-    pending = asyncio.create_task(engine.prompt("wait"))
-    await prompt_started.wait()
-
-    meta = json.loads((Path(session.dir) / "meta.json").read_text())
-    assert meta["status"] == "running"
-    assert meta["metrics"]["num_ptc_calls_python"] == 0
-
-    pending.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await pending
-    engine.close()
-
-
-async def test_latest_cancelled_prompt_finalizes_as_incomplete(session):
+async def test_latest_cancelled_prompt_does_not_finalize_prior_result(session):
     client = DummyClient([DummyMessage(content="first")])
     engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
     await engine.prompt("one")
@@ -198,8 +175,8 @@ async def test_latest_cancelled_prompt_finalizes_as_incomplete(session):
     engine.close()
 
     meta = json.loads((Path(session.dir) / "meta.json").read_text())
-    assert meta["status"] == "incomplete"
-    assert meta["metrics"]["stop_reason"] == "cancelled"
+    assert meta["status"] == "running"
+    assert "answer_preview" not in meta
 
 
 async def test_depth_limit_is_a_completed_result(monkeypatch, session):
@@ -216,7 +193,7 @@ async def test_depth_limit_is_a_completed_result(monkeypatch, session):
     assert meta["metrics"]["stop_reason"] == "depth_limit"
 
 
-async def test_compaction_counts_seed_and_checkpoints_immediately(session):
+async def test_compaction_counts_seed_prompt(session):
     client = DummyClient([DummyMessage(content="summary")])
     engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
     messages = [
@@ -227,14 +204,11 @@ async def test_compaction_counts_seed_and_checkpoints_immediately(session):
 
     try:
         await engine._compact_branch(messages, turn=0, active_tools=[])
-        meta = json.loads((Path(session.dir) / "meta.json").read_text())
     finally:
         engine.close()
 
-    assert meta["metrics"]["num_compactions"] == 1
-    assert meta["metrics"]["compaction_chars_dropped_mean"] == len(
-        "original promptwork"
-    )
+    assert engine._metrics.num_compactions == 1
+    assert engine._metrics.compaction_chars_dropped_mean == len("original promptwork")
 
 
 async def test_engine_failed_prompt_can_be_retried(session):

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -155,6 +155,88 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
     ]
 
 
+async def test_engine_checkpoints_metrics_before_first_model_response(session):
+    client = DummyClient([])
+    prompt_started = asyncio.Event()
+
+    async def block_prompt(**kwargs):
+        prompt_started.set()
+        await asyncio.Future()
+
+    client.create = block_prompt
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+    pending = asyncio.create_task(engine.prompt("wait"))
+    await prompt_started.wait()
+
+    meta = json.loads((Path(session.dir) / "meta.json").read_text())
+    assert meta["status"] == "running"
+    assert meta["metrics"]["num_ptc_calls_python"] == 0
+
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    engine.close()
+
+
+async def test_latest_cancelled_prompt_finalizes_as_incomplete(session):
+    client = DummyClient([DummyMessage(content="first")])
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+    await engine.prompt("one")
+
+    prompt_started = asyncio.Event()
+
+    async def block_prompt(**kwargs):
+        prompt_started.set()
+        await asyncio.Future()
+
+    client.create = block_prompt
+    pending = asyncio.create_task(engine.prompt("two"))
+    await prompt_started.wait()
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    engine.close()
+
+    meta = json.loads((Path(session.dir) / "meta.json").read_text())
+    assert meta["status"] == "incomplete"
+    assert meta["metrics"]["stop_reason"] == "cancelled"
+
+
+async def test_depth_limit_is_a_completed_result(monkeypatch, session):
+    monkeypatch.setenv("RLM_DEPTH", "1")
+    monkeypatch.setenv("RLM_MAX_DEPTH", "0")
+    client = DummyClient([])
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+
+    result = await engine.run("too deep")
+
+    meta = json.loads((Path(session.dir) / "meta.json").read_text())
+    assert result.answer == "[depth limit 0 reached, cannot start]"
+    assert meta["status"] == "done"
+    assert meta["metrics"]["stop_reason"] == "depth_limit"
+
+
+async def test_compaction_counts_seed_and_checkpoints_immediately(session):
+    client = DummyClient([DummyMessage(content="summary")])
+    engine = RLMEngine(client=client, session=session)  # type: ignore[arg-type]
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "original prompt"},
+        {"role": "assistant", "content": "work"},
+    ]
+
+    try:
+        await engine._compact_branch(messages, turn=0, active_tools=[])
+        meta = json.loads((Path(session.dir) / "meta.json").read_text())
+    finally:
+        engine.close()
+
+    assert meta["metrics"]["num_compactions"] == 1
+    assert meta["metrics"]["compaction_chars_dropped_mean"] == len(
+        "original promptwork"
+    )
+
+
 async def test_engine_failed_prompt_can_be_retried(session):
     client = DummyClient(
         [
@@ -303,6 +385,7 @@ async def test_engine_cancelled_tool_recovers_kernel(session, tmp_path):
     ]
     assert result.answer == "continued"
     assert tool_messages[-1]["content"].strip() == "42"
+    assert engine._metrics._ipython_call_count == 2
 
 
 async def test_engine_failed_start_cleans_kernel_before_retry(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,9 +11,12 @@ import importlib
 import inspect
 import json
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 from mcp.types import Tool
+import pytest
 
 from rlm import mcp
 
@@ -95,6 +98,26 @@ def test_skill_name():
     assert mcp._skill_name("tools", "add_event") == "tools_add_event"
     assert mcp._skill_name("web", "search.run") == "web_search_run"
     assert mcp._skill_name("", "2fa") == "_2fa"
+
+
+async def test_discover_tools_rejects_normalized_name_collision(monkeypatch):
+    class FakeSession:
+        async def initialize(self):
+            pass
+
+        async def list_tools(self):
+            return SimpleNamespace(
+                tools=[Tool(name="search", description="", inputSchema={})]
+            )
+
+    @asynccontextmanager
+    async def fake_client_session(server, cwd=None):
+        yield FakeSession()
+
+    monkeypatch.setattr(mcp, "_client_session", fake_client_session)
+
+    with pytest.raises(ValueError, match="MCP tool name collision.*a_b_search"):
+        await mcp.discover_tools({"a-b": "one", "a_b": "two"})
 
 
 def test_build_signature():

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -22,6 +22,7 @@ def _prompt(
     active_tools: list[_Tool],
     *,
     installed_skills: list[str] | None = None,
+    cli_skills: list[str] | None = None,
 ) -> str:
     return build_system_prompt(
         "/repo",
@@ -30,6 +31,7 @@ def _prompt(
         "/repo/.rlm/messages.jsonl",
         allow_recursion=False,
         active_tools=active_tools,
+        cli_skills=cli_skills,
     )
 
 
@@ -90,3 +92,14 @@ def test_search_skill_prompt_included_only_when_search_is_installed():
     assert SEARCH_SKILL_PROMPT not in _prompt(
         [_Tool("ipython")], installed_skills=["search_docs"]
     )
+
+
+def test_only_cli_skills_are_advertised_as_shell_commands():
+    prompt = _prompt(
+        [_Tool("ipython")],
+        installed_skills=["installed", "generated"],
+        cli_skills=["installed"],
+    )
+
+    assert "Skills with shell commands: `installed`" in prompt
+    assert "`generated` --help" not in prompt

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -1,16 +1,9 @@
-"""Sub-agent metric aggregation + mid-run checkpointing (see PR: subagent metrics fix).
-
-Regression context: child stats used to be read from each child's meta.json, which
-only exists after the child's own finalize() — sub-agents cut off mid-run (parent
-rollout ended, gather cancelled, crash) silently contributed zero. And the parent's
-metrics only reached meta.json via finalize(), so a killed rollout lost the whole
-metric family.
-"""
+"""Sub-agent metric aggregation and recoverable metric snapshots."""
 
 import json
 
 from rlm.session import Session
-from rlm.types import RLMMetrics
+from rlm.types import ProgrammaticToolCallStats, RLMMetrics
 
 
 def _write_calls(session_dir, n_python, n_bash=0):
@@ -42,6 +35,16 @@ def test_aggregate_counts_child_with_no_calls(tmp_path):
     agg = s.aggregate_child_metrics()
     assert agg.num_sessions == 1
     assert agg.tool_call_stats.python_total == 0
+
+
+def test_ptc_log_skips_non_object_json(tmp_path):
+    log = tmp_path / "programmatic_tool_calls.jsonl"
+    log.write_text('null\n[]\n"text"\n{"tool": "search", "source": "python"}\n')
+
+    stats = ProgrammaticToolCallStats.from_log(log)
+
+    assert stats.python_total == 1
+    assert stats.by_tool_python == {"search": 1}
 
 
 def test_checkpoint_metrics_persists_midrun(tmp_path):

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -1,0 +1,75 @@
+"""Sub-agent metric aggregation + mid-run checkpointing (see PR: subagent metrics fix).
+
+Regression context: child stats used to be read from each child's meta.json, which
+only exists after the child's own finalize() — sub-agents cut off mid-run (parent
+rollout ended, gather cancelled, crash) silently contributed zero. And the parent's
+metrics only reached meta.json via finalize(), so a killed rollout lost the whole
+metric family.
+"""
+
+import json
+
+from rlm.session import Session
+from rlm.types import RLMMetrics
+
+
+def _write_calls(session_dir, n_python, n_bash=0):
+    lines = ['{"tool": "browsecomp_plus_search", "source": "python"}\n'] * n_python
+    lines += ['{"tool": "edit", "source": "bash"}\n'] * n_bash
+    lines += ["{malformed, exited mid-line\n"]  # from_log must tolerate this
+    (session_dir / "programmatic_tool_calls.jsonl").write_text("".join(lines))
+
+
+def test_aggregate_counts_unfinalized_children(tmp_path):
+    s = Session(tmp_path / "session")
+    child = s.dir / "sub-aaaa"
+    child.mkdir()
+    _write_calls(child, n_python=3, n_bash=1)  # no meta.json: never finalized
+    grand = child / "sub-bbbb"  # nested descendant, also unfinalized
+    grand.mkdir()
+    _write_calls(grand, n_python=1)
+
+    agg = s.aggregate_child_metrics()
+    assert agg.num_sessions == 2
+    assert agg.tool_call_stats.python_total == 4
+    assert agg.tool_call_stats.bash_total == 1
+
+
+def test_aggregate_counts_child_with_no_calls(tmp_path):
+    s = Session(tmp_path / "session")
+    (s.dir / "sub-empty").mkdir()  # spawned, never ran a call, no log file
+
+    agg = s.aggregate_child_metrics()
+    assert agg.num_sessions == 1
+    assert agg.tool_call_stats.python_total == 0
+
+
+def test_checkpoint_metrics_persists_midrun(tmp_path):
+    s = Session(tmp_path / "session")
+    metrics = RLMMetrics()
+    metrics._sub_rlm_enabled = True
+    child = s.dir / "sub-cccc"
+    child.mkdir()
+    _write_calls(child, n_python=2)
+
+    s.checkpoint_metrics(metrics, status="incomplete")
+
+    meta = json.loads((s.dir / "meta.json").read_text())
+    assert meta["status"] == "incomplete"
+    assert meta["metrics"]["sub_rlm_num_calls"] == 1
+    assert meta["metrics"]["sub_rlm_num_ptc_calls_python"] == 2
+    assert meta["programmatic_tool_call_stats"]["python_total"] == 2
+
+    # finalize afterwards still wins with the authoritative version
+    s.finalize("answer", turns=3, metrics=metrics)
+    meta = json.loads((s.dir / "meta.json").read_text())
+    assert meta["status"] == "done"
+    assert meta["metrics"]["sub_rlm_num_ptc_calls_python"] == 2
+
+
+def test_sub_rlm_keys_gated_when_disabled(tmp_path):
+    metrics = RLMMetrics()  # _sub_rlm_enabled defaults False (max_depth == 0)
+    keys = metrics.to_dict().keys()
+    assert not any(k.startswith("sub_rlm_") for k in keys)
+    metrics._sub_rlm_enabled = True
+    assert "sub_rlm_num_calls" in metrics.to_dict()

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -1,6 +1,4 @@
-"""Sub-agent metric aggregation and recoverable metric snapshots."""
-
-import json
+"""Sub-agent metric aggregation."""
 
 from rlm.session import Session
 from rlm.types import ProgrammaticToolCallStats, RLMMetrics
@@ -45,29 +43,6 @@ def test_ptc_log_skips_non_object_json(tmp_path):
 
     assert stats.python_total == 1
     assert stats.by_tool_python == {"search": 1}
-
-
-def test_checkpoint_metrics_persists_midrun(tmp_path):
-    s = Session(tmp_path / "session")
-    metrics = RLMMetrics()
-    metrics._sub_rlm_enabled = True
-    child = s.dir / "sub-cccc"
-    child.mkdir()
-    _write_calls(child, n_python=2)
-
-    s.checkpoint_metrics(metrics, status="incomplete")
-
-    meta = json.loads((s.dir / "meta.json").read_text())
-    assert meta["status"] == "incomplete"
-    assert meta["metrics"]["sub_rlm_num_calls"] == 1
-    assert meta["metrics"]["sub_rlm_num_ptc_calls_python"] == 2
-    assert meta["programmatic_tool_call_stats"]["python_total"] == 2
-
-    # finalize afterwards still wins with the authoritative version
-    s.finalize("answer", turns=3, metrics=metrics)
-    meta = json.loads((s.dir / "meta.json").read_text())
-    assert meta["status"] == "done"
-    assert meta["metrics"]["sub_rlm_num_ptc_calls_python"] == 2
 
 
 def test_sub_rlm_keys_gated_when_disabled(tmp_path):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -14,6 +14,11 @@ Kernel startup is ~700ms per test; keep the set here small.
 
 from __future__ import annotations
 
+import os
+import sys
+
+import pytest
+
 from conftest import (
     DummyClient,
     DummyMessage,
@@ -23,6 +28,7 @@ from conftest import (
 )
 
 from rlm.engine import RLMEngine
+from rlm.tools.skills import discover_skills
 
 
 async def test_python_skill_valid(session):
@@ -46,7 +52,7 @@ async def test_python_skill_valid(session):
     assert result.answer == "ok"
 
 
-async def test_bash_skill_valid(session):
+async def test_bash_skill_valid(session, monkeypatch, tmp_path):
     """Bash form: ``!say ...`` in an ipython tool call runs the skill CLI via IPython's shell escape."""
     prompt = "say hello"
     messages = [
@@ -55,6 +61,20 @@ async def test_bash_skill_valid(session):
     ]
 
     client = DummyClient(messages)
+    bin_dir = os.path.dirname(sys.executable)
+    launcher_dir = tmp_path / "launcher-bin"
+    launcher_dir.mkdir()
+    (launcher_dir / "rlm").symlink_to(sys.executable)
+    (launcher_dir / "say").symlink_to(os.path.join(bin_dir, "say"))
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join(
+            p
+            for p in os.environ["PATH"].split(os.pathsep)
+            if p not in {bin_dir, str(launcher_dir)}
+        ),
+    )
+    monkeypatch.setattr(sys, "argv", [str(launcher_dir / "rlm")])
     engine = RLMEngine(client=client, session=session)  # type: ignore
 
     result = await engine.run(prompt)
@@ -63,6 +83,14 @@ async def test_bash_skill_valid(session):
     show_tool_result(output)
     assert "hello" in output
     assert result.answer == "ok"
+
+
+def test_discover_skills_rejects_installed_generated_collision(monkeypatch, tmp_path):
+    monkeypatch.setattr("rlm.tools.skills.get_installed_skills", lambda: ["search"])
+    (tmp_path / "search.py").write_text("async def run(): pass\n")
+
+    with pytest.raises(ValueError, match="skill name collision.*search"):
+        discover_skills(tmp_path)
 
 
 async def test_python_skill_invalid_args(session):


### PR DESCRIPTION
## Summary

**Sub-agent tool calls were silently dropped.** `aggregate_child_metrics()` read each child's `meta.json`, which only exists after the child's own `finalize()`. A sub-agent cut off before finalization contributed zero even though its per-call `programmatic_tool_calls.jsonl` was already on disk.

This PR now:

- Aggregates `programmatic_tool_calls.jsonl` recursively across all descendant sessions, including unfinished children and nested grandchildren.
- Adds `sub_rlm_num_calls`, gated with the existing `sub_rlm_*` metrics when recursion is enabled.
- Keeps Bash skill wrappers reachable in Prime/uv tool installations so shell-form PTC is recorded rather than bypassing the wrapper.
- Advertises shell commands only for installed skills that actually provide CLIs.
- Rejects installed/generated skill and normalized MCP-name collisions instead of double-counting or silently overwriting tools.
- Retains cancelled IPython invocation metrics and corrects compaction character accounting.
- Ignores valid non-object JSON entries in interrupted PTC logs.
- Prevents a failed later ACP prompt from finalizing an earlier answer as the current result.

## Validation

- `uv run pytest tests/`: 111 passed.
- `uv run pre-commit run --all-files`: passed.
- Prime VM end-to-end audit with `openai/gpt-5.6-sol` and two parallel children plus one grandchild produced the exact requested counts: parent Python/Bash PTC `1/1`, descendant sessions `3`, descendant Python/Bash PTC `2/1`.
- A separate unfinished-child Prime audit confirmed that a child without finalized metadata is counted from its raw call log.

## Context

Found during large-scale eval. Per-turn `meta.json` checkpointing is intentionally not part of this PR; rollout error collection is handled by Verifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session finalization, metrics used in evals, and IPython kernel environment; behavior changes are intentional fixes but affect rollout accounting and multi-prompt ACP sessions.
> 
> **Overview**
> Fixes **silent loss of sub-agent programmatic tool call (PTC) metrics** by aggregating `programmatic_tool_calls.jsonl` across all descendant `sub-*` sessions (including unfinalized and nested children), and exposing **`sub_rlm_num_calls`** alongside existing gated `sub_rlm_*` PTC fields.
> 
> **Engine/session correctness:** each new `prompt()` clears `_has_result` so a cancelled or failed follow-up prompt does not `finalize()` a previous answer; depth-limit exits are treated as completed results with `stop_reason=depth_limit`. Cancelled IPython tools still record metrics if the worker settles; compaction **dropped-char** accounting now includes the seed user message (`messages[1:]`). Kernel **PATH** prepends the `rlm` launcher directory so bash skill CLIs resolve under Prime/uv layouts.
> 
> **Prompt/skills/MCP:** system prompt advertises shell commands only for **`cli_skills`** (pip-installed CLIs), not session-generated MCP modules. **Collisions** raise for MCP normalized tool names and installed vs generated skill names. PTC log parsing ignores non-object JSON lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dff3be062e66477cf9b9870d8afbb6dc6fb3e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
