### PR TITLE
fix: error on ipython calls missing 'code' instead of silent no-op

### DIFF
--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -74,6 +74,19 @@ class IpythonTool:
         return schema
 
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
+        # A missing "code" key used to fall through to "" and execute nothing
+        # silently — the model would then hit NameErrors on state it thought it
+        # created. Laguna in particular emits the arg under "cmd". Turn any such
+        # call into a loud, learnable error instead of a no-op.
+        if "code" not in args or args.get("code") in (None, ""):
+            wrong = ", ".join(repr(k) for k in args if k != "timeout") or "none"
+            return ToolOutcome(
+                content=(
+                    "Error: the ipython tool requires a non-empty 'code' argument; "
+                    f"got keys: {wrong}. Pass your Python under the 'code' key."
+                ),
+                metric_events=[IpythonExecuted(input_chars=0, input_loc=0)],
+            )
         code = args.get("code", "")
         if not isinstance(code, str):
             code = str(code)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -92,3 +92,33 @@ def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     assert captured.out == ""
     assert captured.err == ""
     assert result.strip() == "4 14"
+
+
+def _ipython_ctx():
+    from rlm.tools.base import ToolContext
+    from rlm.types import RLMMetrics, TokenUsage
+
+    return ToolContext(
+        messages=[],
+        metrics=RLMMetrics(),
+        total_usage=TokenUsage(),
+        last_prompt_tokens=0,
+        exec_timeout=30,
+        repl=None,  # error paths return before touching the REPL
+    )
+
+
+def test_ipython_missing_code_key_errors_not_noop():
+    """A tool call under the wrong key (e.g. Laguna's 'cmd') must error loudly."""
+    from rlm.tools.ipython import IpythonTool
+
+    out = IpythonTool().execute({"cmd": "print(1)"}, _ipython_ctx())
+    assert "Error" in out.content and "code" in out.content
+    assert "'cmd'" in out.content
+
+
+def test_ipython_empty_code_errors():
+    from rlm.tools.ipython import IpythonTool
+
+    out = IpythonTool().execute({"code": ""}, _ipython_ctx())
+    assert "Error" in out.content and "code" in out.content


### PR DESCRIPTION
## Problem
`IpythonTool.execute` reads `args.get("code", "")`, so a tool call that puts the code under any other key executes **nothing**, returns an empty result, and raises no error. The model then hits `NameError`s on variables it believes it created, and burns turns rediscovering state.

Observed routinely during large-scale eval: a model emits the code under `cmd` (a `{'cmd': ...}` cell), and the silent no-op appeared across many rollouts. Under a turn budget it injects failure that lands stochastically *later* than the malformed call, so it corrupts credit assignment rather than being locally learnable.

## Fix
If `code` is absent or empty, return a loud error naming the wrong keys ("got keys: 'cmd'. Pass your Python under the 'code' key.") instead of executing an empty string. Now a learnable signal — the model/policy can correct on the next turn, like it already does for the invalid-JSON-args error path.

## Tests
`test_ipython_missing_code_key_errors_not_noop`, `test_ipython_empty_code_errors`. Full suite 114 passed.

See also the depth-limit and skill-preload issues filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized validation in the ipython tool with clearer errors; no auth, data, or execution-path changes beyond skipping empty runs.
> 
> **Overview**
> **Fixes silent IPython no-ops** when models pass Python under the wrong argument (e.g. Laguna’s `cmd` instead of `code`). Previously `execute` treated a missing or empty `code` as `""`, ran nothing, and returned an empty success—leading to later `NameError`s and poor RL credit assignment.
> 
> `IpythonTool.execute` now **fails fast** with an explicit error that lists the unexpected keys and tells the caller to use `code`. Metrics still record an `IpythonExecuted` event with zero input size on this path.
> 
> Adds **`test_ipython_missing_code_key_errors_not_noop`** and **`test_ipython_empty_code_errors`** plus a small `_ipython_ctx()` helper for REPL-free error-path tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f865f8c24249b2474a2168da78010e4fef0a217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
