### PR TITLE
fix: prevent sub-agents from escalating recursion depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All configuration is via environment variables:
 | `OPENAI_API_KEY` / `OPENAI_BASE_URL` | resolved by SDK | OpenAI pair — when `OPENAI_API_KEY` is set, AsyncOpenAI's native env handling is used (covers OpenAI direct and verifiers' rollout tunnel both). Provider precedence: explicit → PI → OpenAI. Keys are scoped to their own base URL so an `OPENAI_API_KEY` lying around can't leak to PI Inference. |
 | `RLM_SKILLS` | — | Comma-separated built-in skills to enable (`edit`, `search`); pre-imported into the kernel. Unknown names raise. See [Skills](#skills). |
 | `RLM_MCP_CONFIG` | — | Standard `mcpServers` config (streamable HTTP or stdio); each server's tools become pre-imported IPython skills (`<server>_<tool>`). See [MCP tools as skills](#mcp-tools-as-skills). |
-| `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |
+| `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents; hard limit: `8`) |
 | `RLM_EXEC_TIMEOUT` | `300` | Seconds per IPython execution |
 | `RLM_MAX_OUTPUT` | `-1` | Max chars returned from a tool call (`-1` disables truncation; `0` is invalid) |
 | `RLM_SUMMARIZE_AT_TOKENS` | — | Auto-compaction threshold: when a turn's prompt tokens reach this value, the conversation is compacted into a summary. Unset disables auto-compaction. |

--- a/src/rlm/api.py
+++ b/src/rlm/api.py
@@ -7,10 +7,14 @@ from rlm.session import Session
 from rlm.types import RLMResult
 
 
-def _child_session() -> Session | None:
+def _child_session(
+    parent_dir: str | os.PathLike | None = None, depth: int | None = None
+) -> Session | None:
     """If inside a parent session (depth > 0), create a child under it."""
-    parent_dir = os.environ.get("RLM_SESSION_DIR")
-    depth = int(os.environ.get("RLM_DEPTH", "0"))
+    if parent_dir is None:
+        parent_dir = os.environ.get("RLM_SESSION_DIR")
+    if depth is None:
+        depth = int(os.environ.get("RLM_DEPTH", "0"))
     if parent_dir and depth > 0:
         return Session(Session.child_dir(parent_dir))
     return None
@@ -18,9 +22,20 @@ def _child_session() -> Session | None:
 
 async def run(prompt: str, **kwargs) -> RLMResult:
     """Run a single rlm agent."""
-    if "session" not in kwargs:
-        child = _child_session()
+    depth = kwargs.pop("_depth", None)
+    max_depth = kwargs.pop("_max_depth", None)
+    parent_session_dir = kwargs.pop("_parent_session_dir", None)
+    if parent_session_dir is not None:
+        child = _child_session(parent_session_dir, depth)
         if child:
             kwargs["session"] = child
+    elif "session" not in kwargs:
+        child = _child_session(depth=depth)
+        if child:
+            kwargs["session"] = child
+    if depth is not None:
+        kwargs["depth"] = depth
+    if max_depth is not None:
+        kwargs["max_depth"] = max_depth
     engine = RLMEngine(**kwargs)
     return await engine.run(prompt)

--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -65,7 +65,7 @@ def resolve_provider() -> tuple[str | None, str | None, dict[str, str]]:
     return PI_INFERENCE_BASE_URL, "EMPTY", {}
 
 
-def make_client() -> AsyncOpenAI:
+def make_client(depth: int | None = None) -> AsyncOpenAI:
     """Create an AsyncOpenAI client from environment variables.
 
     See ``resolve_provider`` for provider precedence. Tags every outbound
@@ -75,7 +75,8 @@ def make_client() -> AsyncOpenAI:
     record them in the rollout's trajectory.
     """
     base_url, api_key, extra_headers = resolve_provider()
-    headers = {"X-RLM-Depth": os.environ.get("RLM_DEPTH", "0"), **extra_headers}
+    rlm_depth = os.environ.get("RLM_DEPTH", "0") if depth is None else str(depth)
+    headers = {"X-RLM-Depth": rlm_depth, **extra_headers}
     return AsyncOpenAI(
         base_url=base_url,
         api_key=api_key,

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -38,6 +38,8 @@ from rlm.types import CompactionApplied, RLMMetrics, RLMResult, TokenUsage
 
 logger = logging.getLogger(__name__)
 
+HARD_MAX_DEPTH = 8
+
 
 # Injected as a user message when the branch's context size reaches the
 # compaction threshold. The model's next reply is expected to be a
@@ -157,6 +159,8 @@ class RLMEngine:
         session: Session | None = None,
         client: AsyncOpenAI | None = None,
         mcp_servers: dict[str, MCPServer] | None = None,
+        depth: int | None = None,
+        max_depth: int | None = None,
     ):
         self.model = model or os.environ.get("RLM_MODEL", "openai/gpt-5-mini")
         self.cwd = cwd or os.getcwd()
