### PR TITLE
feat: add sub-agent utilization metric

### DIFF
--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -157,6 +157,7 @@ class RLMMetrics:
     num_ptc_calls_python: int = 0
     num_ptc_calls_bash: int = 0
     sub_rlm_num_calls: int = 0
+    has_sub_rlm: int = 0
     sub_rlm_num_ptc_calls_python: int = 0
     sub_rlm_num_ptc_calls_bash: int = 0
 
@@ -207,6 +208,7 @@ class RLMMetrics:
                 self._ipython_input_loc_total / self._ipython_call_count
             )
         self.has_compacted = 1 if self.num_compactions > 0 else 0
+        self.has_sub_rlm = 1 if self.sub_rlm_num_calls > 0 else 0
         if self.num_compactions:
             self.turns_between_compactions_mean = (
                 self._turns_between_compactions_total / self.num_compactions
@@ -225,7 +227,10 @@ class RLMMetrics:
             key: value
             for key, value in asdict(self).items()
             if not key.startswith("_")
-            and (sub_rlm_enabled or not key.startswith("sub_rlm_"))
+            and (
+                sub_rlm_enabled
+                or (not key.startswith("sub_rlm_") and key != "has_sub_rlm")
+            )
         }
 
 

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -45,9 +45,14 @@ def test_ptc_log_skips_non_object_json(tmp_path):
     assert stats.by_tool_python == {"search": 1}
 
 
-def test_sub_rlm_keys_gated_when_disabled(tmp_path):
+def test_sub_rlm_metrics_are_derived_and_gated():
     metrics = RLMMetrics()  # _sub_rlm_enabled defaults False (max_depth == 0)
     keys = metrics.to_dict().keys()
     assert not any(k.startswith("sub_rlm_") for k in keys)
+    assert "has_sub_rlm" not in keys
+
     metrics._sub_rlm_enabled = True
-    assert "sub_rlm_num_calls" in metrics.to_dict()
+    assert metrics.to_dict()["has_sub_rlm"] == 0
+
+    metrics.sub_rlm_num_calls = 1
+    assert metrics.to_dict()["has_sub_rlm"] == 1


### PR DESCRIPTION
## Summary

Adds `has_sub_rlm`, a per-rollout binary metric that is `1` when the rollout created at least one descendant RLM session and `0` otherwise.

This complements `sub_rlm_num_calls`: averaging the count gives the mean number of descendant sessions per rollout, while averaging `has_sub_rlm` gives the fraction of rollouts that invoked sub-agents.

The metric is gated with the existing recursive metrics and is omitted when recursive RLMs are disabled. Verifiers exports it automatically through its numeric RLM metric collector, so no Verifiers change is required.

## Validation

- `uv run pytest tests/ -q`: 111 passed
- `uv run pre-commit run --all-files`: passed

## Stack

Stacked on #122 (`fix/subagent-metrics`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to metric derivation and export filtering; no runtime or auth behavior.
> 
> **Overview**
> Adds **`has_sub_rlm`**, a per-rollout 0/1 flag derived from **`sub_rlm_num_calls`** (same pattern as **`has_compacted`**), so aggregations can report the **fraction of rollouts that spawned sub-agents** instead of only the mean descendant count.
> 
> **`RLMMetrics.to_dict()`** now omits **`has_sub_rlm`** when recursive RLMs are disabled, alongside the existing **`sub_rlm_*`** keys. Tests cover gating and that the flag flips to **1** when **`sub_rlm_num_calls > 0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23cdfc831ed7d2529e0ae21eea39ef3896739e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->