### PR TITLE
feat: add built-in fetch skill (read webpage text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimal CLI coding agent with a persistent IPython execution environment and o
 
 The model gets a single built-in tool, `ipython`: a persistent IPython kernel for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash`. The tool set is not configurable. File edits, shell work, and orchestration all go through it.
 
-For convenience, rlm ships built-in *skills* that can be enabled per run via `RLM_SKILLS` (comma-separated, off by default): `edit` (single-occurrence string replacement) and `search` (web search via Serper, needs `SERPER_API_KEY`). Enabled skills are pre-imported into the IPython kernel like any other skill (see [Skills](#skills)), so the agent calls `await edit(path=..., old_str=..., new_str=...)` or `await search(query=...)`.
+For convenience, rlm ships built-in *skills* that can be enabled per run via `RLM_SKILLS` (comma-separated, off by default): `edit` (single-occurrence string replacement), `search` (web search via Serper, needs `SERPER_API_KEY`), and `fetch` (retrieve a URL as cleaned text). Enabled skills are pre-imported into the IPython kernel like any other skill (see [Skills](#skills)), so the agent calls `await edit(path=..., old_str=..., new_str=...)`, `await search(query=...)`, or `await fetch(url=...)`.
 
 Context is reclaimed automatically: when a turn's prompt token count crosses `RLM_SUMMARIZE_AT_TOKENS`, the engine compacts the conversation into a summary and continues on a fresh branch. The IPython kernel keeps running across the compaction, so REPL state survives (see [Compaction](#compaction)).
 
@@ -99,7 +99,7 @@ versioned contract described above.
 | `SERPER_API_KEY` | — | API key for the built-in `search` skill (Serper backend). Resolved by the supervisor and not copied into the kernel. |
 | `PRIME_API_KEY` | — | PI Inference pair: targets `https://api.pinference.ai/api/v1` and forwards `PRIME_TEAM_ID` as `X-Prime-Team-ID` when set. |
 | `OPENAI_API_KEY` / `OPENAI_BASE_URL` | resolved at startup | OpenAI pair (covers OpenAI direct and verifiers' rollout tunnel). Provider precedence: explicit → PI → OpenAI. Keys are scoped to their own base URL so an `OPENAI_API_KEY` lying around can't leak to PI Inference. |
-| `RLM_SKILLS` | — | Comma-separated built-in skills to enable (`edit`, `search`); pre-imported into the kernel. Unknown names raise. See [Skills](#skills). |
+| `RLM_SKILLS` | — | Comma-separated built-in skills to enable (`edit`, `search`, `fetch`); pre-imported into the kernel. Unknown names raise. See [Skills](#skills). |
 | `RLM_MCP_CONFIG` | — | Standard `mcpServers` config (streamable HTTP or stdio); each server's tools become pre-imported IPython skills (`<server>_<tool>`). See [MCP tools as skills](#mcp-tools-as-skills). |
 | `RLM_KERNEL_ENV` | `{}` | JSON object of task variables explicitly passed to IPython and its subprocesses. Supervisor, provider, MCP, and broker configuration names are reserved. |
 | `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimal CLI coding agent with a persistent IPython execution environment and o
 
 The model gets a single built-in tool, `ipython`: a persistent IPython kernel for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash`. The tool set is not configurable. File edits, shell work, and orchestration all go through it.
 
-For convenience, rlm ships built-in *skills* that can be enabled per run via `RLM_SKILLS` (comma-separated, off by default): `edit` (single-occurrence string replacement), `search` (web search via Serper, needs `SERPER_API_KEY`), and `fetch` (retrieve a URL as cleaned text). Enabled skills are pre-imported into the IPython kernel like any other skill (see [Skills](#skills)), so the agent calls `await edit(path=..., old_str=..., new_str=...)`, `await search(query=...)`, or `await fetch(url=...)`.
+For convenience, rlm ships built-in *skills* that can be enabled per run via `RLM_SKILLS` (comma-separated, off by default): `edit` (single-occurrence string replacement), `search` (web search via Serper, needs `SERPER_API_KEY`), and `fetch` (retrieve a URL as cleaned text). Enabled skills are pre-imported into the IPython kernel like any other skill (see [Skills](#skills)), so the agent calls `await edit(path=..., old_str=..., new_str=...)`, `await search(query=...)`, or `await fetch(url=...)`. `fetch` also exists as a native builtin tool with the same semantics, for tool-calling runs (opt-in via `RLM_BUILTIN_TOOLS`).
 
 Context is reclaimed automatically: when a turn's prompt token count crosses `RLM_SUMMARIZE_AT_TOKENS`, the engine compacts the conversation into a summary and continues on a fresh branch. The IPython kernel keeps running across the compaction, so REPL state survives (see [Compaction](#compaction)).
 

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -67,8 +67,8 @@ SEARCH_SKILL_PROMPT = (
 )
 FETCH_SKILL_PROMPT = (
     "To read a specific webpage, use the pre-imported async `fetch` skill: "
-    '`await fetch(url="...")` returns the webpage as cleaned text. Use it to open URLs '
-    "from `search` results."
+    '`await fetch(url="...")` returns the webpage as cleaned text. It can be used '
+    "to open URLs from `search` results."
 )
 
 # One curated line per built-in skill, appended generically for whatever is enabled.

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -55,6 +55,12 @@ SEARCH_SKILL_PROMPT = (
     "several angles at once, fan out with `asyncio.gather(search(...), search(...))`."
 )
 
+FETCH_SKILL_PROMPT = (
+    "To read a specific webpage, use the pre-imported async `fetch` skill: "
+    '`await fetch(url="...")` returns the webpage as cleaned text. Use it to open URLs '
+    "from `search` results."
+)
+
 
 def build_system_prompt(
     cwd: str,
@@ -137,6 +143,8 @@ def build_system_prompt(
             skill_lines.append(EDIT_SKILL_PROMPT)
         if "search" in installed_skills:
             skill_lines.append(SEARCH_SKILL_PROMPT)
+        if "fetch" in installed_skills:
+            skill_lines.append(FETCH_SKILL_PROMPT)
     if skill_lines:
         parts.extend(["", *skill_lines])
 

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -43,6 +43,17 @@ IPYTHON_CONTROL_PROMPT = (
     "Run shell commands with `%%bash` as the very first line of a code cell "
     "(no comments, imports, or statements before it). " + PROJECT_ENV_PROMPT
 )
+BASH_SKILL_PROMPT = (
+    "Run shell with `out = await bash('''command here''')` — always "
+    "triple-quote the command so shell quotes and multi-line scripts never "
+    "need escaping. It returns the output as a string; no need for "
+    "`subprocess` or `%%bash`. Chain related commands with && in one call."
+)
+BASH_SKILL_WITH_TOOL_PROMPT = (
+    "Inside ipython you can also run shell with `await bash(command=...)` — "
+    "it returns the output as a string, useful when mixing shell and Python "
+    "in one cell or avoiding shell quoting."
+)
 EDIT_SKILL_PROMPT = (
     "Inside ipython you can also edit files with the pre-imported async `edit` "
     'skill: `await edit(path="pkg/file.py", old_str=..., new_str=...)` — handy '
@@ -54,12 +65,19 @@ SEARCH_SKILL_PROMPT = (
     "assign the result to a variable so you can revisit it. To cover "
     "several angles at once, fan out with `asyncio.gather(search(...), search(...))`."
 )
-
 FETCH_SKILL_PROMPT = (
     "To read a specific webpage, use the pre-imported async `fetch` skill: "
     '`await fetch(url="...")` returns the webpage as cleaned text. Use it to open URLs '
     "from `search` results."
 )
+
+# One curated line per built-in skill, appended generically for whatever is enabled.
+BUILTIN_SKILL_PROMPTS: dict[str, str] = {
+    "bash": BASH_SKILL_PROMPT,
+    "edit": EDIT_SKILL_PROMPT,
+    "search": SEARCH_SKILL_PROMPT,
+    "fetch": FETCH_SKILL_PROMPT,
+}
 
 
 def build_system_prompt(
@@ -126,25 +144,9 @@ def build_system_prompt(
             )
         else:
             skill_lines.append("The listed skills are IPython-only.")
-        if "bash" in installed_skills and _has_tool(active_tools, "bash"):
-            skill_lines.append(
-                "Inside ipython you can also run shell with `await bash(command=...)` — "
-                "it returns the output as a string, useful when mixing shell and Python "
-                "in one cell or avoiding shell quoting."
-            )
-        elif "bash" in installed_skills:
-            skill_lines.append(
-                "Run shell with `out = await bash('''command here''')` — always "
-                "triple-quote the command so shell quotes and multi-line scripts never "
-                "need escaping. It returns the output as a string; no need for "
-                "`subprocess` or `%%bash`. Chain related commands with && in one call."
-            )
-        if "edit" in installed_skills:
-            skill_lines.append(EDIT_SKILL_PROMPT)
-        if "search" in installed_skills:
-            skill_lines.append(SEARCH_SKILL_PROMPT)
-        if "fetch" in installed_skills:
-            skill_lines.append(FETCH_SKILL_PROMPT)
+        for name in installed_skills:
+            if prompt := _builtin_skill_prompt(name, active_tools):
+                skill_lines.append(prompt)
     if skill_lines:
         parts.extend(["", *skill_lines])
 
@@ -177,6 +179,17 @@ def _should_include_git_history_guard(
     if allow_git:
         return False
     return any(tool.name in SHELL_TOOL_NAMES for tool in active_tools)
+
+
+def _builtin_skill_prompt(
+    name: str, active_tools: list["BuiltinTool"]
+) -> str | None:
+    """The curated line for one enabled built-in skill (None for uploaded skills).
+    `bash` swaps its guidance when the native bash tool is also active — the skill
+    is then the secondary shell path."""
+    if name == "bash" and _has_tool(active_tools, "bash"):
+        return BASH_SKILL_WITH_TOOL_PROMPT
+    return BUILTIN_SKILL_PROMPTS.get(name)
 
 
 def _has_tool(active_tools: list["BuiltinTool"], name: str) -> bool:

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -181,9 +181,7 @@ def _should_include_git_history_guard(
     return any(tool.name in SHELL_TOOL_NAMES for tool in active_tools)
 
 
-def _builtin_skill_prompt(
-    name: str, active_tools: list["BuiltinTool"]
-) -> str | None:
+def _builtin_skill_prompt(name: str, active_tools: list["BuiltinTool"]) -> str | None:
     """The curated line for one enabled built-in skill (None for uploaded skills).
     `bash` swaps its guidance when the native bash tool is also active — the skill
     is then the secondary shell path."""

--- a/src/rlm/skills/__init__.py
+++ b/src/rlm/skills/__init__.py
@@ -14,6 +14,7 @@ from pathlib import Path
 _BUILTIN_SKILLS: dict[str, str | None] = {
     "bash": "rlm.skills.bash",
     "edit": "rlm.skills.edit",
+    "fetch": "rlm.skills.fetch",
     "search": None,
 }
 

--- a/src/rlm/skills/fetch.py
+++ b/src/rlm/skills/fetch.py
@@ -1,0 +1,59 @@
+"""Built-in ``fetch`` skill — retrieve a webpage and return its cleaned text.
+
+Enabled via ``RLM_SKILLS``; pre-imported into the IPython kernel so the agent calls
+``await fetch(url="...")``. Gives the model a proper tool for reading a webpage instead of
+hand-rolling ``curl``/``requests``/``urllib`` (which tend to return raw HTML, spam, or errors).
+Pairs with the ``search`` skill: ``search`` finds URLs, ``fetch`` reads them.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import re
+
+import httpx
+
+DEFAULT_MAX_CHARS = 20_000
+
+_TAG_BLOCKS = re.compile(r"(?is)<(script|style|noscript|template|svg)[^>]*>.*?</\1>")
+_TAGS = re.compile(r"(?s)<[^>]+>")
+_WS = re.compile(r"\s+")
+
+
+def html_to_text(body: str) -> str:
+    """Strip scripts/styles/tags and collapse whitespace into readable text."""
+    body = _TAG_BLOCKS.sub(" ", body)
+    body = _TAGS.sub(" ", body)
+    return _WS.sub(" ", _html.unescape(body)).strip()
+
+
+async def run(url: str, *, max_chars: int = DEFAULT_MAX_CHARS) -> str:
+    """Fetch a webpage and return its cleaned text content (truncated to ``max_chars``).
+
+    Args:
+        url: The webpage to fetch (``https://`` assumed if no scheme).
+        max_chars: Truncate the returned text to this many characters.
+
+    Returns:
+        ``URL: <url>`` followed by the webpage's cleaned text, or a short error string.
+    """
+    if not re.match(r"^https?://", url):
+        url = "https://" + url
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=45) as client:
+            response = await client.get(
+                url, headers={"User-Agent": "Mozilla/5.0 (compatible; rlm-fetch)"}
+            )
+        response.raise_for_status()
+    except Exception as exc:
+        return f"Error fetching {url}: {type(exc).__name__}: {exc}"
+    content_type = response.headers.get("content-type", "").lower()
+    try:
+        body = response.text
+    except (UnicodeDecodeError, LookupError):
+        body = response.content.decode("utf-8", errors="replace")
+    is_html = "html" in content_type or "<html" in body[:1000].lower()
+    text = html_to_text(body) if is_html else body.strip()
+    if len(text) > max_chars:
+        text = text[:max_chars] + f"\n... [truncated at {max_chars} chars]"
+    return f"URL: {url}\n\n{text}"

--- a/src/rlm/skills/fetch.py
+++ b/src/rlm/skills/fetch.py
@@ -4,6 +4,8 @@ Enabled via ``RLM_SKILLS``; pre-imported into the IPython kernel so the agent ca
 ``await fetch(url="...")``. Gives the model a proper tool for reading a webpage instead of
 hand-rolling ``curl``/``requests``/``urllib`` (which tend to return raw HTML, spam, or errors).
 Pairs with the ``search`` skill: ``search`` finds URLs, ``fetch`` reads them.
+
+Also exposed as a native builtin tool (``rlm.tools.fetch``) with the same semantics.
 """
 
 from __future__ import annotations
@@ -14,6 +16,8 @@ import re
 import httpx
 
 DEFAULT_MAX_CHARS = 20_000
+REQUEST_TIMEOUT = 45
+REQUEST_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; rlm-fetch)"}
 
 _TAG_BLOCKS = re.compile(r"(?is)<(script|style|noscript|template|svg)[^>]*>.*?</\1>")
 _TAGS = re.compile(r"(?s)<[^>]+>")
@@ -27,26 +31,18 @@ def html_to_text(body: str) -> str:
     return _WS.sub(" ", _html.unescape(body)).strip()
 
 
-async def run(url: str, *, max_chars: int = DEFAULT_MAX_CHARS) -> str:
-    """Fetch a webpage and return its cleaned text content (truncated to ``max_chars``).
+def normalize_url(url: str) -> str:
+    """Assume ``https://`` when the URL has no scheme."""
+    return url if re.match(r"^https?://", url) else "https://" + url
 
-    Args:
-        url: The webpage to fetch (``https://`` assumed if no scheme).
-        max_chars: Truncate the returned text to this many characters.
 
-    Returns:
-        ``URL: <url>`` followed by the webpage's cleaned text, or a short error string.
-    """
-    if not re.match(r"^https?://", url):
-        url = "https://" + url
-    try:
-        async with httpx.AsyncClient(follow_redirects=True, timeout=45) as client:
-            response = await client.get(
-                url, headers={"User-Agent": "Mozilla/5.0 (compatible; rlm-fetch)"}
-            )
-        response.raise_for_status()
-    except Exception as exc:
-        return f"Error fetching {url}: {type(exc).__name__}: {exc}"
+def fetch_error(url: str, exc: Exception) -> str:
+    """A short error string — data for the agent, not a crash."""
+    return f"Error fetching {url}: {type(exc).__name__}: {exc}"
+
+
+def render_response(url: str, response: httpx.Response, max_chars: int) -> str:
+    """Decode a response, clean HTML to text, truncate, and prefix the URL."""
     content_type = response.headers.get("content-type", "").lower()
     try:
         body = response.text
@@ -57,3 +53,25 @@ async def run(url: str, *, max_chars: int = DEFAULT_MAX_CHARS) -> str:
     if len(text) > max_chars:
         text = text[:max_chars] + f"\n... [truncated at {max_chars} chars]"
     return f"URL: {url}\n\n{text}"
+
+
+async def run(url: str, *, max_chars: int = DEFAULT_MAX_CHARS) -> str:
+    """Fetch a webpage and return its cleaned text content (truncated to ``max_chars``).
+
+    Args:
+        url: The webpage to fetch (``https://`` assumed if no scheme).
+        max_chars: Truncate the returned text to this many characters.
+
+    Returns:
+        ``URL: <url>`` followed by the webpage's cleaned text, or a short error string.
+    """
+    url = normalize_url(url)
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True, timeout=REQUEST_TIMEOUT
+        ) as client:
+            response = await client.get(url, headers=REQUEST_HEADERS)
+        response.raise_for_status()
+    except Exception as exc:
+        return fetch_error(url, exc)
+    return render_response(url, response, max_chars)

--- a/src/rlm/tools/fetch.py
+++ b/src/rlm/tools/fetch.py
@@ -1,0 +1,81 @@
+"""Native ``fetch`` builtin tool — retrieve a webpage and return its cleaned text.
+
+Tool twin of the ``fetch`` skill (``rlm.skills.fetch``): same cleaning, truncation,
+and error semantics, exposed as a native tool call instead of a REPL function.
+Opt-in: registered but in no tooling preset, so it runs only when named in
+``RLM_BUILTIN_TOOLS`` — a network-capable tool stays off by default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from rlm.skills.fetch import (
+    DEFAULT_MAX_CHARS,
+    REQUEST_HEADERS,
+    REQUEST_TIMEOUT,
+    fetch_error,
+    normalize_url,
+    render_response,
+)
+from rlm.tools.base import ToolContext, ToolOutcome
+
+FETCH_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "fetch",
+        "description": (
+            "Fetch a webpage and return its cleaned text (scripts, styles, and tags "
+            "stripped). Use it to read URLs, e.g. ones found via search."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The webpage to fetch (https:// assumed if no scheme).",
+                },
+                "max_chars": {
+                    "type": "integer",
+                    "description": (
+                        "Truncate the returned text to this many characters "
+                        f"(default {DEFAULT_MAX_CHARS})."
+                    ),
+                },
+            },
+            "required": ["url"],
+        },
+    },
+}
+
+
+def fetch_page(url: str, max_chars: int = DEFAULT_MAX_CHARS) -> str:
+    """Synchronous twin of ``rlm.skills.fetch.run`` (tools execute in a worker thread)."""
+    url = normalize_url(url)
+    try:
+        with httpx.Client(follow_redirects=True, timeout=REQUEST_TIMEOUT) as client:
+            response = client.get(url, headers=REQUEST_HEADERS)
+        response.raise_for_status()
+    except Exception as exc:
+        return fetch_error(url, exc)
+    return render_response(url, response, max_chars)
+
+
+class FetchTool:
+    """One webpage read per call; returns cleaned text or a short error string."""
+
+    name = "fetch"
+
+    def schema(self) -> dict[str, Any]:
+        return FETCH_SCHEMA
+
+    def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
+        url = args.get("url")
+        if not isinstance(url, str) or not url.strip():
+            return ToolOutcome(content="Error: url is required")
+        max_chars = args.get("max_chars", DEFAULT_MAX_CHARS)
+        if not isinstance(max_chars, int) or max_chars <= 0:
+            return ToolOutcome(content="Error: max_chars must be a positive integer")
+        return ToolOutcome(content=fetch_page(url.strip(), max_chars=max_chars))

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -12,16 +12,21 @@ import os
 
 from rlm.tools.base import BuiltinTool
 from rlm.tools.bash import BashTool, EditTool
+from rlm.tools.fetch import FetchTool
 from rlm.tools.ipython import IpythonTool
 
 # All registered tools by name. Tests (and extensions) may add entries; names
-# listed in RLM_BUILTIN_TOOLS or the default set become active.
+# listed in RLM_BUILTIN_TOOLS or the active preset become active.
 _TOOLS_BY_NAME: dict[str, BuiltinTool] = {
     "bash": BashTool(),
     "edit": EditTool(),
+    "fetch": FetchTool(),
     "ipython": IpythonTool(),
 }
-_DEFAULT = ("bash", "edit", "ipython")
+# Stock tools: activated only via a preset or RLM_BUILTIN_TOOLS. Entries added at
+# runtime beyond these (test fixtures/extensions) auto-join the active set. `fetch`
+# is deliberately in no preset — a network-capable tool stays opt-in.
+_STOCK = ("bash", "edit", "fetch", "ipython")
 
 
 _TOOLING_PRESETS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
@@ -64,7 +69,7 @@ def _selected() -> tuple[BuiltinTool, ...]:
     # default: the RLM_TOOLING preset's tools plus any extra registered tools
     # (fixtures/extensions).
     preset = preset_tools()
-    extras = [n for n in _TOOLS_BY_NAME if n not in _DEFAULT]
+    extras = [n for n in _TOOLS_BY_NAME if n not in _STOCK]
     return tuple(_TOOLS_BY_NAME[n] for n in [*preset, *extras])
 
 

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -23,9 +23,11 @@ _TOOLS_BY_NAME: dict[str, BuiltinTool] = {
     "fetch": FetchTool(),
     "ipython": IpythonTool(),
 }
-# Stock tools: activated only via a preset or RLM_BUILTIN_TOOLS. Entries added at
-# runtime beyond these (test fixtures/extensions) auto-join the active set. `fetch`
-# is deliberately in no preset — a network-capable tool stays opt-in.
+# NOT an activation list — activation comes from the RLM_TOOLING preset or
+# RLM_BUILTIN_TOOLS. _STOCK only marks the shipped tools so they are excluded from
+# the extras rule below, which auto-activates entries registered at runtime (test
+# fixtures/extensions). A stock tool outside every preset (`fetch` — network-capable)
+# therefore runs only when RLM_BUILTIN_TOOLS names it.
 _STOCK = ("bash", "edit", "fetch", "ipython")
 
 

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -199,3 +199,22 @@ def test_enable_bash_skill_writes_stub(tmp_path):
 async def test_bash_survives_binary_output():
     out = await bash("printf 'head\\xff\\xfetail'")
     assert "head" in out and "tail" in out
+
+
+def test_enable_fetch_skill_writes_stub(tmp_path):
+    enabled = enable_builtin_skills(["fetch"], tmp_path)
+    assert enabled == ["fetch"]
+    stub = (tmp_path / "fetch.py").read_text()
+    assert "from rlm.skills.fetch import run" in stub
+
+
+def test_fetch_html_to_text_strips_markup():
+    from rlm.skills.fetch import html_to_text
+
+    html = (
+        "<html><head><style>x{}</style></head><body><h1>T</h1>"
+        "<p>Hello &amp; world</p><script>bad()</script><p>Line2</p></body></html>"
+    )
+    out = html_to_text(html)
+    assert "Hello & world" in out and "Line2" in out
+    assert "bad()" not in out and "<" not in out

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -230,3 +230,24 @@ def test_truncate_tool_output_caps_and_reports():
     assert out.startswith("Warning: truncated output")
     assert "bytes truncated" in out
     assert "Total output lines: 10001" in out
+
+
+def test_fetch_tool_is_opt_in(monkeypatch):
+    """fetch is registered but joins the active set only when named explicitly."""
+    from rlm.tools.registry import get_active_builtin_tools
+
+    monkeypatch.delenv("RLM_BUILTIN_TOOLS", raising=False)
+    monkeypatch.delenv("RLM_TOOLING", raising=False)
+    assert "fetch" not in [tool.name for tool in get_active_builtin_tools()]
+
+    monkeypatch.setenv("RLM_BUILTIN_TOOLS", "ipython,fetch")
+    assert [tool.name for tool in get_active_builtin_tools()] == ["ipython", "fetch"]
+
+
+def test_fetch_tool_validates_args():
+    from rlm.tools.fetch import FetchTool
+
+    tool = FetchTool()
+    assert tool.schema()["function"]["name"] == "fetch"
+    assert tool.execute({}, None).content == "Error: url is required"
+    assert "max_chars" in tool.execute({"url": "x.org", "max_chars": 0}, None).content


### PR DESCRIPTION
Adds a built-in `fetch` skill: pre-imported async `fetch(url=...)` that GETs a page with httpx (redirects followed, browser-ish UA) and returns its **cleaned text** — scripts/styles/templates stripped, tags collapsed, entities unescaped — truncated to `max_chars` (default 20k). Non-UTF-8 pages decode safely (`errors="replace"`). Network/HTTP errors come back as short `Error: ...` strings (data for the agent, not a crash).

Pairs with the `search` skill: `search` finds URLs, `fetch` reads them. A neutral prompt line advertises the skill and its signature when enabled.

- `src/rlm/skills/fetch.py` — the skill
- `src/rlm/skills/__init__.py` — registers `fetch` in the built-ins
- `src/rlm/prompt.py` — `FETCH_SKILL_PROMPT`, emitted when the skill is enabled
- `README.md` — documents `fetch`
- tests: enable-stub + `html_to_text` markup stripping
- `src/rlm/tools/fetch.py` + registry entry — the native tool twin (opt-in); tests for opt-in activation + arg validation

## Measured effect (paired A/B, redsearcher, 100 tasks/arm, same pin, skills-only diff, no sub-agents)

| policy model | regime | WITH fetch | WITHOUT | delta | wins/losses/ties | sign-test p |
|---|---|---|---|---|---|---|
| deepseek-v4-flash | uncapped | 0.392 | 0.392 | +0.000 | 14/14/69 (n=97) | 1.0 |
| Laguna-S-2.1 | capped* | 0.219 | 0.177 | +0.042 | 17/13/66 (n=96) | 0.59 |

*capped = per-session 100 turns, 100k context, 8k/call, 10k tool-out (identical across arms).

**Reading:** no significant reward gain from the skill itself. Mechanism from mining the control arms: a strong code model simply substitutes — deepseek hand-rolled **12,086** page reads (`requests.get`/`urllib`/`curl`) across 100/100 control rollouts, so `fetch` is a convenience wrapper for a capability the model already exercises. Laguna shows a small positive trend (+0.042, n.s.) with modest adoption (29/100 rollouts, 391 calls). The value of `fetch` is therefore primarily **hygiene** (clean text instead of raw HTML in context, uniform error strings, one sanctioned path that a truncation policy can target) rather than measured task reward.

## Failure taxonomy from the runs (follow-up material)

2,971 fetch calls (deepseek arm): **33% error rate**, dominated by `404` (835× — **631 on en.wikipedia.org: the model guesses `/wiki/Title` URLs from memory**), then 403 (71), 429 (34). 28% of successful reads hit the 20k `max_chars` cap. Suggested follow-ups:
1. On 404, append a hint ("page not found — use `search()` to find the real URL") or auto-fallback to the site's search endpoint for known hosts (Wikipedia opensearch).
2. Continuation support (`fetch(url, start_char=N)` or a trailing "N more chars available" note) so truncated reads can page through.
3. Respect `Retry-After` on 429.

Per review, fetch is now ALSO exposed as a native builtin tool (`src/rlm/tools/fetch.py`): same cleaning/truncation/error semantics via helpers shared with the skill, sync execution for the tool worker thread. Registered but in no tooling preset — a network-capable tool activates only when named in `RLM_BUILTIN_TOOLS`.

First of a 4-PR stack: fetch (this) → contract-only config (#160) → execution guardrails (#158) → role-aware sub-agent prompting (#151).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables outbound HTTP from the IPython kernel when the skill is turned on, which expands attack surface and context size (large page reads), though behavior is bounded by truncation and matches existing network-capable skills like bash/requests.
> 
> **Overview**
> Adds an opt-in **`fetch`** built-in skill via `RLM_SKILLS`, alongside `edit` and `search`, so agents can call **`await fetch(url="...")`** from IPython instead of ad-hoc HTTP/curl.
> 
> The new **`rlm.skills.fetch`** module GETs pages with **httpx** (redirects, timeout, default UA), normalizes scheme-less URLs, converts HTML to plain text (strip script/style blocks and tags, unescape entities), truncates at **20k** chars by default, and returns short error strings on failure rather than raising. Registration writes the usual session stub like other kernel skills; the system prompt gains **`FETCH_SKILL_PROMPT`** when `fetch` is enabled. **README** documents the skill and `RLM_SKILLS` value. Tests cover stub generation and **`html_to_text`** markup stripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5594d8f5886d4472d7c8658648603fbef7b8ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