@@ -187,8 +191,13 @@ class RLMEngine:
         self.append_to_system_prompt = append_to_system_prompt or os.environ.get(
             "RLM_APPEND_TO_SYSTEM_PROMPT"
         )
-        self.max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
-        self.depth = int(os.environ.get("RLM_DEPTH", "0"))
+        configured_max_depth = int(
+            os.environ.get("RLM_MAX_DEPTH", "0") if max_depth is None else max_depth
+        )
+        self.max_depth = max(0, min(configured_max_depth, HARD_MAX_DEPTH))
+        self.depth = max(
+            0, int(os.environ.get("RLM_DEPTH", "0") if depth is None else depth)
+        )
 
         # Task MCP tool servers to expose as IPython skills; kwarg wins, otherwise
         # parse RLM_MCP_CONFIG (a standard mcpServers config).
@@ -208,7 +217,7 @@ class RLMEngine:
         _max_tok = int(os.environ.get("RLM_MAX_TOKENS", "0"))
         self.max_tokens = _max_tok if _max_tok > 0 else None
 
-        self.client = client or make_client()
+        self.client = client or make_client(depth=self.depth)
         self.session = session
         self._total_usage = TokenUsage()
         self._last_prompt_tokens = 0
@@ -360,7 +369,13 @@ class RLMEngine:
             if self.mcp_servers
             else None
         )
-        self._repl = IPythonREPL(cwd=self.cwd, session=self.session, env=repl_env)
+        self._repl = IPythonREPL(
+            cwd=self.cwd,
+            session=self.session,
+            env=repl_env,
+            depth=self.depth,
+            max_depth=self.max_depth,
+        )
         try:
             self._repl.start()
             self._known_children = {p.name for p in self.session.dir.glob("sub-*")}

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -133,10 +133,16 @@ class IPythonREPL:
         cwd: str,
         session: "Session | None" = None,
         env: dict[str, str] | None = None,
+        depth: int | None = None,
+        max_depth: int | None = None,
     ):
         self.cwd = cwd
         self.session = session
         self.env = env or {}
+        self.depth = int(os.environ.get("RLM_DEPTH", "0") if depth is None else depth)
+        self.max_depth = int(
+            os.environ.get("RLM_MAX_DEPTH", "0") if max_depth is None else max_depth
+        )
         self._km = None
         self._kc = None
         self._ipc_dir = None
@@ -181,8 +187,8 @@ class IPythonREPL:
     def _inject_startup(self):
         """Set up kernel: cwd, env vars, nest_asyncio, skill pre-imports."""
         session_dir = str(self.session.dir) if self.session else None
-        depth = int(os.environ.get("RLM_DEPTH", "0"))
-        max_depth = int(os.environ.get("RLM_MAX_DEPTH", "0"))
+        depth = self.depth
+        max_depth = self.max_depth
         allow_recursion = depth < max_depth
         # Pip-installed skills + the MCP-tool modules generated into the session dir (rlm.mcp);
         # the session dir goes on the kernel's sys.path so those import by name.
@@ -251,8 +257,23 @@ def _wrap_callable(mod, log_source):
 for _name in {skill_names!r}:
     globals()[_name] = _wrap_callable(__import__(_name), 'python')
 
+def _bind_rlm_run(run):
+    async def bounded_run(prompt, **kwargs):
+        kwargs['_depth'] = {depth!r} + 1
+        kwargs['_max_depth'] = {max_depth!r}
+        kwargs['_parent_session_dir'] = {session_dir!r}
+        return await run(prompt, **kwargs)
+
+    bounded_run.__signature__ = inspect.signature(run)
+    bounded_run.__doc__ = run.__doc__
+    return bounded_run
+
+
+_rlm = _wrap_callable(__import__('rlm'), None)
+_rlm.run = _bind_rlm_run(_rlm.run)
 if {allow_recursion!r}:
