### PR TITLE
feat: bound recursive agent concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ All configuration is via environment variables:
 | `RLM_SKILLS` | — | Comma-separated built-in skills to enable (`edit`, `search`); pre-imported into the kernel. Unknown names raise. See [Skills](#skills). |
 | `RLM_MCP_CONFIG` | — | Standard `mcpServers` config (streamable HTTP or stdio); each server's tools become pre-imported IPython skills (`<server>_<tool>`). See [MCP tools as skills](#mcp-tools-as-skills). |
 | `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |
+| `RLM_MAX_CONCURRENT_SUBAGENTS` | `4` | Max live sub-agents across one recursive session tree. Must be at least `RLM_MAX_DEPTH`; capacity is divided across depths to prevent nested-agent deadlocks. |
 | `RLM_EXEC_TIMEOUT` | `300` | Seconds per IPython execution |
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
 | `RLM_SUMMARIZE_AT_TOKENS` | — | Auto-compaction threshold: when a turn's prompt tokens reach this value, the conversation is compacted into a summary. Unset disables auto-compaction. |
@@ -111,6 +112,11 @@ results = await asyncio.gather(
 ```
 
 When recursion is disabled by depth, the system prompt does not advertise these APIs and child runs beyond the depth limit fail immediately.
+
+At most `RLM_MAX_CONCURRENT_SUBAGENTS` recursive agents run at once across the
+entire session tree. Additional calls wait for a slot. The shared slots are
+partitioned across enabled recursion depths so an agent waiting on a descendant
+cannot consume the descendant's capacity.
 
 ## Compaction
 

--- a/src/rlm/api.py
+++ b/src/rlm/api.py
@@ -1,26 +1,43 @@
 """Public Python API for running rlm agents."""
 
 import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator
 
+from rlm.concurrency import max_concurrent_subagents, subagent_slot
 from rlm.engine import RLMEngine
 from rlm.session import Session
 from rlm.types import RLMResult
 
 
-def _child_session() -> Session | None:
-    """If inside a parent session (depth > 0), create a child under it."""
+def _parent_session_dir() -> Path | None:
+    """Return the parent session when called from a recursive agent kernel."""
     parent_dir = os.environ.get("RLM_SESSION_DIR")
     depth = int(os.environ.get("RLM_DEPTH", "0"))
     if parent_dir and depth > 0:
-        return Session(Session.child_dir(parent_dir))
+        return Path(parent_dir)
     return None
+
+
+@asynccontextmanager
+async def _admit_subagent(parent_dir: Path | None) -> AsyncIterator[None]:
+    if parent_dir is None:
+        yield
+        return
+
+    depth = int(os.environ.get("RLM_DEPTH", "0"))
+    max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
+    limit = max_concurrent_subagents(max_depth)
+    async with subagent_slot(parent_dir, depth=depth, max_depth=max_depth, limit=limit):
+        yield
 
 
 async def run(prompt: str, **kwargs) -> RLMResult:
     """Run a single rlm agent."""
-    if "session" not in kwargs:
-        child = _child_session()
-        if child:
-            kwargs["session"] = child
-    engine = RLMEngine(**kwargs)
-    return await engine.run(prompt)
+    parent_dir = _parent_session_dir()
+    async with _admit_subagent(parent_dir):
+        if "session" not in kwargs and parent_dir is not None:
+            kwargs["session"] = Session(Session.child_dir(parent_dir))
+        engine = RLMEngine(**kwargs)
+        return await engine.run(prompt)

--- a/src/rlm/concurrency.py
+++ b/src/rlm/concurrency.py
@@ -1,0 +1,90 @@
+"""Cross-process admission control for recursive agents."""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator
+
+
+DEFAULT_MAX_CONCURRENT_SUBAGENTS = 4
+SUBAGENT_CONCURRENCY_ENV = "RLM_MAX_CONCURRENT_SUBAGENTS"
+_POLL_INTERVAL_SECONDS = 0.05
+
+
+def max_concurrent_subagents(max_depth: int) -> int:
+    """Read and validate the per-session-tree sub-agent concurrency bound."""
+    raw = os.environ.get(
+        SUBAGENT_CONCURRENCY_ENV, str(DEFAULT_MAX_CONCURRENT_SUBAGENTS)
+    )
+    try:
+        limit = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{SUBAGENT_CONCURRENCY_ENV} must be an int") from exc
+    if limit <= 0:
+        raise ValueError(f"{SUBAGENT_CONCURRENCY_ENV} must be positive")
+    if max_depth > limit:
+        raise ValueError(
+            f"{SUBAGENT_CONCURRENCY_ENV} ({limit}) must be at least "
+            f"RLM_MAX_DEPTH ({max_depth})"
+        )
+    return limit
+
+
+def _slot_indices(depth: int, max_depth: int, limit: int) -> range:
+    """Assign disjoint capacity to each depth so nested waits cannot deadlock."""
+    slots_per_depth, extra = divmod(limit, max_depth)
+    start = (depth - 1) * slots_per_depth + min(depth - 1, extra)
+    width = slots_per_depth + (1 if depth <= extra else 0)
+    return range(start, start + width)
+
+
+def _root_session_dir(session_dir: Path | str, depth: int) -> Path:
+    root = Path(session_dir).resolve()
+    for _ in range(depth - 1):
+        root = root.parent
+    return root
+
+
+@asynccontextmanager
+async def subagent_slot(
+    session_dir: Path | str,
+    *,
+    depth: int,
+    max_depth: int,
+    limit: int,
+) -> AsyncIterator[None]:
+    """Hold one crash-safe slot for a live recursive agent."""
+    if depth <= 0 or depth > max_depth:
+        yield
+        return
+
+    lock_dir = _root_session_dir(session_dir, depth) / ".subagent-slots"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    slot_paths = [
+        lock_dir / f"slot-{index}.lock"
+        for index in _slot_indices(depth, max_depth, limit)
+    ]
+
+    acquired_fd: int | None = None
+    while acquired_fd is None:
+        for slot_path in slot_paths:
+            fd = os.open(slot_path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                os.close(fd)
+            else:
+                acquired_fd = fd
+                break
+        if acquired_fd is None:
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+    try:
+        yield
+    finally:
+        fcntl.flock(acquired_fd, fcntl.LOCK_UN)
+        os.close(acquired_fd)

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from openai import AsyncOpenAI, BadRequestError
 
 from rlm.client import call_with_retries, extract_usage, make_client
+from rlm.concurrency import max_concurrent_subagents
 from rlm.mcp import (
     MCP_CONFIG_ENV,
     MCPServer,
@@ -189,6 +190,7 @@ class RLMEngine:
         )
         self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
         self.depth = int(os.environ.get("RLM_DEPTH", "0"))
+        self.max_concurrent_subagents = max_concurrent_subagents(self.max_depth)
 
         # Task MCP tool servers to expose as IPython skills; kwarg wins, otherwise
         # parse RLM_MCP_CONFIG (a standard mcpServers config).

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,139 @@
+"""Recursive agent concurrency limits."""
+
+import asyncio
+import fcntl
+import multiprocessing
+import os
+
+import pytest
+
+import rlm.api
+from rlm.concurrency import (
+    SUBAGENT_CONCURRENCY_ENV,
+    _slot_indices,
+    max_concurrent_subagents,
+    subagent_slot,
+)
+from rlm.types import RLMResult
+
+
+def _probe_lock_from_another_process(lock_path):
+    fd = os.open(lock_path, os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        raise SystemExit(1) from None
+    finally:
+        os.close(fd)
+
+
+def test_limit_reserves_capacity_for_each_depth(monkeypatch):
+    monkeypatch.setenv(SUBAGENT_CONCURRENCY_ENV, "5")
+
+    assert max_concurrent_subagents(max_depth=2) == 5
+    assert list(_slot_indices(depth=1, max_depth=2, limit=5)) == [0, 1, 2]
+    assert list(_slot_indices(depth=2, max_depth=2, limit=5)) == [3, 4]
+
+
+def test_limit_cannot_be_smaller_than_recursion_depth(monkeypatch):
+    monkeypatch.setenv(SUBAGENT_CONCURRENCY_ENV, "1")
+
+    with pytest.raises(ValueError, match="must be at least RLM_MAX_DEPTH"):
+        max_concurrent_subagents(max_depth=2)
+
+
+async def test_same_depth_calls_wait_for_a_shared_slot(tmp_path):
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    async def first():
+        async with subagent_slot(tmp_path, depth=1, max_depth=1, limit=1):
+            first_entered.set()
+            await release_first.wait()
+
+    async def second():
+        async with subagent_slot(tmp_path, depth=1, max_depth=1, limit=1):
+            second_entered.set()
+
+    first_task = asyncio.create_task(first())
+    await first_entered.wait()
+    second_task = asyncio.create_task(second())
+    await asyncio.sleep(0.1)
+    assert not second_entered.is_set()
+
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+    assert second_entered.is_set()
+
+
+async def test_nested_depth_has_reserved_slot(tmp_path):
+    child_dir = tmp_path / "sub-child"
+    child_dir.mkdir()
+    async with subagent_slot(tmp_path, depth=1, max_depth=2, limit=2):
+        await asyncio.wait_for(
+            _enter_slot_once(child_dir, depth=2, max_depth=2, limit=2),
+            timeout=1,
+        )
+
+    assert (tmp_path / ".subagent-slots").is_dir()
+    assert not (child_dir / ".subagent-slots").exists()
+
+
+async def test_slot_is_shared_across_processes(tmp_path):
+    async with subagent_slot(tmp_path, depth=1, max_depth=1, limit=1):
+        lock_path = tmp_path / ".subagent-slots" / "slot-0.lock"
+        process = multiprocessing.get_context("spawn").Process(
+            target=_probe_lock_from_another_process, args=(lock_path,)
+        )
+        process.start()
+        await asyncio.to_thread(process.join, 5)
+
+    assert not process.is_alive()
+    assert process.exitcode == 1
+
+
+async def test_api_bounds_live_subagents(monkeypatch, tmp_path):
+    parent_dir = tmp_path / "session"
+    parent_dir.mkdir()
+    monkeypatch.setenv("RLM_SESSION_DIR", str(parent_dir))
+    monkeypatch.setenv("RLM_DEPTH", "1")
+    monkeypatch.setenv("RLM_MAX_DEPTH", "1")
+    monkeypatch.setenv(SUBAGENT_CONCURRENCY_ENV, "1")
+
+    first_entered = asyncio.Event()
+    release = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    class BlockingEngine:
+        def __init__(self, *, session):
+            self.session = session
+
+        async def run(self, prompt):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            first_entered.set()
+            await release.wait()
+            active -= 1
+            self.session.close()
+            return RLMResult(answer=prompt)
+
+    monkeypatch.setattr(rlm.api, "RLMEngine", BlockingEngine)
+    first_task = asyncio.create_task(rlm.api.run("first"))
+    await first_entered.wait()
+    second_task = asyncio.create_task(rlm.api.run("second"))
+    await asyncio.sleep(0.1)
+
+    assert max_active == 1
+    assert len(list(parent_dir.glob("sub-*"))) == 1
+
+    release.set()
+    await asyncio.gather(first_task, second_task)
+    assert len(list(parent_dir.glob("sub-*"))) == 2
+
+
+async def _enter_slot_once(tmp_path, *, depth, max_depth, limit):
+    async with subagent_slot(tmp_path, depth=depth, max_depth=max_depth, limit=limit):
+        return


### PR DESCRIPTION
## Summary

Adds a hard, per-rollout bound on live recursive agents through `RLM_MAX_CONCURRENT_SUBAGENTS` (default: `4`). Calls beyond the limit wait before creating their child session or starting an engine.

The limiter uses advisory file locks in the root session directory, so every recursive IPython kernel in the process tree shares the same capacity and abandoned slots are released automatically if a process exits. Capacity is partitioned across enabled recursion depths; this prevents the classic deadlock where all global slots are held by agents waiting for descendants that cannot acquire a slot.

`RLM_MAX_CONCURRENT_SUBAGENTS` must be positive and at least `RLM_MAX_DEPTH`. The README documents the setting and the depth-partitioning behavior.

## Why

`RLM_MAX_DEPTH` bounded nesting but not width. A model could issue an arbitrarily large `asyncio.gather(rlm(...), ...)`, starting an unbounded number of recursive engines and IPython kernels inside one rollout. Verifiers' episode concurrency bound does not see or constrain this internal fan-out.

## Validation

- `uv run pytest tests/ -q`: 117 passed
- `uv run pre-commit run --all-files`: passed
- Prime VM + `openai/gpt-5.6-sol` (high reasoning), depth 1 / limit 2: requested four children; observed `FIRST_WAVE_COUNT=2`, `TOTAL_CHILDREN=4`, `sub_rlm_num_calls=4`, reward 1.0
- Prime VM + `openai/gpt-5.6-sol` (high reasoning), depth 2 / limit 2: two children plus one grandchild completed without deadlock; `sub_rlm_num_calls=3`, reward 1.0

## Stack

Stacked on #123 (`feat/has-sub-rlm`), which is stacked on #122.
