### PR TITLE
feat: add PTC utilization metric

### DIFF
--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -156,6 +156,7 @@ class RLMMetrics:
     # they run within a single tool call and never reach the API proxy).
     num_ptc_calls_python: int = 0
     num_ptc_calls_bash: int = 0
+    has_ptc: int = 0  # 1 if the root or any descendant made a PTC attempt
     sub_rlm_num_calls: int = 0
     has_sub_rlm: int = 0
     sub_rlm_num_ptc_calls_python: int = 0
@@ -208,6 +209,18 @@ class RLMMetrics:
                 self._ipython_input_loc_total / self._ipython_call_count
             )
         self.has_compacted = 1 if self.num_compactions > 0 else 0
+        self.has_ptc = (
+            1
+            if any(
+                (
+                    self.num_ptc_calls_python,
+                    self.num_ptc_calls_bash,
+                    self.sub_rlm_num_ptc_calls_python,
+                    self.sub_rlm_num_ptc_calls_bash,
+                )
+            )
+            else 0
+        )
         self.has_sub_rlm = 1 if self.sub_rlm_num_calls > 0 else 0
         if self.num_compactions:
             self.turns_between_compactions_mean = (

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -56,3 +56,16 @@ def test_sub_rlm_metrics_are_derived_and_gated():
 
     metrics.sub_rlm_num_calls = 1
     assert metrics.to_dict()["has_sub_rlm"] == 1
+
+
+def test_has_ptc_covers_direct_and_descendant_calls():
+    metrics = RLMMetrics()
+    assert metrics.to_dict()["has_ptc"] == 0
+
+    metrics.num_ptc_calls_python = 1
+    assert metrics.to_dict()["has_ptc"] == 1
+
+    metrics.num_ptc_calls_python = 0
+    metrics._sub_rlm_enabled = True
+    metrics.sub_rlm_num_ptc_calls_bash = 1
+    assert metrics.to_dict()["has_ptc"] == 1


### PR DESCRIPTION
## Summary

Adds `has_ptc`, a per-rollout binary metric that is `1` when the root or any recursive descendant makes at least one skill/MCP programmatic tool-call attempt and `0` otherwise.

This complements the direct and descendant PTC call counts: averaging `has_ptc` gives the fraction of rollouts that used PTC, while averaging the counts gives invocation volume.

Recursive `rlm()` calls remain represented by `has_sub_rlm` and `sub_rlm_num_calls`; `has_ptc` covers skill and MCP calls issued programmatically from IPython.

Verifiers exports the metric automatically through its numeric RLM metric collector.

## Validation

- `uv run pytest tests/ -q`: 112 passed
- `uv run pre-commit run --all-files`: passed

## Stack

Stacked on #123 (`feat/has-sub-rlm`), which is stacked on #122.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to metric derivation and tests; no runtime or export-path behavior beyond a new numeric field.
> 
> **Overview**
> Adds **`has_ptc`**, a per-rollout 0/1 metric on `RLMMetrics` that indicates whether programmatic tool calls (python or bash from IPython) happened on the root session or any recursive descendant.
> 
> The flag is derived in `_refresh_derived_metrics` from `num_ptc_calls_python`, `num_ptc_calls_bash`, and the existing `sub_rlm_num_ptc_calls_*` counters, so it stays in sync whenever metrics are refreshed (including via `to_dict`). Averaging `has_ptc` yields the fraction of rollouts that used PTC, alongside the existing count metrics for volume.
> 
> Tests assert zero when no PTC, one for direct python PTC, and one when only a descendant bash PTC count is set (with sub-RLM metrics enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18668ab3734552ee0c49c6683269109e13a107f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->