### PR TITLE
chore: update readme for nano-rlm rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# rlm - training
+# nano-rlm
 
-⚠️ this is a training only harness, only use this to train on agentic task using verifiers 
-
-A minimal CLI coding agent with a persistent IPython execution environment and optional recursive sub-agents.
+A minimal CLI coding agent with a persistent IPython execution environment and optional recursive sub-agents. For a full-fledged coding agent built on the same RLM principles, see [prime-agent](https://github.com/PrimeIntellect-ai/prime-agent).
 
 The model gets a single built-in tool, `ipython`: a persistent IPython kernel for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash`. The tool set is not configurable. File edits, shell work, and orchestration all go through it.
 
@@ -15,8 +13,8 @@ Inside the IPython session, a callable `rlm` is pre-injected into the namespace.
 ## Install
 
 ```bash
-git clone https://github.com/PrimeIntellect-ai/rlm.git
-cd rlm
+git clone https://github.com/PrimeIntellect-ai/nano-rlm.git
+cd nano-rlm
 uv sync
 source .venv/bin/activate
 ```


### PR DESCRIPTION
## Summary
- Rename the README title from `rlm - training` to `nano-rlm` to match the repo name.
- Remove the training-only warning banner.
- Fix the clone URL and directory in the install instructions (`rlm` → `nano-rlm`).
- Link to [prime-agent](https://github.com/PrimeIntellect-ai/prime-agent) as the full-fledged coding agent built on the same RLM principles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or configuration changes.
> 
> **Overview**
> Repositions the project in **README** as **nano-rlm** instead of **rlm - training**, and removes the banner that said the repo was training-only.
> 
> Install steps now clone **`PrimeIntellect-ai/nano-rlm`** and `cd nano-rlm`. A new sentence links to **[prime-agent](https://github.com/PrimeIntellect-ai/prime-agent)** as the fuller coding agent on the same RLM ideas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca4dade4d5b16be7319d49aed46d201bb1e0f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->