-    globals()['rlm'] = _wrap_callable(__import__('rlm'), None)
+    globals()['rlm'] = _rlm
+del _bind_rlm_run, _rlm
 """
         self._execute_silent(setup_code)
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -16,7 +16,8 @@ import pytest
 
 from conftest import DummyClient, DummyMessage, DummyToolCall
 from rlm.acp import RLMACPAgent
-from rlm.engine import RLMEngine
+from rlm.api import run as run_rlm
+from rlm.engine import HARD_MAX_DEPTH, RLMEngine
 from rlm.session import Session
 from rlm.types import RLMResult, TokenUsage
 
@@ -191,6 +192,37 @@ async def test_depth_limit_is_a_completed_result(monkeypatch, session):
     assert result.answer == "[depth limit 0 reached, cannot start]"
     assert meta["status"] == "done"
     assert meta["metrics"]["stop_reason"] == "depth_limit"
+
+
+async def test_explicit_recursion_context_ignores_mutated_env(monkeypatch, session):
+    monkeypatch.setenv("RLM_DEPTH", "0")
+    monkeypatch.setenv("RLM_MAX_DEPTH", "5")
+    client = DummyClient([])
+
+    result = await run_rlm(
+        "too deep",
+        _depth=2,
+        _max_depth=1,
+        _parent_session_dir=session.dir,
+        client=client,
+        session=session,
+    )
+
+    assert result.answer == "[depth limit 1 reached, cannot start]"
+    assert result.session_dir.parent == session.dir
+    assert client.calls == []
+
+
+def test_max_depth_has_a_hard_ceiling():
+    engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        depth=-1,
+        max_depth=HARD_MAX_DEPTH + 1,
+    )
+
+    assert engine.depth == 0
+    assert engine.max_depth == HARD_MAX_DEPTH
+    engine.close()
 
 
 async def test_compaction_counts_seed_prompt(session):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,6 +16,7 @@ from conftest import (
     tool_result,
 )
 
+import rlm.client as client_module
 from rlm.engine import RLMEngine
 
 
@@ -92,3 +93,48 @@ def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     assert captured.out == ""
     assert captured.err == ""
     assert result.strip() == "4 14"
+
+
+def test_ipython_recursion_context_ignores_env_mutation(session):
+    from rlm.tools.ipython import IPythonREPL
+
+    repl = IPythonREPL(
+        cwd=str(session.dir),
+        session=session,
+        depth=1,
+        max_depth=1,
+    )
+    repl.start()
+    try:
+        output = repl.execute(
+            "import os\n"
+            "os.environ['RLM_DEPTH'] = '0'\n"
+            "os.environ['RLM_MAX_DEPTH'] = '5'\n"
+            "print('preloaded', 'rlm' in globals())\n"
+            "import rlm\n"
+            "result = await rlm('too deep', client=object())\n"
+            "print(result.answer)"
+        )
+    finally:
+        repl.shutdown()
+
+    assert output.splitlines() == [
+        "preloaded False",
+        "[depth limit 1 reached, cannot start]",
+    ]
+
+
+def test_client_uses_explicit_depth_for_request_header(monkeypatch):
+    kwargs = {}
+
+    def fake_client(**client_kwargs):
+        kwargs.update(client_kwargs)
+        return object()
+
+    monkeypatch.setenv("RLM_API_KEY", "test-key")
+    monkeypatch.setenv("RLM_DEPTH", "0")
+    monkeypatch.setattr(client_module, "AsyncOpenAI", fake_client)
+
+    client_module.make_client(depth=2)
+
+    assert kwargs["default_headers"]["X-RLM-Depth"] == "2"


### PR DESCRIPTION
## Summary

- freeze child depth, maximum depth, and parent session state when the IPython kernel starts
- override mutable recursion context on calls through the injected `rlm`
- derive `X-RLM-Depth` from the engine's explicit depth
- clamp recursion to a hard maximum depth of 8
- add API-level and real-IPython regression coverage

## Root cause

Recursive engines derived their depth and maximum depth from `RLM_DEPTH` and `RLM_MAX_DEPTH` inside the IPython process. A sub-agent could rewrite those variables before calling `rlm`, causing the next engine to treat it as a root agent with a higher recursion limit. The same mutated depth was also used for the inference request header and child-session placement.

The injected `rlm` wrapper now captures the recursion context when the kernel is initialized and passes it through private arguments that override caller values. The engine threads that explicit depth into the child REPL and inference client. At the configured limit, `rlm` remains absent from the preloaded namespace, but an explicit import still receives the bounded wrapper and records a normal `depth_limit` result.

This is defense in depth for the reported environment-variable bypass. Full isolation from arbitrary in-process Python still requires a separate trusted process or sandbox boundary.

## Validation

- `uv run pytest tests/` — 116 passed
- `uv run pre-commit run --all-files` — passed
- `git diff --check` — passed

Closes #130
