### PR TITLE
feat: proxy MCP tools through the supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ not advertise `session/load`: an arbitrary live Python kernel cannot be
 reconstructed after the ACP process exits, so clients must keep the process
 alive for the lifetime of a session.
 
+ACP clients can pass trusted per-rollout configuration under the
+`ai.prime.rlm/runtime-v1` key in `session/new._meta`. Supported fields are an
+opaque `lineage_session_id`, explicit provider configuration, `kernel_env`, and
+`search_api_key`. This lets a harness deliver credentials over the private ACP
+stdio channel instead of placing them in the agent process environment. RLM
+never echoes those inputs. `session/new`, `session/prompt`, and `session/close`
+responses carry cumulative, credential-free snapshots under
+`ai.prime.rlm/session-v1`; only the close snapshot with `final: true` is
+authoritative for training metrics.
+
+Every inference request carries versioned `X-RLM-*` provenance headers for its
+session, invocation, prompt segment, logical call, causal parent, depth, and
+call kind (`turn` or `compaction`). IDs remain stable across transport retries
+and recursion inherits the spawning call and segment. These headers are
+observability metadata, not authorization, and are visible to the configured
+inference endpoint.
+
 ## Python SDK
 
 ```python

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ help(tools_add_event)  # signature (typed from the schema) + the tool's descript
 await tools_add_event(day="monday", title="standup")
 ```
 
-Each call connects using the configured transport, invokes the tool, and returns its text content (a tool-reported error is raised as `RuntimeError`). The generated modules are written into the session directory and the kernel imports them from there. Unlike installed skills, MCP skills are IPython-only — they're not exposed as shell commands.
+Each call connects using the configured transport, invokes the tool, and returns its text content (a tool-reported error is raised as `RuntimeError`). Discovery and invocation run in the session supervisor. The generated modules contain only the public tool schema and an opaque capability; server URLs, headers, commands, and environment variables are not copied into the kernel environment or session artifacts. The kernel imports these proxy modules from the session directory and reaches the supervisor over the session-local broker. Unlike installed skills, MCP skills are IPython-only — they're not exposed as shell commands.
 
 ## Kernel
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ All configuration is via environment variables:
 | `RLM_HOME` | `~/.rlm` | Root directory for sessions and data |
 | `RLM_MODEL` | `openai/gpt-5-mini` | Model name (PI Inference slug). Override with `--model` or `RLM_MODEL` for OpenAI/Anthropic direct (e.g. `gpt-4o`, `claude-sonnet-4-5`) |
 | `RLM_API_KEY` / `RLM_BASE_URL` | — / SDK default (`https://api.openai.com/v1`) | Explicit override (highest priority). Independent: setting `RLM_API_KEY` alone targets the SDK default endpoint; set `RLM_BASE_URL` too for a custom endpoint. For PI, use `PRIME_API_KEY` (below) which owns the full pair. |
-| `SERPER_API_KEY` | — | API key for the built-in `search` skill (Serper backend). Required when `search` is enabled. |
+| `SERPER_API_KEY` | — | API key for the built-in `search` skill (Serper backend). Resolved by the supervisor and not copied into the kernel. |
 | `PRIME_API_KEY` | — | PI Inference pair: targets `https://api.pinference.ai/api/v1` and forwards `PRIME_TEAM_ID` as `X-Prime-Team-ID` when set. |
 | `OPENAI_API_KEY` / `OPENAI_BASE_URL` | resolved at startup | OpenAI pair (covers OpenAI direct and verifiers' rollout tunnel). Provider precedence: explicit → PI → OpenAI. Keys are scoped to their own base URL so an `OPENAI_API_KEY` lying around can't leak to PI Inference. |
 | `RLM_SKILLS` | — | Comma-separated built-in skills to enable (`edit`, `search`); pre-imported into the kernel. Unknown names raise. See [Skills](#skills). |
 | `RLM_MCP_CONFIG` | — | Standard `mcpServers` config (streamable HTTP or stdio); each server's tools become pre-imported IPython skills (`<server>_<tool>`). See [MCP tools as skills](#mcp-tools-as-skills). |
+| `RLM_KERNEL_ENV` | `{}` | JSON object of task variables explicitly passed to IPython and its subprocesses. Supervisor, provider, MCP, and broker configuration names are reserved. |
 | `RLM_MAX_DEPTH` | `0` | Max recursion depth (`0` means no sub-agents) |
 | `RLM_MAX_CONCURRENT_SUBAGENTS` | `max(4, RLM_MAX_DEPTH)` | Maximum live recursive agents in a session tree. Capacity is reserved per depth to prevent nested-call deadlocks. |
 | `RLM_MAX_SUBAGENT_CALLS` | `64` | Maximum accepted recursive calls across the complete session tree. |
@@ -139,7 +140,7 @@ These artifacts are consumable for debugging, visualization, or training-data ex
 
 ## Skills
 
-`rlm` ships a small set of built-in skills enabled per run via `RLM_SKILLS` (`edit`, `search`; see [MCP tools as skills](#mcp-tools-as-skills) for the related MCP path). `search` does web search through Serper and needs `SERPER_API_KEY`; it returns title/URL/snippet for a single query (`await search(query="...")`). Additional skills are supplied by the host environment: before `install.sh` runs, the environment places skill packages under `/task/rlm-skills/<name>/`, and `install.sh` installs them alongside `rlm` so they're both importable and on `$PATH`.
+`rlm` ships a small set of built-in skills enabled per run via `RLM_SKILLS` (`edit`, `search`; see [MCP tools as skills](#mcp-tools-as-skills) for the related MCP path). `edit` runs in the kernel. Credentialed `search` runs in the supervisor through the capability broker, so `SERPER_API_KEY` is unavailable to IPython and its subprocesses; it returns title/URL/snippet for a single query (`await search(query="...")`). Additional skills are supplied by the host environment: before `install.sh` runs, the environment places skill packages under `/task/rlm-skills/<name>/`, and `install.sh` installs them alongside `rlm` so they're both importable and on `$PATH`.
 
 From IPython, import a skill and call its async `run(...)` entrypoint:
 
@@ -150,7 +151,7 @@ help(websearch)  # signature + docstring
 results = await websearch(queries=["latest jupyter_client release"])
 ```
 
-From the shell, invoke the same skill by command name:
+Uploaded `rlm-skill-*` packages also expose their declared console command. Session-generated built-in and MCP proxy skills are IPython-only:
 
 ```bash
 websearch --queries "latest jupyter_client release"
@@ -229,6 +230,8 @@ Each call connects using the configured transport, invokes the tool, and returns
 ## Kernel
 
 The IPython kernel always runs in rlm's own Python (`sys.executable`). `install.sh` puts `rlm` and all discovered skills into the same `uv tool install` environment, so `from rlm import run`, `import edit`, etc. work natively from inside an IPython cell.
+
+The kernel starts from a small platform environment (`PATH`, home/user/shell, locale, temporary-directory, certificate, and virtual-environment variables) plus the explicit `RLM_KERNEL_ENV` mapping. It receives private Jupyter/IPython config directories and does not inherit the rest of the supervisor process environment. This de-ambients credentials; it is not hostile-code containment because the kernel still shares the sandbox user, filesystem, process namespace, and network with the supervisor.
 
 To exercise packages from the target project's `.venv` (e.g. running its test suite), shell out from an IPython cell: `!./.venv/bin/python3 -m pytest`. The kernel itself stays isolated from whatever project venv the agent is working on — no cross-cell state involving sandbox packages.
 

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -66,6 +66,19 @@ class _SessionState:
     snapshot_sequence: int = 0
 
 
+def _request_is_cancelling(awaited: asyncio.Task[Any]) -> bool:
+    current = asyncio.current_task()
+    cancelling = getattr(current, "cancelling", None)
+    if cancelling is not None:
+        return bool(cancelling())
+    return not awaited.cancelled()
+
+
+async def _cancel_and_wait(task: asyncio.Task[Any]) -> None:
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
 def _session_metadata(
     state: _SessionState, status: SessionStatus, *, final: bool = False
 ) -> dict[str, Any]:
@@ -314,10 +327,10 @@ class RLMACPAgent(Agent):
             task = asyncio.create_task(state.engine.prompt(_prompt_text(prompt)))
             state.prompt_task = task
             try:
-                result = await task
+                result = await asyncio.shield(task)
             except asyncio.CancelledError:
-                current = asyncio.current_task()
-                if current is not None and current.cancelling():
+                if _request_is_cancelling(task):
+                    await _cancel_and_wait(task)
                     raise
                 state.last_stop_reason = "cancelled"
                 return PromptResponse(
@@ -352,10 +365,10 @@ class RLMACPAgent(Agent):
             )
             state.delivery_task = delivery
             try:
-                await delivery
+                await asyncio.shield(delivery)
             except asyncio.CancelledError:
-                current = asyncio.current_task()
-                if current is not None and current.cancelling():
+                if _request_is_cancelling(delivery):
+                    await _cancel_and_wait(delivery)
                     raise
                 if not state.closing:
                     raise

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -50,6 +50,11 @@ from rlm.tools.ipython import RESERVED_KERNEL_ENV_NAMES
 SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
 CAPABILITIES_METADATA_KEY = "ai.prime.rlm/capabilities-v1"
 RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
+CAPABILITIES_METADATA = {
+    "runtime_versions": [1],
+    "session_snapshot_versions": [1],
+    "lineage_versions": [1],
+}
 SessionStatus = Literal["created", "idle", "closing", "closed"]
 _LINEAGE_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 
@@ -266,9 +271,9 @@ class RLMACPAgent(Agent):
                 session_capabilities=SessionCapabilities(
                     close=SessionCloseCapabilities()
                 ),
+                field_meta={CAPABILITIES_METADATA_KEY: CAPABILITIES_METADATA},
             ),
             agent_info=Implementation(name="rlm", title="RLM", version=version("rlm")),
-            field_meta={CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}},
         )
 
     async def new_session(

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
+import re
+from dataclasses import dataclass, field, replace
 from importlib.metadata import version
-from typing import Any
+from typing import Any, Literal
 
 from acp import (
     PROTOCOL_VERSION,
@@ -41,8 +42,16 @@ from acp.schema import (
 )
 
 from rlm.engine import RLMEngine
+from rlm.config import ProviderConfig, RuntimeConfig
 from rlm.mcp import MCPServer
 from rlm.session import Session
+from rlm.tools.ipython import RESERVED_KERNEL_ENV_NAMES
+
+SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
+CAPABILITIES_METADATA_KEY = "ai.prime.rlm/capabilities-v1"
+RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
+SessionStatus = Literal["created", "idle", "closing", "closed"]
+_LINEAGE_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 
 
 @dataclass
@@ -50,7 +59,131 @@ class _SessionState:
     engine: RLMEngine
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     prompt_task: asyncio.Task | None = None
+    delivery_task: asyncio.Task | None = None
+    close_task: asyncio.Task[dict[str, Any]] | None = None
     closing: bool = False
+    last_stop_reason: str | None = None
+    snapshot_sequence: int = 0
+
+
+def _session_metadata(
+    state: _SessionState, status: SessionStatus, *, final: bool = False
+) -> dict[str, Any]:
+    snapshot = {
+        "schema_version": 1,
+        "sequence": state.snapshot_sequence,
+        "status": status,
+        "final": final,
+        "last_stop_reason": state.last_stop_reason,
+        **state.engine.execution_snapshot(),
+    }
+    state.snapshot_sequence += 1
+    return {SESSION_METADATA_KEY: snapshot}
+
+
+def _runtime_config(
+    field_meta: Any,
+) -> tuple[RuntimeConfig, str | None]:
+    config = RuntimeConfig.from_env()
+    if field_meta is None:
+        return config, None
+    if not isinstance(field_meta, dict):
+        raise RequestError.invalid_params({"reason": "ACP _meta must be an object"})
+    payload = field_meta.get(RUNTIME_METADATA_KEY)
+    if payload is None:
+        return config, None
+    if not isinstance(payload, dict):
+        raise RequestError.invalid_params(
+            {"reason": f"{RUNTIME_METADATA_KEY} must be an object"}
+        )
+    unknown = sorted(
+        set(payload)
+        - {"lineage_session_id", "provider", "kernel_env", "search_api_key"}
+    )
+    if unknown:
+        raise RequestError.invalid_params(
+            {"reason": f"{RUNTIME_METADATA_KEY} has unknown fields: {unknown}"}
+        )
+
+    lineage_session_id = payload.get("lineage_session_id")
+    if lineage_session_id is not None and (
+        not isinstance(lineage_session_id, str)
+        or _LINEAGE_ID_RE.fullmatch(lineage_session_id) is None
+    ):
+        raise RequestError.invalid_params(
+            {"reason": "lineage_session_id must be a bounded opaque identifier"}
+        )
+
+    provider = config.provider
+    if "provider" in payload:
+        provider_payload = payload["provider"]
+        if not isinstance(provider_payload, dict):
+            raise RequestError.invalid_params({"reason": "provider must be an object"})
+        provider_unknown = sorted(
+            set(provider_payload) - {"base_url", "api_key", "headers", "max_retries"}
+        )
+        if provider_unknown:
+            raise RequestError.invalid_params(
+                {"reason": f"provider has unknown fields: {provider_unknown}"}
+            )
+        base_url = provider_payload.get("base_url")
+        api_key = provider_payload.get("api_key")
+        headers = provider_payload.get("headers", {})
+        max_retries = provider_payload.get("max_retries", provider.max_retries)
+        if base_url is not None and not isinstance(base_url, str):
+            raise RequestError.invalid_params(
+                {"reason": "provider base_url is invalid"}
+            )
+        if not isinstance(api_key, str) or not api_key:
+            raise RequestError.invalid_params({"reason": "provider api_key is invalid"})
+        if not isinstance(headers, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in headers.items()
+        ):
+            raise RequestError.invalid_params(
+                {"reason": "provider headers are invalid"}
+            )
+        if (
+            not isinstance(max_retries, int)
+            or isinstance(max_retries, bool)
+            or max_retries < 0
+        ):
+            raise RequestError.invalid_params(
+                {"reason": "provider max_retries is invalid"}
+            )
+        try:
+            provider = ProviderConfig(base_url, api_key, headers, max_retries)
+        except ValueError as error:
+            raise RequestError.invalid_params({"reason": str(error)}) from error
+
+    kernel_env = payload.get("kernel_env")
+    if kernel_env is None:
+        resolved_kernel_env = config.kernel_env
+    elif not isinstance(kernel_env, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in kernel_env.items()
+    ):
+        raise RequestError.invalid_params({"reason": "kernel_env must map strings"})
+    else:
+        resolved_kernel_env = tuple(kernel_env.items())
+        reserved_kernel_env = sorted(RESERVED_KERNEL_ENV_NAMES.intersection(kernel_env))
+        if reserved_kernel_env:
+            raise RequestError.invalid_params(
+                {"reason": f"kernel_env contains reserved names: {reserved_kernel_env}"}
+            )
+
+    search_api_key = payload.get("search_api_key", config.search_api_key)
+    if search_api_key is not None and not isinstance(search_api_key, str):
+        raise RequestError.invalid_params({"reason": "search_api_key is invalid"})
+    return (
+        replace(
+            config,
+            provider=provider,
+            kernel_env=resolved_kernel_env,
+            search_api_key=search_api_key,
+        ),
+        lineage_session_id,
+    )
 
 
 def _mcp_servers(
@@ -122,6 +255,7 @@ class RLMACPAgent(Agent):
                 ),
             ),
             agent_info=Implementation(name="rlm", title="RLM", version=version("rlm")),
+            field_meta={CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}},
         )
 
     async def new_session(
@@ -137,6 +271,7 @@ class RLMACPAgent(Agent):
                 {"reason": "RLM does not support additional session directories"}
             )
         resolved_mcp_servers = _mcp_servers(mcp_servers)
+        runtime_config, lineage_session_id = _runtime_config(kwargs)
         session = Session()
         session_id = session.dir.name
         try:
@@ -144,12 +279,18 @@ class RLMACPAgent(Agent):
                 cwd=cwd,
                 session=session,
                 mcp_servers=resolved_mcp_servers,
+                runtime_config=runtime_config,
+                lineage_session_id=lineage_session_id,
             )
         except BaseException:
             session.close()
             raise
-        self._sessions[session_id] = _SessionState(engine=engine)
-        return NewSessionResponse(session_id=session_id)
+        state = _SessionState(engine=engine)
+        self._sessions[session_id] = state
+        return NewSessionResponse(
+            session_id=session_id,
+            field_meta=_session_metadata(state, "created"),
+        )
 
     async def prompt(
         self,
@@ -175,19 +316,56 @@ class RLMACPAgent(Agent):
             try:
                 result = await task
             except asyncio.CancelledError:
-                return PromptResponse(stop_reason="cancelled")
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
+                state.last_stop_reason = "cancelled"
+                return PromptResponse(
+                    stop_reason="cancelled",
+                    field_meta=_session_metadata(
+                        state, "closing" if state.closing else "idle"
+                    ),
+                )
+            except Exception:
+                state.last_stop_reason = "error"
+                raise
             finally:
                 state.prompt_task = None
 
-            await self._client.session_update(
-                session_id=session_id,
-                update=update_agent_message(text_block(result.answer)),
-            )
             stop_reason = (
                 "max_tokens"
                 if state.engine.stop_reason == "token_budget"
                 else "end_turn"
             )
+            state.last_stop_reason = state.engine.stop_reason or stop_reason
+            if state.closing:
+                return PromptResponse(
+                    stop_reason="cancelled",
+                    field_meta=_session_metadata(state, "closing"),
+                )
+
+            delivery = asyncio.create_task(
+                self._client.session_update(
+                    session_id=session_id,
+                    update=update_agent_message(text_block(result.answer)),
+                )
+            )
+            state.delivery_task = delivery
+            try:
+                await delivery
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
+                if not state.closing:
+                    raise
+                return PromptResponse(
+                    stop_reason="cancelled",
+                    field_meta=_session_metadata(state, "closing"),
+                )
+            finally:
+                state.delivery_task = None
+
             return PromptResponse(
                 stop_reason=stop_reason,
                 usage=Usage(
@@ -195,6 +373,7 @@ class RLMACPAgent(Agent):
                     input_tokens=result.usage.prompt_tokens,
                     output_tokens=result.usage.completion_tokens,
                 ),
+                field_meta=_session_metadata(state, "idle"),
             )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
@@ -205,19 +384,41 @@ class RLMACPAgent(Agent):
     async def close_session(
         self, session_id: str, **kwargs: Any
     ) -> CloseSessionResponse:
-        state = self._sessions.pop(session_id, None)
+        state = self._sessions.get(session_id)
         if state is None:
             raise RequestError.resource_not_found(session_id)
-        state.closing = True
-        if state.prompt_task is not None:
-            state.prompt_task.cancel()
-        async with state.lock:
-            await state.engine.aclose()
-        return CloseSessionResponse()
+        if state.close_task is None:
+            state.closing = True
+            state.close_task = asyncio.create_task(
+                self._close_session(session_id, state)
+            )
+        metadata = await asyncio.shield(state.close_task)
+        return CloseSessionResponse(field_meta=metadata)
+
+    async def _close_session(
+        self, session_id: str, state: _SessionState
+    ) -> dict[str, Any]:
+        try:
+            if state.prompt_task is not None:
+                state.prompt_task.cancel()
+            if state.delivery_task is not None:
+                state.delivery_task.cancel()
+            async with state.lock:
+                await state.engine.aclose()
+            return _session_metadata(state, "closed", final=True)
+        finally:
+            if self._sessions.get(session_id) is state:
+                self._sessions.pop(session_id)
 
     async def shutdown(self) -> None:
-        for session_id in list(self._sessions):
-            await self.close_session(session_id)
+        results = await asyncio.gather(
+            *(self.close_session(session_id) for session_id in list(self._sessions)),
+            return_exceptions=True,
+        )
+        if error := next(
+            (result for result in results if isinstance(result, BaseException)), None
+        ):
+            raise error
 
 
 async def serve_acp() -> None:

--- a/src/rlm/broker.py
+++ b/src/rlm/broker.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
+import keyword
 import struct
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +26,15 @@ class BrokerEndpoint:
 
 _endpoint: BrokerEndpoint | None = None
 _scope_id: str | None = None
+
+_JSON_TO_PY = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
 
 
 def configure(endpoint: BrokerEndpoint | None) -> None:
@@ -98,16 +109,74 @@ async def run(prompt: str, **kwargs: Any) -> RLMResult:
         raise RuntimeError("recursive RLM calls are unavailable outside an active cell")
     if not isinstance(prompt, str):
         raise TypeError("prompt must be a string")
+    response = await _request(
+        {
+            "op": "rlm.run",
+            "prompt": prompt,
+            "options": kwargs,
+        }
+    )
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise RuntimeError("invalid response from RLM supervisor")
+    return result_from_json(result)
+
+
+async def call_skill(capability: str, arguments: dict[str, Any]) -> str:
+    """Invoke a supervisor-owned skill through its opaque capability."""
+    response = await _request(
+        {
+            "op": "skill.call",
+            "skill_capability": capability,
+            "arguments": arguments,
+        }
+    )
+    result = response.get("result")
+    if not isinstance(result, str):
+        raise RuntimeError("invalid skill response from RLM supervisor")
+    return result
+
+
+def make_skill(descriptor: dict[str, Any]):
+    """Build a callable coroutine from a public brokered-skill descriptor."""
+    capability = descriptor["capability"]
+    description = descriptor["description"]
+    schema = descriptor["input_schema"]
+
+    async def run(**kwargs: Any) -> str:
+        return await call_skill(capability, kwargs)
+
+    properties = schema.get("properties", {})
+    required = set(schema.get("required", []))
+    parameters = [
+        inspect.Parameter(
+            name,
+            inspect.Parameter.KEYWORD_ONLY,
+            default=inspect.Parameter.empty if name in required else None,
+            annotation=_JSON_TO_PY.get(value.get("type"), inspect.Parameter.empty),
+        )
+        for name, value in properties.items()
+        if name.isidentifier() and not keyword.iskeyword(name)
+    ]
+    parameters.sort(
+        key=lambda parameter: parameter.default is not inspect.Parameter.empty
+    )
+    run.__signature__ = inspect.Signature(parameters)
+    run.__doc__ = description
+    return run
+
+
+async def _request(payload: dict[str, Any]) -> dict[str, Any]:
+    if _endpoint is None or _scope_id is None:
+        raise RuntimeError("brokered calls are unavailable outside an active cell")
     reader, writer = await asyncio.open_unix_connection(_endpoint.socket_path)
     try:
         await write_frame(
             writer,
             {
-                "op": "rlm.run",
                 "capability": _endpoint.capability,
                 "scope_id": _scope_id,
-                "prompt": prompt,
-                "options": kwargs,
+                **payload,
             },
             MAX_REQUEST_BYTES,
         )
@@ -117,7 +186,4 @@ async def run(prompt: str, **kwargs: Any) -> RLMResult:
         await writer.wait_closed()
     if error := response.get("error"):
         raise RuntimeError(str(error))
-    result = response.get("result")
-    if not isinstance(result, dict):
-        raise RuntimeError("invalid response from RLM supervisor")
-    return result_from_json(result)
+    return response

--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -17,6 +17,16 @@ from pydantic import ValidationError
 from rlm.config import InvocationContext, ProviderConfig
 from rlm.types import TokenUsage
 
+RLM_SESSION_ID_HEADER = "X-RLM-Session-ID"
+RLM_INVOCATION_ID_HEADER = "X-RLM-Invocation-ID"
+RLM_PARENT_INVOCATION_ID_HEADER = "X-RLM-Parent-Invocation-ID"
+RLM_SEGMENT_ID_HEADER = "X-RLM-Segment-ID"
+RLM_CALL_ID_HEADER = "X-RLM-Call-ID"
+RLM_PARENT_CALL_ID_HEADER = "X-RLM-Parent-Call-ID"
+RLM_DEPTH_HEADER = "X-RLM-Depth"
+RLM_CALL_KIND_HEADER = "X-RLM-Call-Kind"
+RLM_LINEAGE_VERSION_HEADER = "X-RLM-Lineage-Version"
+
 _RETRYABLE: tuple[type[BaseException], ...] = (
     APIConnectionError,
     APITimeoutError,
@@ -68,13 +78,46 @@ def make_client(
     """
     provider = provider or ProviderConfig.from_env()
     invocation = invocation or InvocationContext.from_env()
-    headers = {"X-RLM-Depth": str(invocation.depth), **provider.headers}
+    reserved = sorted(
+        name for name in provider.headers if name.lower().startswith("x-rlm-")
+    )
+    if reserved:
+        raise ValueError(f"provider headers contain reserved names: {reserved}")
+    headers = {**provider.headers, RLM_DEPTH_HEADER: str(invocation.depth)}
     return AsyncOpenAI(
         base_url=provider.base_url,
         api_key=provider.api_key,
         max_retries=provider.max_retries,
         default_headers=headers,
     )
+
+
+def model_call_headers(
+    *,
+    session_id: str,
+    invocation_id: str,
+    parent_invocation_id: str | None,
+    segment_id: str,
+    call_id: str,
+    parent_call_id: str | None,
+    depth: int,
+    call_kind: str,
+) -> dict[str, str]:
+    """Build provenance headers for one logical model call."""
+    headers = {
+        RLM_LINEAGE_VERSION_HEADER: "1",
+        RLM_SESSION_ID_HEADER: session_id,
+        RLM_INVOCATION_ID_HEADER: invocation_id,
+        RLM_SEGMENT_ID_HEADER: segment_id,
+        RLM_CALL_ID_HEADER: call_id,
+        RLM_DEPTH_HEADER: str(depth),
+        RLM_CALL_KIND_HEADER: call_kind,
+    }
+    if parent_invocation_id is not None:
+        headers[RLM_PARENT_INVOCATION_ID_HEADER] = parent_invocation_id
+    if parent_call_id is not None:
+        headers[RLM_PARENT_CALL_ID_HEADER] = parent_call_id
+    return headers
 
 
 async def call_with_retries(

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -58,6 +58,13 @@ class ProviderConfig:
     headers: dict[str, str] = field(default_factory=dict, repr=False)
     max_retries: int = 5
 
+    def __post_init__(self) -> None:
+        reserved = sorted(
+            name for name in self.headers if name.lower().startswith("x-rlm-")
+        )
+        if reserved:
+            raise ValueError(f"provider headers contain reserved names: {reserved}")
+
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> ProviderConfig:
         env = os.environ if environ is None else environ

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass, field
 from typing import Mapping
 
 
 PI_INFERENCE_BASE_URL = "https://api.pinference.ai/api/v1"
+KERNEL_ENV_CONFIG_ENV = "RLM_KERNEL_ENV"
 
 
 def _optional_positive_int(value: str | int | None, name: str) -> int | None:
@@ -36,13 +38,24 @@ def _summarize_at_tokens(value: str | int | None) -> int | None:
     return parsed
 
 
+def _kernel_env(value: str | None) -> tuple[tuple[str, str], ...]:
+    if not value:
+        return ()
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict) or not all(
+        isinstance(key, str) and isinstance(item, str) for key, item in parsed.items()
+    ):
+        raise ValueError(f"{KERNEL_ENV_CONFIG_ENV} must be a JSON object of strings")
+    return tuple(parsed.items())
+
+
 @dataclass(frozen=True)
 class ProviderConfig:
     """Credentials and transport options for one inference provider."""
 
     base_url: str | None
-    api_key: str | None
-    headers: dict[str, str] = field(default_factory=dict)
+    api_key: str | None = field(repr=False)
+    headers: dict[str, str] = field(default_factory=dict, repr=False)
     max_retries: int = 5
 
     @classmethod
@@ -132,6 +145,8 @@ class RuntimeConfig:
     system_prompt_path: str | None = None
     append_to_system_prompt: str | None = None
     skills: tuple[str, ...] = ()
+    kernel_env: tuple[tuple[str, str], ...] = field(default=(), repr=False)
+    search_api_key: str | None = field(default=None, repr=False)
 
     @classmethod
     def from_env(
@@ -190,4 +205,6 @@ class RuntimeConfig:
             append_to_system_prompt=append_to_system_prompt
             or env.get("RLM_APPEND_TO_SYSTEM_PROMPT"),
             skills=tuple(s.strip() for s in raw_skills.split(",") if s.strip()),
+            kernel_env=_kernel_env(env.get(KERNEL_ENV_CONFIG_ENV)),
+            search_api_key=env.get("SERPER_API_KEY"),
         )

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -14,13 +14,7 @@ from openai import AsyncOpenAI, BadRequestError
 
 from rlm.client import call_with_retries, extract_usage, make_client
 from rlm.config import RuntimeConfig
-from rlm.mcp import (
-    MCP_CONFIG_ENV,
-    MCPServer,
-    dump_mcp_servers,
-    generate_mcp_skills,
-    load_mcp_servers,
-)
+from rlm.mcp import MCPServer, load_mcp_servers
 from rlm.prompt import build_system_prompt
 from rlm.session import Session
 from rlm.skills import enable_builtin_skills
@@ -302,27 +296,10 @@ class RLMEngine:
             cwd=self.cwd,
         )
 
-        # Skills the kernel pre-imports, all written into the session dir (the REPL and prompt
-        # read them back from there): enabled built-in skills (rlm.skills) + any wired MCP tools
-        # (PTC). ipython is the sole builtin tool, so the kernel always starts.
+        # Skills the kernel pre-imports are written into the session directory.
         enable_builtin_skills(self.skills, self.session.dir)
-        if self.mcp_servers:
-            mcp_skills = await generate_mcp_skills(
-                self.mcp_servers, self.session.dir, self.cwd
-            )
-            logger.info(
-                "rlm: exposed %d MCP tool(s) as skills - %s",
-                len(mcp_skills),
-                ", ".join(mcp_skills),
-            )
-
-        repl_env = (
-            {MCP_CONFIG_ENV: dump_mcp_servers(self.mcp_servers)}
-            if self.mcp_servers
-            else None
-        )
         broker_endpoint = None
-        if self.depth < self.max_depth:
+        if self.depth < self.max_depth or self.mcp_servers:
             if self._supervisor is None:
                 self._supervisor = SessionTreeSupervisor(
                     root_session=self.session,
@@ -332,15 +309,32 @@ class RLMEngine:
                 )
                 self._invocation_id = self._supervisor.root_id
                 self._owns_supervisor = True
-            await self._supervisor.start()
-            if self._invocation_id is None:
-                raise RuntimeError("recursive engine has no supervisor invocation")
-            broker_endpoint = self._supervisor.endpoint_for(self._invocation_id)
+            try:
+                await self._supervisor.start()
+                if self._invocation_id is None:
+                    raise RuntimeError("recursive engine has no supervisor invocation")
+                broker_endpoint = self._supervisor.endpoint_for(self._invocation_id)
+                if self.mcp_servers:
+                    reserved_names = {"rlm", *self.skills, *discover_skills()}
+                    mcp_skills = self._supervisor.write_mcp_skill_modules(
+                        self.session.dir, reserved_names
+                    )
+                    logger.info(
+                        "rlm: exposed %d brokered MCP tool(s) as skills - %s",
+                        len(mcp_skills),
+                        ", ".join(mcp_skills),
+                    )
+            except BaseException:
+                if self._owns_supervisor:
+                    await self._supervisor.aclose()
+                    self._supervisor = None
+                    self._invocation_id = None
+                    self._owns_supervisor = False
+                raise
 
         self._repl = IPythonREPL(
             cwd=self.cwd,
             session=self.session,
-            env=repl_env,
             depth=self.depth,
             max_depth=self.max_depth,
             broker_endpoint=broker_endpoint,
@@ -626,6 +620,14 @@ class RLMEngine:
         try:
             if self.session is not None:
                 if self._has_result:
+                    direct_tool_stats = None
+                    child_tool_stats = None
+                    if self._supervisor is not None and self._invocation_id is not None:
+                        direct_tool_stats, child_tool_stats = (
+                            self._supervisor.programmatic_tool_call_stats(
+                                self._invocation_id
+                            )
+                        )
                     self.session.finalize(
                         self._last_answer,
                         usage={
@@ -634,6 +636,8 @@ class RLMEngine:
                         },
                         turns=self._turn,
                         metrics=self._metrics,
+                        trusted_direct_tool_stats=direct_tool_stats,
+                        trusted_child_tool_stats=child_tool_stats,
                     )
                 else:
                     self.session.close()

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -8,11 +8,18 @@ import json
 import logging
 import os
 import time
+import uuid
+from copy import deepcopy
 from pathlib import Path
 
 from openai import AsyncOpenAI, BadRequestError
 
-from rlm.client import call_with_retries, extract_usage, make_client
+from rlm.client import (
+    call_with_retries,
+    extract_usage,
+    make_client,
+    model_call_headers,
+)
 from rlm.config import RuntimeConfig
 from rlm.mcp import MCPServer, load_mcp_servers
 from rlm.prompt import build_system_prompt
@@ -30,7 +37,13 @@ from rlm.tools import (
     get_builtin_tool,
     get_installed_skills,
 )
-from rlm.types import CompactionApplied, RLMMetrics, RLMResult, TokenUsage
+from rlm.types import (
+    CompactionApplied,
+    ProgrammaticToolCallStats,
+    RLMMetrics,
+    RLMResult,
+    TokenUsage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +138,10 @@ class RLMEngine:
         runtime_config: RuntimeConfig | None = None,
         supervisor: SessionTreeSupervisor | None = None,
         invocation_id: str | None = None,
+        parent_invocation_id: str | None = None,
+        parent_call_id: str | None = None,
+        lineage_session_id: str | None = None,
+        segment_id: str | None = None,
     ):
         if runtime_config is not None and any(
             value is not None
@@ -171,7 +188,21 @@ class RLMEngine:
         self.client = client or make_client(config.provider, config.invocation)
         self.session = session
         self._supervisor = supervisor
-        self._invocation_id = invocation_id
+        self._invocation_id = invocation_id or (
+            supervisor.root_id if supervisor is not None else uuid.uuid4().hex
+        )
+        self._parent_invocation_id = parent_invocation_id
+        self._last_call_id = parent_call_id
+        if (
+            supervisor is not None
+            and lineage_session_id is not None
+            and lineage_session_id != supervisor.session_id
+        ):
+            raise ValueError("lineage_session_id does not match the session supervisor")
+        self._lineage_session_id = lineage_session_id or (
+            supervisor.session_id if supervisor is not None else None
+        )
+        self._initial_segment_id = segment_id
         self._owns_supervisor = False
         self._total_usage = TokenUsage()
         self._last_prompt_tokens = 0
@@ -242,10 +273,13 @@ class RLMEngine:
             prompt_tokens=self._total_usage.prompt_tokens,
             completion_tokens=self._total_usage.completion_tokens,
         )
+        lineage_head_before = self._last_call_id
 
         self._metrics.stop_reason = ""
+        segment_id = self._initial_segment_id or uuid.uuid4().hex
+        self._initial_segment_id = None
         try:
-            result = await self._run_loop()
+            result = await self._run_loop(segment_id)
         except BaseException as exc:
             attempted_turns = self._turn - turn_before
             try:
@@ -269,6 +303,7 @@ class RLMEngine:
             self._messages[:] = messages_before
             self._branch_start_turn = branch_start_before
             self._turn = turn_before
+            self._last_call_id = lineage_head_before
             if isinstance(exc, asyncio.CancelledError):
                 self._metrics.stop_reason = "cancelled"
             raise
@@ -297,6 +332,8 @@ class RLMEngine:
             prompt_preview=prompt[:200],
             cwd=self.cwd,
         )
+        if self._lineage_session_id is None:
+            self._lineage_session_id = self.session.dir.name
 
         # Credential-free built-ins run locally; privileged skills are brokered.
         local_skills = [name for name in self.skills if name != "search"]
@@ -309,13 +346,12 @@ class RLMEngine:
                     runtime_config=self.runtime_config,
                     cwd=self.cwd,
                     mcp_servers=self.mcp_servers,
+                    root_invocation_id=self._invocation_id,
+                    lineage_session_id=self._lineage_session_id,
                 )
-                self._invocation_id = self._supervisor.root_id
                 self._owns_supervisor = True
             try:
                 await self._supervisor.start()
-                if self._invocation_id is None:
-                    raise RuntimeError("recursive engine has no supervisor invocation")
                 broker_endpoint = self._supervisor.endpoint_for(self._invocation_id)
                 if self.mcp_servers or "search" in self.skills:
                     reserved_names = {"rlm", *local_skills, *discover_skills()}
@@ -331,7 +367,6 @@ class RLMEngine:
                 if self._owns_supervisor:
                     await self._supervisor.aclose()
                     self._supervisor = None
-                    self._invocation_id = None
                     self._owns_supervisor = False
                 raise
 
@@ -362,11 +397,10 @@ class RLMEngine:
             if self._owns_supervisor and self._supervisor is not None:
                 await self._supervisor.aclose()
                 self._supervisor = None
-                self._invocation_id = None
                 self._owns_supervisor = False
             raise
 
-    async def _run_loop(self) -> RLMResult:
+    async def _run_loop(self, segment_id: str) -> RLMResult:
         messages = self._messages
         if messages is None:
             raise RuntimeError("RLM engine is not started")
@@ -376,9 +410,11 @@ class RLMEngine:
         for turn in itertools.count(self._turn):
             self._turn = turn + 1
             # Call LLM
+            call_id = uuid.uuid4().hex
             request_kwargs = {
                 "model": self.model,
                 "messages": messages,
+                "extra_headers": self._model_call_headers(segment_id, call_id, "turn"),
             }
             if self._active_tool_schemas:
                 request_kwargs["tools"] = self._active_tool_schemas
@@ -394,7 +430,6 @@ class RLMEngine:
                 self._metrics.stop_reason = "request_too_large"
                 final_text = "[request body too large]"
                 break
-
             usage = extract_usage(response)
             self._total_usage.prompt_tokens += usage.prompt_tokens
             self._total_usage.completion_tokens += usage.completion_tokens
@@ -408,6 +443,7 @@ class RLMEngine:
             msg_dict = msg.model_dump(exclude_none=True)
             msg_dict.setdefault("content", "")
             messages.append(msg_dict)
+            self._last_call_id = call_id
 
             # Log assistant message; parse tool-call args once, reuse below.
             tool_calls_log: list[dict] | None = None
@@ -479,7 +515,11 @@ class RLMEngine:
                     and self._supervisor is not None
                     and self._invocation_id is not None
                 ):
-                    scope_id = await self._supervisor.open_scope(self._invocation_id)
+                    scope_id = await self._supervisor.open_scope(
+                        self._invocation_id,
+                        parent_call_id=call_id,
+                        segment_id=segment_id,
+                    )
                 try:
                     if scope_id is not None:
                         repl.set_broker_scope(scope_id)
@@ -558,7 +598,7 @@ class RLMEngine:
             ):
                 try:
                     await self._compact_branch(
-                        messages, turn, self._active_tool_schemas
+                        messages, turn, self._active_tool_schemas, segment_id
                     )
                 except BadRequestError as e:
                     if not _is_request_too_large(e):
@@ -649,8 +689,31 @@ class RLMEngine:
             if self._repl is not None:
                 self._repl.shutdown()
 
+    def _programmatic_tool_call_stats(
+        self,
+    ) -> tuple[ProgrammaticToolCallStats, ProgrammaticToolCallStats]:
+        if self.session is None:
+            return ProgrammaticToolCallStats(), ProgrammaticToolCallStats()
+        direct = ProgrammaticToolCallStats.from_log(
+            self.session.dir / "programmatic_tool_calls.jsonl"
+        )
+        child = self.session.aggregate_child_metrics(
+            "local_programmatic_tool_call_stats"
+        ).tool_call_stats
+        if self._supervisor is not None:
+            trusted_direct, trusted_child = (
+                self._supervisor.programmatic_tool_call_stats(self._invocation_id)
+            )
+            direct = direct.merge(trusted_direct)
+            child = child.merge(trusted_child)
+        return direct, child
+
     async def _compact_branch(
-        self, messages: list[dict], turn: int, active_tools: list[dict]
+        self,
+        messages: list[dict],
+        turn: int,
+        active_tools: list[dict],
+        segment_id: str,
     ) -> None:
         """Ask the model for a handoff summary and rebuild ``messages``.
 
@@ -685,14 +748,25 @@ class RLMEngine:
         if self._repl is not None:
             checkpoint_prompt += REPL_RESTART_NOTE
         messages.append({"role": "user", "content": checkpoint_prompt})
-        request_kwargs: dict = {"model": self.model, "messages": messages}
+        call_id = uuid.uuid4().hex
+        request_kwargs: dict = {
+            "model": self.model,
+            "messages": messages,
+            "extra_headers": self._model_call_headers(
+                segment_id, call_id, "compaction"
+            ),
+        }
         if active_tools:
             request_kwargs["tools"] = active_tools
             request_kwargs["tool_choice"] = "none"
-        response = await call_with_retries(
-            self.client.chat.completions.create,
-            **request_kwargs,
-        )
+        try:
+            response = await call_with_retries(
+                self.client.chat.completions.create,
+                **request_kwargs,
+            )
+        except BaseException:
+            messages.pop()
+            raise
         usage = extract_usage(response)
         self._total_usage.prompt_tokens += usage.prompt_tokens
         self._total_usage.completion_tokens += usage.completion_tokens
@@ -732,6 +806,68 @@ class RLMEngine:
         )
         self._branch_start_turn = turn + 1
         self._metrics.turns_since_last_compaction = 0
+        self._last_call_id = call_id
+
+    def _model_call_headers(
+        self, segment_id: str, call_id: str, call_kind: str
+    ) -> dict[str, str]:
+        if self.session is None:
+            raise RuntimeError("RLM session is not initialized")
+        return model_call_headers(
+            session_id=self._lineage_session_id or self.session.dir.name,
+            invocation_id=self._invocation_id,
+            parent_invocation_id=self._parent_invocation_id,
+            segment_id=segment_id,
+            call_id=call_id,
+            parent_call_id=self._last_call_id,
+            depth=self.depth,
+            call_kind=call_kind,
+        )
+
+    def execution_snapshot(self) -> dict:
+        """Return a credential-free snapshot of cumulative execution state."""
+        if self.session is None:
+            raise RuntimeError("RLM session is not initialized")
+        direct_tool_stats, child_tool_stats = self._programmatic_tool_call_stats()
+        metrics = deepcopy(self._metrics)
+        metrics.apply_programmatic_tool_call_stats(direct_tool_stats, child_tool_stats)
+        metric_values = {
+            key: value
+            for key, value in metrics.to_dict().items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        }
+        snapshot = {
+            "session_id": self._lineage_session_id or self.session.dir.name,
+            "root_invocation_id": self._invocation_id,
+            "model": self.model,
+            "turns": self._turn,
+            "usage": {
+                "prompt_tokens": self._total_usage.prompt_tokens,
+                "completion_tokens": self._total_usage.completion_tokens,
+                "total_tokens": self._total_usage.total,
+            },
+            "metrics": metric_values,
+            "programmatic_tool_call_stats": direct_tool_stats.merge(
+                child_tool_stats
+            ).to_dict(),
+            "supervisor": {
+                "subagent_calls": self._supervisor.total_calls
+                if self._supervisor is not None
+                else 0,
+                "active_subagent_calls": self._supervisor.active_calls
+                if self._supervisor is not None
+                else 0,
+            },
+            "limits": {
+                "max_depth": self.runtime_config.policy.max_depth,
+                "max_concurrent_subagents": self.runtime_config.policy.max_concurrent_subagents,
+                "max_subagent_calls": self.runtime_config.policy.max_subagent_calls,
+                "max_tokens": self.runtime_config.policy.max_tokens,
+                "summarize_at_tokens": self.runtime_config.policy.summarize_at_tokens,
+                "max_compactions": self.runtime_config.policy.max_compactions,
+            },
+        }
+        return snapshot
 
     def _load_system_prompt(
         self, messages_path: str, active_tools: list[BuiltinTool]

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -28,6 +28,7 @@ from rlm.tools import (
     discover_skills,
     get_active_builtin_tools,
     get_builtin_tool,
+    get_installed_skills,
 )
 from rlm.types import CompactionApplied, RLMMetrics, RLMResult, TokenUsage
 
@@ -163,6 +164,7 @@ class RLMEngine:
 
         # Built-in skills (rlm.skills) to enable for this run, from RLM_SKILLS (comma-separated).
         self.skills = list(config.skills)
+        self.kernel_env = dict(config.kernel_env)
         self.max_tokens = config.policy.max_tokens
 
         self._owns_client = client is None
@@ -296,10 +298,11 @@ class RLMEngine:
             cwd=self.cwd,
         )
 
-        # Skills the kernel pre-imports are written into the session directory.
-        enable_builtin_skills(self.skills, self.session.dir)
+        # Credential-free built-ins run locally; privileged skills are brokered.
+        local_skills = [name for name in self.skills if name != "search"]
+        enable_builtin_skills(local_skills, self.session.dir)
         broker_endpoint = None
-        if self.depth < self.max_depth or self.mcp_servers:
+        if self.depth < self.max_depth or self.mcp_servers or "search" in self.skills:
             if self._supervisor is None:
                 self._supervisor = SessionTreeSupervisor(
                     root_session=self.session,
@@ -314,15 +317,15 @@ class RLMEngine:
                 if self._invocation_id is None:
                     raise RuntimeError("recursive engine has no supervisor invocation")
                 broker_endpoint = self._supervisor.endpoint_for(self._invocation_id)
-                if self.mcp_servers:
-                    reserved_names = {"rlm", *self.skills, *discover_skills()}
-                    mcp_skills = self._supervisor.write_mcp_skill_modules(
+                if self.mcp_servers or "search" in self.skills:
+                    reserved_names = {"rlm", *local_skills, *discover_skills()}
+                    brokered_skills = self._supervisor.write_brokered_skill_modules(
                         self.session.dir, reserved_names
                     )
                     logger.info(
-                        "rlm: exposed %d brokered MCP tool(s) as skills - %s",
-                        len(mcp_skills),
-                        ", ".join(mcp_skills),
+                        "rlm: exposed %d supervisor-owned skill(s) - %s",
+                        len(brokered_skills),
+                        ", ".join(brokered_skills),
                     )
             except BaseException:
                 if self._owns_supervisor:
@@ -335,6 +338,7 @@ class RLMEngine:
         self._repl = IPythonREPL(
             cwd=self.cwd,
             session=self.session,
+            kernel_env=self.kernel_env,
             depth=self.depth,
             max_depth=self.max_depth,
             broker_endpoint=broker_endpoint,
@@ -741,6 +745,7 @@ class RLMEngine:
             messages_path,
             allow_recursion=self.depth < self.max_depth,
             active_tools=active_tools,
+            shell_skills=get_installed_skills(),
         )
         if self.append_to_system_prompt:
             system_prompt += "\n\n" + self.append_to_system_prompt

--- a/src/rlm/mcp.py
+++ b/src/rlm/mcp.py
@@ -156,24 +156,8 @@ class MCPRegistry:
     ) -> list[str]:
         if self._tools is None:
             raise RuntimeError("MCP tools have not been discovered")
-        reserved = set(reserved_names)
         descriptors = [entry.descriptor for entry in self._tools.values()]
-        conflicts = sorted(
-            descriptor.name for descriptor in descriptors if descriptor.name in reserved
-        )
-        if conflicts:
-            raise ValueError(
-                f"MCP tool names conflict with existing skills: {conflicts}"
-            )
-
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        for descriptor in descriptors:
-            source = _MODULE_TEMPLATE.format(
-                description=descriptor.description,
-                descriptor=descriptor.to_dict(),
-            )
-            (dest_dir / f"{descriptor.name}.py").write_text(source)
-        return [descriptor.name for descriptor in descriptors]
+        return write_skill_modules(descriptors, dest_dir, reserved_names)
 
 
 def load_mcp_servers() -> dict[str, MCPServer]:
@@ -295,6 +279,34 @@ __doc__ = {description!r}
 __rlm_brokered__ = True
 run = make_skill({descriptor!r})
 """
+
+
+def write_skill_modules(
+    descriptors: Iterable[MCPToolDescriptor],
+    dest_dir: Path,
+    reserved_names: Iterable[str] = (),
+) -> list[str]:
+    """Write public brokered-skill descriptors as importable proxy modules."""
+    descriptor_list = list(descriptors)
+    reserved = set(reserved_names)
+    names = [descriptor.name for descriptor in descriptor_list]
+    duplicates = sorted(name for name in set(names) if names.count(name) > 1)
+    conflicts = sorted(name for name in names if name in reserved)
+    if duplicates:
+        raise ValueError(f"duplicate brokered skill names: {duplicates}")
+    if conflicts:
+        raise ValueError(
+            f"brokered skill names conflict with existing skills: {conflicts}"
+        )
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for descriptor in descriptor_list:
+        source = _MODULE_TEMPLATE.format(
+            description=descriptor.description,
+            descriptor=descriptor.to_dict(),
+        )
+        (dest_dir / f"{descriptor.name}.py").write_text(source)
+    return names
 
 
 def list_skill_modules(skills_dir: Path) -> list[str]:

--- a/src/rlm/mcp.py
+++ b/src/rlm/mcp.py
@@ -1,33 +1,27 @@
-"""MCP tool servers exposed as pre-imported IPython skills.
-
-A v1 harness can wire task-specific tool servers to the agent over MCP. rlm has no MCP
-client in its native tool-call loop; instead each MCP tool becomes a *skill* — a generated
-async function the agent calls straight from the IPython REPL (``await tools_add_event(...)``),
-the same programmatic tool-call (PTC) path as installed skills. The servers arrive as a
-standard ``mcpServers`` config in ``RLM_MCP_CONFIG`` (set by the verifiers rlm harness).
-
-Each tool is written to its own flat module in the session directory (added to the kernel's
-``sys.path``); the module's ``run`` carries a signature built from the tool's input schema so
-``help()`` / ``inspect.signature`` show the real arguments.
-"""
+"""Supervisor-owned MCP discovery, registration, and invocation."""
 
 from __future__ import annotations
 
 import inspect
 import json
+import keyword
 import os
 import re
-from collections.abc import AsyncIterator
+import secrets
+from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
-from mcp.types import Tool
 
 MCP_CONFIG_ENV = "RLM_MCP_CONFIG"
+MAX_MCP_TOOLS = 128
+MAX_MCP_SKILL_NAME_CHARS = 96
+MAX_MCP_DESCRIPTOR_BYTES = 1024 * 1024
 
 _JSON_TO_PY = {
     "string": str,
@@ -38,8 +32,148 @@ _JSON_TO_PY = {
     "object": dict,
 }
 
-
 MCPServer = str | dict[str, Any]
+
+
+@dataclass(frozen=True)
+class MCPToolDescriptor:
+    """Public information exposed to an IPython kernel for one MCP tool."""
+
+    capability: str
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "capability": self.capability,
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+        }
+
+
+@dataclass(frozen=True)
+class _RegisteredMCPTool:
+    descriptor: MCPToolDescriptor
+    server: MCPServer
+    tool_name: str
+
+
+class MCPToolError(RuntimeError):
+    """An error intentionally returned by an MCP tool."""
+
+
+class MCPRegistry:
+    """Keep MCP transport configuration private and expose opaque tool capabilities."""
+
+    def __init__(self, servers: dict[str, MCPServer], cwd: str | None = None) -> None:
+        self._servers = {
+            name: _normalize_server(spec) for name, spec in servers.items()
+        }
+        self._cwd = cwd
+        self._tools: dict[str, _RegisteredMCPTool] | None = None
+
+    async def discover(self) -> tuple[MCPToolDescriptor, ...]:
+        if self._tools is not None:
+            return tuple(entry.descriptor for entry in self._tools.values())
+
+        registered: dict[str, _RegisteredMCPTool] = {}
+        names: set[str] = set()
+        descriptor_bytes = 0
+        for server_name, server in self._servers.items():
+            try:
+                async with _client_session(server, self._cwd) as session:
+                    await session.initialize()
+                    tools = (await session.list_tools()).tools
+            except Exception:
+                raise RuntimeError(
+                    f"MCP server {server_name!r} discovery failed"
+                ) from None
+            for tool in tools:
+                if len(registered) >= MAX_MCP_TOOLS:
+                    raise ValueError(f"MCP tool count exceeds {MAX_MCP_TOOLS}")
+                name = _skill_name(server_name, tool.name)
+                if not name.isidentifier() or keyword.iskeyword(name):
+                    raise ValueError(
+                        f"MCP tool name {name!r} is not a Python identifier"
+                    )
+                if len(name) > MAX_MCP_SKILL_NAME_CHARS:
+                    raise ValueError(
+                        f"MCP tool name exceeds {MAX_MCP_SKILL_NAME_CHARS} characters"
+                    )
+                if name in names:
+                    raise ValueError(f"duplicate normalized MCP tool name: {name!r}")
+                names.add(name)
+                capability = secrets.token_urlsafe(24)
+                descriptor = MCPToolDescriptor(
+                    capability=capability,
+                    name=name,
+                    description=tool.description or f"MCP tool {tool.name!r}.",
+                    input_schema=dict(tool.inputSchema),
+                )
+                descriptor_bytes += len(
+                    json.dumps(descriptor.to_dict(), separators=(",", ":")).encode()
+                )
+                if descriptor_bytes > MAX_MCP_DESCRIPTOR_BYTES:
+                    raise ValueError(
+                        "MCP public tool metadata exceeds "
+                        f"{MAX_MCP_DESCRIPTOR_BYTES} bytes"
+                    )
+                registered[capability] = _RegisteredMCPTool(
+                    descriptor=descriptor,
+                    server=server,
+                    tool_name=tool.name,
+                )
+        self._tools = registered
+        return tuple(entry.descriptor for entry in registered.values())
+
+    def descriptor(self, capability: str) -> MCPToolDescriptor:
+        if self._tools is None:
+            raise RuntimeError("MCP tools have not been discovered")
+        try:
+            return self._tools[capability].descriptor
+        except KeyError as exc:
+            raise PermissionError("unknown MCP tool capability") from exc
+
+    async def call(self, capability: str, arguments: dict[str, Any]) -> str:
+        descriptor = self.descriptor(capability)
+        entry = self._tools[capability]
+        try:
+            return await call_tool(
+                entry.server,
+                entry.tool_name,
+                arguments,
+                self._cwd,
+            )
+        except MCPToolError as exc:
+            raise RuntimeError(str(exc)) from None
+        except Exception:
+            raise RuntimeError(f"MCP tool {descriptor.name!r} is unavailable") from None
+
+    def write_skill_modules(
+        self, dest_dir: Path, reserved_names: Iterable[str] = ()
+    ) -> list[str]:
+        if self._tools is None:
+            raise RuntimeError("MCP tools have not been discovered")
+        reserved = set(reserved_names)
+        descriptors = [entry.descriptor for entry in self._tools.values()]
+        conflicts = sorted(
+            descriptor.name for descriptor in descriptors if descriptor.name in reserved
+        )
+        if conflicts:
+            raise ValueError(
+                f"MCP tool names conflict with existing skills: {conflicts}"
+            )
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        for descriptor in descriptors:
+            source = _MODULE_TEMPLATE.format(
+                description=descriptor.description,
+                descriptor=descriptor.to_dict(),
+            )
+            (dest_dir / f"{descriptor.name}.py").write_text(source)
+        return [descriptor.name for descriptor in descriptors]
 
 
 def load_mcp_servers() -> dict[str, MCPServer]:
@@ -67,7 +201,7 @@ def _normalize_server(server: MCPServer) -> MCPServer:
 
 
 def _skill_name(server: str, tool: str) -> str:
-    """A valid Python identifier (importable + REPL call name) for a server's tool."""
+    """Return the normalized Python name for a server tool."""
     ident = re.sub(r"\W", "_", f"{server}_{tool}")
     return f"_{ident}" if ident[:1].isdigit() else ident
 
@@ -119,30 +253,13 @@ async def _client_session(
         yield session
 
 
-async def discover_tools(
-    servers: dict[str, MCPServer], cwd: str | None = None
-) -> dict[str, tuple[str, Tool]]:
-    """List each server's tools using one discovery session per server."""
-    found: dict[str, tuple[str, Tool]] = {}
-    for server, spec in servers.items():
-        async with _client_session(spec, cwd) as session:
-            await session.initialize()
-            for tool in (await session.list_tools()).tools:
-                found[_skill_name(server, tool.name)] = (server, tool)
-    return found
-
-
 async def call_tool(
     server: MCPServer,
     name: str,
-    arguments: dict,
+    arguments: dict[str, Any],
     cwd: str | None = None,
 ) -> str:
-    """Call an MCP tool and return its text content.
-
-    Raises ``RuntimeError`` on a tool-reported error, so a failed call surfaces as an
-    exception in the REPL rather than a silently-wrong return value.
-    """
+    """Call an MCP tool and return its text content."""
     async with _client_session(server, cwd) as session:
         await session.initialize()
         result = await session.call_tool(name, arguments or {})
@@ -150,15 +267,12 @@ async def call_tool(
         getattr(block, "text", "") or str(block) for block in result.content
     )
     if result.isError:
-        raise RuntimeError(text or f"MCP tool {name!r} failed")
+        raise MCPToolError(text or f"MCP tool {name!r} failed")
     return text
 
 
-def build_signature(schema: dict) -> inspect.Signature:
-    """A keyword-only signature mirroring a tool's input schema (required params first).
-
-    Non-identifier property names are skipped (still reachable via ``**kwargs``).
-    """
+def build_signature(schema: dict[str, Any]) -> inspect.Signature:
+    """Return a keyword-only Python signature for a JSON input schema."""
     properties, required = schema.get("properties", {}), set(schema.get("required", []))
     params = [
         inspect.Parameter(
@@ -168,78 +282,21 @@ def build_signature(schema: dict) -> inspect.Signature:
             annotation=_JSON_TO_PY.get(prop.get("type"), inspect.Parameter.empty),
         )
         for name, prop in properties.items()
-        if name.isidentifier()
+        if name.isidentifier() and not keyword.iskeyword(name)
     ]
-    params.sort(key=lambda p: p.default is not inspect.Parameter.empty)
+    params.sort(key=lambda parameter: parameter.default is not inspect.Parameter.empty)
     return inspect.Signature(params)
 
 
-def make_skill(server: str, tool: Tool, cwd: str | None = None):
-    """Build the async ``run`` for a generated skill module from an MCP ``Tool``.
+_MODULE_TEMPLATE = """\
+from rlm.broker import make_skill
 
-    Generated modules are a single statement (``run = make_skill(server, Tool(...))``). The
-    returned coroutine forwards keyword args to the tool; its ``__signature__`` and
-    ``__doc__`` come from the tool so ``help()`` / ``inspect.signature`` expose the real API.
-    """
-
-    async def run(**kwargs):
-        try:
-            spec = load_mcp_servers()[server]
-        except KeyError as exc:
-            raise RuntimeError(f"MCP server {server!r} is not configured") from exc
-        return await call_tool(spec, tool.name, kwargs, cwd)
-
-    run.__signature__ = build_signature(tool.inputSchema)
-    run.__doc__ = tool.description or f"MCP tool {tool.name!r}."
-    return run
-
-
-_MODULE_TEMPLATE = '''\
-"""{summary}"""
-
-from mcp.types import Tool
-
-from rlm.mcp import make_skill
-
-run = make_skill({server!r}, Tool.model_validate({tool!r}), cwd={cwd!r})
-'''
-
-
-def write_skill_modules(
-    found: dict[str, tuple[str, Tool]],
-    dest_dir: Path,
-    cwd: str | None = None,
-) -> list[str]:
-    """Write one importable ``<skill>.py`` per discovered tool into ``dest_dir``.
-
-    Returns the generated skill names (importable once ``dest_dir`` is on ``sys.path``).
-    """
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    for name, (server, tool) in found.items():
-        summary = next(
-            iter((tool.description or "").splitlines()), f"MCP tool {tool.name}."
-        )
-        source = _MODULE_TEMPLATE.format(
-            summary=summary.replace('"""', "'''"),
-            server=server,
-            tool=tool.model_dump(mode="json"),
-            cwd=cwd,
-        )
-        (dest_dir / f"{name}.py").write_text(source)
-    return list(found)
-
-
-async def generate_mcp_skills(
-    servers: dict[str, MCPServer], dest_dir: Path, cwd: str | None = None
-) -> list[str]:
-    """Discover all tools on ``servers`` and write them as skill modules in ``dest_dir``."""
-    return write_skill_modules(await discover_tools(servers, cwd), dest_dir, cwd)
+__doc__ = {description!r}
+__rlm_brokered__ = True
+run = make_skill({descriptor!r})
+"""
 
 
 def list_skill_modules(skills_dir: Path) -> list[str]:
-    """Names of the MCP-skill modules in ``skills_dir`` (its top-level ``.py`` files).
-
-    The directory the kernel imports from is the source of truth, so callers read it back
-    instead of threading the generated names around.
-    """
+    """Return names of generated skill modules in ``skills_dir``."""
     return sorted(path.stem for path in skills_dir.glob("*.py"))

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -88,6 +88,7 @@ def build_system_prompt(
     *,
     allow_recursion: bool,
     active_tools: list[BuiltinTool],
+    shell_skills: list[str] | None = None,
 ) -> str:
     """Build the system prompt.
 
@@ -119,10 +120,15 @@ def build_system_prompt(
             "Each skill is an async function by the same name. "
             "Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`."
         )
-        skill_lines.append(
-            "Each skill is also available as a shell command by the same name: `<skill> ...`. "
-            "Discover its CLI usage with `<skill> --help`."
-        )
+        shell_skill_set = set(shell_skills or [])
+        if shell_skill_set:
+            names = ", ".join(f"`{name}`" for name in sorted(shell_skill_set))
+            skill_lines.append(
+                f"Shell-enabled installed skills: {names}. Discover CLI usage with "
+                "`<skill> --help`. Other listed skills are IPython-only."
+            )
+        else:
+            skill_lines.append("The listed skills are IPython-only.")
         if "edit" in installed_skills:
             skill_lines.append(EDIT_SKILL_PROMPT)
         if "search" in installed_skills:

--- a/src/rlm/session.py
+++ b/src/rlm/session.py
@@ -67,7 +67,9 @@ class Session:
     def log_sub_spawn(self, child_name: str, command: str):
         self.log({"type": "sub_spawn", "child_dir": child_name, "command": command})
 
-    def aggregate_child_metrics(self) -> ChildSessionAggregate:
+    def aggregate_child_metrics(
+        self, field: str = "programmatic_tool_call_stats"
+    ) -> ChildSessionAggregate:
         """Walk sub-*/meta.json and bundle their programmatic tool-call stats."""
         aggregate = ChildSessionAggregate()
         for child_dir in self.dir.glob("sub-*"):
@@ -77,11 +79,17 @@ class Session:
                     meta = json.load(f)
             except FileNotFoundError:
                 continue
-            aggregate.absorb(ProgrammaticToolCallStats.from_meta(meta))
+            aggregate.absorb(ProgrammaticToolCallStats.from_meta(meta, field))
         return aggregate
 
     def finalize(
-        self, answer: str, usage: dict | None = None, turns: int = 0, metrics=None
+        self,
+        answer: str,
+        usage: dict | None = None,
+        turns: int = 0,
+        metrics=None,
+        trusted_direct_tool_stats: ProgrammaticToolCallStats | None = None,
+        trusted_child_tool_stats: ProgrammaticToolCallStats | None = None,
     ):
         entry = {"type": "done", "answer": answer[:1000]}
         if usage:
@@ -94,19 +102,33 @@ class Session:
         if usage:
             meta_update["usage"] = usage
         if metrics is not None:
-            direct_tool_stats = ProgrammaticToolCallStats.from_log(
+            local_direct_tool_stats = ProgrammaticToolCallStats.from_log(
                 self.dir / "programmatic_tool_calls.jsonl"
             )
-            child = self.aggregate_child_metrics()
+            local_child_tool_stats = self.aggregate_child_metrics(
+                "local_programmatic_tool_call_stats"
+            ).tool_call_stats
+            direct_tool_stats = local_direct_tool_stats
+            if trusted_direct_tool_stats is not None:
+                direct_tool_stats = direct_tool_stats.merge(trusted_direct_tool_stats)
+            if trusted_child_tool_stats is not None:
+                child_tool_stats = local_child_tool_stats.merge(
+                    trusted_child_tool_stats
+                )
+            else:
+                child_tool_stats = self.aggregate_child_metrics().tool_call_stats
 
             metrics.apply_programmatic_tool_call_stats(
-                direct_tool_stats, child.tool_call_stats
+                direct_tool_stats, child_tool_stats
             )
 
             meta_update["metrics"] = metrics.to_dict()
             meta_update["programmatic_tool_call_stats"] = direct_tool_stats.merge(
-                child.tool_call_stats
+                child_tool_stats
             ).to_dict()
+            meta_update["local_programmatic_tool_call_stats"] = (
+                local_direct_tool_stats.merge(local_child_tool_stats).to_dict()
+            )
         self.write_meta(**meta_update)
         self._msg_file.close()
 

--- a/src/rlm/skills/__init__.py
+++ b/src/rlm/skills/__init__.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-# Built-in skill name -> module its ``run`` is re-exported from.
-_BUILTIN_SKILLS: dict[str, str] = {
+# Built-in skill name -> local module, or ``None`` for a supervisor-owned skill.
+_BUILTIN_SKILLS: dict[str, str | None] = {
     "edit": "rlm.skills.edit",
-    "search": "rlm.skills.search",
+    "search": None,
 }
 
 
@@ -23,7 +23,7 @@ def available_builtin_skills() -> list[str]:
 
 
 def enable_builtin_skills(names: list[str], dest_dir: Path) -> list[str]:
-    """Write a re-export module into ``dest_dir`` for each enabled built-in skill.
+    """Write local built-ins into ``dest_dir``; brokered built-ins are skipped.
 
     Returns the enabled names; unknown names raise.
     """
@@ -35,7 +35,6 @@ def enable_builtin_skills(names: list[str], dest_dir: Path) -> list[str]:
         )
     dest_dir.mkdir(parents=True, exist_ok=True)
     for name in names:
-        (dest_dir / f"{name}.py").write_text(
-            f"from {_BUILTIN_SKILLS[name]} import run\n"
-        )
+        if module := _BUILTIN_SKILLS[name]:
+            (dest_dir / f"{name}.py").write_text(f"from {module} import run\n")
     return names

--- a/src/rlm/skills/search.py
+++ b/src/rlm/skills/search.py
@@ -7,7 +7,6 @@ skill in research-environments/rlm_browsecomp.
 
 from __future__ import annotations
 
-import asyncio
 import os
 
 import httpx
@@ -32,23 +31,29 @@ def format_results(results, query: str) -> str:
     return "\n\n---\n\n".join(sections)
 
 
-def search(query: str, num_results: int = 5) -> str:
+def search(query: str, num_results: int = 5, *, api_key: str | None = None) -> str:
     """Run a synchronous Serper web search and return formatted results."""
-    api_key = os.environ.get("SERPER_API_KEY", "")
+    if api_key is None:
+        api_key = os.environ.get("SERPER_API_KEY", "")
     if not api_key:
         return "Error: SERPER_API_KEY environment variable is not set"
-    response = httpx.post(
-        SERPER_URL,
-        json={"q": query},
-        headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
-        timeout=45,
-    )
-    response.raise_for_status()
+    try:
+        response = httpx.post(
+            SERPER_URL,
+            json={"q": query},
+            headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+            timeout=45,
+        )
+        response.raise_for_status()
+    except Exception:
+        raise RuntimeError("web search is unavailable") from None
     organic = response.json().get("organic") or []
     return format_results(organic[:num_results], query)
 
 
-async def run(query: str, *, num_results: int = 5) -> str:
+async def run_with_api_key(
+    api_key: str | None, query: str, *, num_results: int = 5
+) -> str:
     """Run a web search via Serper and return formatted results.
 
     Args:
@@ -58,4 +63,25 @@ async def run(query: str, *, num_results: int = 5) -> str:
     Returns:
         Formatted results (title, URL, snippet).
     """
-    return await asyncio.to_thread(search, query, num_results)
+    if not api_key:
+        return "Error: SERPER_API_KEY environment variable is not set"
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                SERPER_URL,
+                json={"q": query},
+                headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+                timeout=45,
+            )
+        response.raise_for_status()
+        organic = response.json().get("organic") or []
+    except Exception:
+        raise RuntimeError("web search is unavailable") from None
+    return format_results(organic[:num_results], query)
+
+
+async def run(query: str, *, num_results: int = 5) -> str:
+    """Run search directly using ``SERPER_API_KEY`` from the current process."""
+    return await run_with_api_key(
+        os.environ.get("SERPER_API_KEY"), query, num_results=num_results
+    )

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -10,15 +10,21 @@ import tempfile
 import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
 
 from rlm.broker import BrokerEndpoint, read_frame, result_to_json, write_frame
 from rlm.config import RuntimeConfig
+from rlm.mcp import MCPRegistry, MCPServer
 from rlm.session import Session
-from rlm.types import RLMResult
+from rlm.types import ProgrammaticToolCallStats, RLMResult
 
 if TYPE_CHECKING:
     from rlm.engine import RLMEngine
+
+
+MAX_BROKER_CONNECTIONS = 128
+BROKER_INITIAL_FRAME_TIMEOUT_SECONDS = 5
 
 
 @dataclass
@@ -29,7 +35,7 @@ class _Invocation:
     session: Session
     runtime_config: RuntimeConfig
     cwd: str
-    mcp_servers: dict[str, Any]
+    mcp_servers: dict[str, MCPServer]
 
 
 def depth_capacities(max_depth: int, limit: int, root_depth: int = 0) -> dict[int, int]:
@@ -55,7 +61,7 @@ class SessionTreeSupervisor:
         root_session: Session,
         runtime_config: RuntimeConfig,
         cwd: str,
-        mcp_servers: dict[str, Any] | None = None,
+        mcp_servers: dict[str, MCPServer] | None = None,
         engine_factory: Callable[..., RLMEngine] | None = None,
     ) -> None:
         self._engine_factory = engine_factory
@@ -66,10 +72,12 @@ class SessionTreeSupervisor:
         self._close_task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
         self._total_calls = 0
-        self._tasks: set[asyncio.Task[RLMResult]] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._child_tasks: set[asyncio.Task[RLMResult]] = set()
         self._connection_tasks: set[asyncio.Task[None]] = set()
         self._connection_writers: set[asyncio.StreamWriter] = set()
-        self._scopes: dict[str, tuple[str, set[asyncio.Task[RLMResult]]]] = {}
+        self._scopes: dict[str, tuple[str, set[asyncio.Task[Any]]]] = {}
+        self._mcp_registry = MCPRegistry(mcp_servers, cwd) if mcp_servers else None
 
         root_id = uuid.uuid4().hex
         root = _Invocation(
@@ -83,6 +91,8 @@ class SessionTreeSupervisor:
         )
         self.root_id = root_id
         self._invocations = {root_id: root}
+        self._parents = {root_id: None}
+        self._tool_stats: dict[str, ProgrammaticToolCallStats] = {}
         self._capabilities = {root.capability: root_id}
         capacities = depth_capacities(
             runtime_config.policy.max_depth,
@@ -99,13 +109,15 @@ class SessionTreeSupervisor:
 
     @property
     def active_calls(self) -> int:
-        return len(self._tasks)
+        return len(self._child_tasks)
 
     async def start(self) -> None:
         if self._server is not None:
             return
         if self._closed:
             raise RuntimeError("session supervisor is closed")
+        if self._mcp_registry is not None:
+            await self._mcp_registry.discover()
         self._broker_dir = Path(tempfile.mkdtemp(prefix="rlm-brk-"))
         os.chmod(self._broker_dir, 0o700)
         self._socket_path = str(self._broker_dir / "b.sock")
@@ -114,10 +126,36 @@ class SessionTreeSupervisor:
         )
         os.chmod(self._socket_path, 0o600)
 
+    def write_mcp_skill_modules(
+        self, dest_dir: Path, reserved_names: Iterable[str] = ()
+    ) -> list[str]:
+        if self._mcp_registry is None:
+            return []
+        return self._mcp_registry.write_skill_modules(dest_dir, reserved_names)
+
+    def programmatic_tool_call_stats(
+        self, invocation_id: str
+    ) -> tuple[ProgrammaticToolCallStats, ProgrammaticToolCallStats]:
+        direct = ProgrammaticToolCallStats().merge(
+            self._tool_stats.get(invocation_id, ProgrammaticToolCallStats())
+        )
+        descendants = ProgrammaticToolCallStats()
+        for candidate_id, stats in self._tool_stats.items():
+            parent_id = self._parents.get(candidate_id)
+            while parent_id is not None:
+                if parent_id == invocation_id:
+                    descendants = descendants.merge(stats)
+                    break
+                parent_id = self._parents.get(parent_id)
+        return direct, descendants
+
     def _accept_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         if self._closed or self._close_task is not None:
+            writer.close()
+            return
+        if len(self._connection_tasks) >= MAX_BROKER_CONNECTIONS:
             writer.close()
             return
         self._connection_writers.add(writer)
@@ -171,6 +209,39 @@ class SessionTreeSupervisor:
             self._total_calls += 1
             task = asyncio.create_task(self._run_child(parent_id, prompt))
             self._tasks.add(task)
+            self._child_tasks.add(task)
+            scope[1].add(task)
+            task.add_done_callback(self._tasks.discard)
+            task.add_done_callback(self._child_tasks.discard)
+            task.add_done_callback(scope[1].discard)
+            return task
+
+    async def _start_skill_call(
+        self,
+        capability: str,
+        scope_id: str,
+        skill_capability: str,
+        arguments: dict[str, Any],
+    ) -> asyncio.Task[str]:
+        async with self._lock:
+            invocation_id = self._capabilities.get(capability)
+            scope = self._scopes.get(scope_id)
+            if invocation_id is None or scope is None or scope[0] != invocation_id:
+                raise PermissionError("invalid broker capability")
+            if self._mcp_registry is None:
+                raise PermissionError("MCP tools are unavailable")
+            descriptor = self._mcp_registry.descriptor(skill_capability)
+            stats = self._tool_stats.setdefault(
+                invocation_id, ProgrammaticToolCallStats()
+            )
+            stats.python_total += 1
+            stats.by_tool_python[descriptor.name] = (
+                stats.by_tool_python.get(descriptor.name, 0) + 1
+            )
+            task = asyncio.create_task(
+                self._mcp_registry.call(skill_capability, arguments)
+            )
+            self._tasks.add(task)
             scope[1].add(task)
             task.add_done_callback(self._tasks.discard)
             task.add_done_callback(scope[1].discard)
@@ -205,6 +276,7 @@ class SessionTreeSupervisor:
                     child_session.close()
                     raise asyncio.CancelledError
                 self._invocations[child_id] = child
+                self._parents[child_id] = parent_id
                 self._capabilities[child.capability] = child_id
             try:
                 factory = self._engine_factory
@@ -230,34 +302,56 @@ class SessionTreeSupervisor:
     async def _handle_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
-        child_task: asyncio.Task[RLMResult] | None = None
+        operation_task: asyncio.Task[Any] | None = None
         disconnect_task: asyncio.Task[bytes] | None = None
         try:
-            request = await read_frame(reader)
-            if request.get("op") != "rlm.run":
+            try:
+                request = await asyncio.wait_for(
+                    read_frame(reader), timeout=BROKER_INITIAL_FRAME_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                raise TimeoutError("broker request timed out") from None
+            operation = request.get("op")
+            if operation not in {"rlm.run", "skill.call"}:
                 raise ValueError("unknown broker operation")
             capability = request.get("capability")
             scope_id = request.get("scope_id")
-            prompt = request.get("prompt")
-            options = request.get("options", {})
-            if not all(
-                isinstance(value, str) for value in (capability, scope_id, prompt)
-            ):
-                raise ValueError("invalid recursive RLM request")
-            if not isinstance(options, dict):
-                raise ValueError("recursive RLM options must be an object")
-            child_task = await self._start_child(capability, scope_id, prompt, options)
+            if not all(isinstance(value, str) for value in (capability, scope_id)):
+                raise ValueError("invalid broker request")
+            if operation == "rlm.run":
+                prompt = request.get("prompt")
+                options = request.get("options", {})
+                if not isinstance(prompt, str) or not isinstance(options, dict):
+                    raise ValueError("invalid recursive RLM request")
+                operation_task = await self._start_child(
+                    capability, scope_id, prompt, options
+                )
+            else:
+                skill_capability = request.get("skill_capability")
+                arguments = request.get("arguments", {})
+                if not isinstance(skill_capability, str) or not isinstance(
+                    arguments, dict
+                ):
+                    raise ValueError("invalid skill request")
+                operation_task = await self._start_skill_call(
+                    capability,
+                    scope_id,
+                    skill_capability,
+                    arguments,
+                )
             disconnect_task = asyncio.create_task(reader.read(1))
             done, _ = await asyncio.wait(
-                {child_task, disconnect_task},
+                {operation_task, disconnect_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            if disconnect_task in done and child_task not in done:
-                child_task.cancel()
-                await asyncio.gather(child_task, return_exceptions=True)
+            if disconnect_task in done and operation_task not in done:
+                operation_task.cancel()
+                await asyncio.gather(operation_task, return_exceptions=True)
                 return
-            result = await child_task
-            await write_frame(writer, {"result": result_to_json(result)})
+            result = await operation_task
+            if isinstance(result, RLMResult):
+                result = result_to_json(result)
+            await write_frame(writer, {"result": result})
         except Exception as exc:
             if not writer.is_closing():
                 try:

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -45,6 +45,14 @@ class _Invocation:
     mcp_servers: dict[str, MCPServer]
 
 
+@dataclass
+class _Scope:
+    invocation_id: str
+    parent_call_id: str | None
+    segment_id: str | None
+    tasks: set[asyncio.Task[Any]]
+
+
 def depth_capacities(max_depth: int, limit: int, root_depth: int = 0) -> dict[int, int]:
     """Reserve capacity per descendant depth so nested calls cannot deadlock."""
     levels = max_depth - root_depth
@@ -70,6 +78,8 @@ class SessionTreeSupervisor:
         cwd: str,
         mcp_servers: dict[str, MCPServer] | None = None,
         engine_factory: Callable[..., RLMEngine] | None = None,
+        root_invocation_id: str | None = None,
+        lineage_session_id: str | None = None,
     ) -> None:
         self._engine_factory = engine_factory
         self._server: asyncio.AbstractServer | None = None
@@ -83,7 +93,7 @@ class SessionTreeSupervisor:
         self._child_tasks: set[asyncio.Task[RLMResult]] = set()
         self._connection_tasks: set[asyncio.Task[None]] = set()
         self._connection_writers: set[asyncio.StreamWriter] = set()
-        self._scopes: dict[str, tuple[str, set[asyncio.Task[Any]]]] = {}
+        self._scopes: dict[str, _Scope] = {}
         self._mcp_registry = MCPRegistry(mcp_servers, cwd) if mcp_servers else None
         self._brokered_skills: dict[
             str,
@@ -113,7 +123,8 @@ class SessionTreeSupervisor:
             )
             self._brokered_skills[capability] = (descriptor, self._call_search)
 
-        root_id = uuid.uuid4().hex
+        root_id = root_invocation_id or uuid.uuid4().hex
+        self.session_id = lineage_session_id or root_session.dir.name
         root = _Invocation(
             id=root_id,
             parent_id=None,
@@ -209,18 +220,25 @@ class SessionTreeSupervisor:
         invocation = self._invocations[invocation_id]
         return BrokerEndpoint(self._socket_path, invocation.capability)
 
-    async def open_scope(self, invocation_id: str) -> str:
+    async def open_scope(
+        self,
+        invocation_id: str,
+        parent_call_id: str | None = None,
+        segment_id: str | None = None,
+    ) -> str:
         async with self._lock:
             if self._closed or invocation_id not in self._invocations:
                 raise RuntimeError("recursive invocation is no longer active")
             scope_id = secrets.token_urlsafe(24)
-            self._scopes[scope_id] = (invocation_id, set())
+            self._scopes[scope_id] = _Scope(
+                invocation_id, parent_call_id, segment_id, set()
+            )
             return scope_id
 
     async def close_scope(self, scope_id: str) -> None:
         async with self._lock:
             scope = self._scopes.pop(scope_id, None)
-            tasks = list(scope[1]) if scope else []
+            tasks = list(scope.tasks) if scope else []
         for task in tasks:
             task.cancel()
         if tasks:
@@ -234,7 +252,7 @@ class SessionTreeSupervisor:
         async with self._lock:
             parent_id = self._capabilities.get(capability)
             scope = self._scopes.get(scope_id)
-            if parent_id is None or scope is None or scope[0] != parent_id:
+            if parent_id is None or scope is None or scope.invocation_id != parent_id:
                 raise PermissionError("invalid recursive RLM capability")
             parent = self._invocations[parent_id]
             child_depth = parent.runtime_config.invocation.depth + 1
@@ -247,13 +265,17 @@ class SessionTreeSupervisor:
                     self._limit_result(parent, "recursive call limit reached")
                 )
             self._total_calls += 1
-            task = asyncio.create_task(self._run_child(parent_id, prompt))
+            task = asyncio.create_task(
+                self._run_child(
+                    parent_id, prompt, scope.parent_call_id, scope.segment_id
+                )
+            )
             self._tasks.add(task)
             self._child_tasks.add(task)
-            scope[1].add(task)
+            scope.tasks.add(task)
             task.add_done_callback(self._tasks.discard)
             task.add_done_callback(self._child_tasks.discard)
-            task.add_done_callback(scope[1].discard)
+            task.add_done_callback(scope.tasks.discard)
             return task
 
     async def _start_skill_call(
@@ -266,7 +288,11 @@ class SessionTreeSupervisor:
         async with self._lock:
             invocation_id = self._capabilities.get(capability)
             scope = self._scopes.get(scope_id)
-            if invocation_id is None or scope is None or scope[0] != invocation_id:
+            if (
+                invocation_id is None
+                or scope is None
+                or scope.invocation_id != invocation_id
+            ):
                 raise PermissionError("invalid broker capability")
             try:
                 descriptor, handler = self._brokered_skills[skill_capability]
@@ -281,15 +307,21 @@ class SessionTreeSupervisor:
             )
             task = asyncio.create_task(handler(arguments))
             self._tasks.add(task)
-            scope[1].add(task)
+            scope.tasks.add(task)
             task.add_done_callback(self._tasks.discard)
-            task.add_done_callback(scope[1].discard)
+            task.add_done_callback(scope.tasks.discard)
             return task
 
     async def _limit_result(self, parent: _Invocation, message: str) -> RLMResult:
         return RLMResult(answer=f"[{message}]", session_dir=parent.session.dir)
 
-    async def _run_child(self, parent_id: str, prompt: str) -> RLMResult:
+    async def _run_child(
+        self,
+        parent_id: str,
+        prompt: str,
+        parent_call_id: str | None,
+        segment_id: str | None,
+    ) -> RLMResult:
         parent = self._invocations[parent_id]
         child_context = parent.runtime_config.invocation.child()
         semaphore = self._semaphores[child_context.depth]
@@ -330,6 +362,10 @@ class SessionTreeSupervisor:
                     runtime_config=child.runtime_config,
                     supervisor=self,
                     invocation_id=child.id,
+                    parent_invocation_id=parent_id,
+                    parent_call_id=parent_call_id,
+                    lineage_session_id=self.session_id,
+                    segment_id=segment_id,
                 )
                 return await engine.run(prompt)
             finally:

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -8,15 +8,22 @@ import secrets
 import shutil
 import tempfile
 import uuid
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, replace
+from functools import partial
 from pathlib import Path
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from rlm.broker import BrokerEndpoint, read_frame, result_to_json, write_frame
 from rlm.config import RuntimeConfig
-from rlm.mcp import MCPRegistry, MCPServer
+from rlm.mcp import (
+    MCPRegistry,
+    MCPServer,
+    MCPToolDescriptor,
+    write_skill_modules,
+)
 from rlm.session import Session
+from rlm.skills.search import run_with_api_key as run_search
 from rlm.types import ProgrammaticToolCallStats, RLMResult
 
 if TYPE_CHECKING:
@@ -78,6 +85,33 @@ class SessionTreeSupervisor:
         self._connection_writers: set[asyncio.StreamWriter] = set()
         self._scopes: dict[str, tuple[str, set[asyncio.Task[Any]]]] = {}
         self._mcp_registry = MCPRegistry(mcp_servers, cwd) if mcp_servers else None
+        self._brokered_skills: dict[
+            str,
+            tuple[
+                MCPToolDescriptor,
+                Callable[[dict[str, Any]], Awaitable[str]],
+            ],
+        ] = {}
+        self._root_config = runtime_config
+        if "search" in runtime_config.skills:
+            capability = secrets.token_urlsafe(24)
+            descriptor = MCPToolDescriptor(
+                capability=capability,
+                name="search",
+                description=(
+                    "Run a web search via Serper and return formatted title, URL, "
+                    "and snippet results."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "num_results": {"type": "integer"},
+                    },
+                    "required": ["query"],
+                },
+            )
+            self._brokered_skills[capability] = (descriptor, self._call_search)
 
         root_id = uuid.uuid4().hex
         root = _Invocation(
@@ -117,7 +151,11 @@ class SessionTreeSupervisor:
         if self._closed:
             raise RuntimeError("session supervisor is closed")
         if self._mcp_registry is not None:
-            await self._mcp_registry.discover()
+            for descriptor in await self._mcp_registry.discover():
+                self._brokered_skills[descriptor.capability] = (
+                    descriptor,
+                    partial(self._mcp_registry.call, descriptor.capability),
+                )
         self._broker_dir = Path(tempfile.mkdtemp(prefix="rlm-brk-"))
         os.chmod(self._broker_dir, 0o700)
         self._socket_path = str(self._broker_dir / "b.sock")
@@ -126,12 +164,14 @@ class SessionTreeSupervisor:
         )
         os.chmod(self._socket_path, 0o600)
 
-    def write_mcp_skill_modules(
+    def write_brokered_skill_modules(
         self, dest_dir: Path, reserved_names: Iterable[str] = ()
     ) -> list[str]:
-        if self._mcp_registry is None:
-            return []
-        return self._mcp_registry.write_skill_modules(dest_dir, reserved_names)
+        descriptors = [entry[0] for entry in self._brokered_skills.values()]
+        return write_skill_modules(descriptors, dest_dir, reserved_names)
+
+    async def _call_search(self, arguments: dict[str, Any]) -> str:
+        return await run_search(self._root_config.search_api_key, **arguments)
 
     def programmatic_tool_call_stats(
         self, invocation_id: str
@@ -228,9 +268,10 @@ class SessionTreeSupervisor:
             scope = self._scopes.get(scope_id)
             if invocation_id is None or scope is None or scope[0] != invocation_id:
                 raise PermissionError("invalid broker capability")
-            if self._mcp_registry is None:
-                raise PermissionError("MCP tools are unavailable")
-            descriptor = self._mcp_registry.descriptor(skill_capability)
+            try:
+                descriptor, handler = self._brokered_skills[skill_capability]
+            except KeyError as exc:
+                raise PermissionError("unknown brokered skill capability") from exc
             stats = self._tool_stats.setdefault(
                 invocation_id, ProgrammaticToolCallStats()
             )
@@ -238,9 +279,7 @@ class SessionTreeSupervisor:
             stats.by_tool_python[descriptor.name] = (
                 stats.by_tool_python.get(descriptor.name, 0) + 1
             )
-            task = asyncio.create_task(
-                self._mcp_registry.call(skill_capability, arguments)
-            )
+            task = asyncio.create_task(handler(arguments))
             self._tasks.add(task)
             scope[1].add(task)
             task.add_done_callback(self._tasks.discard)

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -309,7 +309,7 @@ class SessionTreeSupervisor:
                 request = await asyncio.wait_for(
                     read_frame(reader), timeout=BROKER_INITIAL_FRAME_TIMEOUT_SECONDS
                 )
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 raise TimeoutError("broker request timed out") from None
             operation = request.get("op")
             if operation not in {"rlm.run", "skill.call"}:

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -62,6 +62,7 @@ _KERNEL_SECRET_ENV = {
     "PRIME_TEAM_ID",
     "RLM_API_KEY",
     "RLM_BASE_URL",
+    "RLM_MCP_CONFIG",
 }
 
 
@@ -276,16 +277,20 @@ def _wrap_callable(mod, log_source, register=True):
     return wrapped
 
 
-for _name in {skill_names!r}:
-    globals()[_name] = _wrap_callable(__import__(_name), 'python')
-
-if {allow_recursion!r}:
-    import rlm as _rlm_package
+if {bool(self.broker_endpoint)!r}:
     import rlm.broker as _rlm_broker
     _rlm_broker.configure(_rlm_broker.BrokerEndpoint(
         {self.broker_endpoint.socket_path if self.broker_endpoint else None!r},
         {self.broker_endpoint.capability if self.broker_endpoint else None!r},
     ))
+
+for _name in {skill_names!r}:
+    _module = __import__(_name)
+    _source = None if getattr(_module, '__rlm_brokered__', False) else 'python'
+    globals()[_name] = _wrap_callable(_module, _source)
+
+if {allow_recursion!r}:
+    import rlm as _rlm_package
     _rlm_package.run = _rlm_broker.run
     globals()['rlm'] = _wrap_callable(_rlm_package, None)
 """

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -12,6 +12,8 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Mapping
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rlm.tools.base import ToolContext, ToolOutcome
@@ -55,15 +57,96 @@ IPYTHON_SCHEMA = {
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 IPYTHON_TIMEOUT_MAX_SECONDS = 600
-_KERNEL_SECRET_ENV = {
+_KERNEL_BASE_ENV_NAMES = {
+    "CURL_CA_BUNDLE",
+    "HOME",
+    "LANG",
+    "LOGNAME",
+    "PATH",
+    "REQUESTS_CA_BUNDLE",
+    "SHELL",
+    "SSL_CERT_FILE",
+    "TERM",
+    "TMPDIR",
+    "TZ",
+    "USER",
+    "VIRTUAL_ENV",
+}
+RESERVED_KERNEL_ENV_NAMES = {
+    "IPYTHONDIR",
+    "JUPYTER_CONFIG_DIR",
+    "JUPYTER_DATA_DIR",
+    "JUPYTER_RUNTIME_DIR",
     "OPENAI_API_KEY",
     "OPENAI_BASE_URL",
     "PRIME_API_KEY",
     "PRIME_TEAM_ID",
     "RLM_API_KEY",
+    "RLM_ALLOW_GIT",
+    "RLM_APPEND_TO_SYSTEM_PROMPT",
     "RLM_BASE_URL",
+    "RLM_DEPTH",
+    "RLM_EXEC_TIMEOUT",
+    "RLM_EXTRA_UV_ARGS",
+    "RLM_HOME",
+    "RLM_KERNEL_ENV",
+    "RLM_MAX_COMPACTIONS",
+    "RLM_MAX_CONCURRENT_SUBAGENTS",
+    "RLM_MAX_DEPTH",
+    "RLM_MAX_OUTPUT",
+    "RLM_MAX_SUBAGENT_CALLS",
+    "RLM_MAX_TOKENS",
+    "RLM_MAX_TOOL_OUTPUT_CHARS",
     "RLM_MCP_CONFIG",
+    "RLM_MODEL",
+    "RLM_SDK_MAX_RETRIES",
+    "RLM_SESSION_DIR",
+    "RLM_SKILLS",
+    "RLM_SUMMARIZE_AT_TOKENS",
+    "RLM_SYSTEM_PROMPT_PATH",
+    "SERPER_API_KEY",
 }
+
+
+def build_kernel_env(
+    task_env: Mapping[str, str] | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    private_dir: str | None = None,
+) -> dict[str, str]:
+    """Build a minimal kernel environment plus explicitly supplied task variables."""
+    source = os.environ if environ is None else environ
+    explicit = dict(task_env or {})
+    invalid_types = [
+        key
+        for key, value in explicit.items()
+        if not isinstance(key, str) or not isinstance(value, str)
+    ]
+    if invalid_types:
+        raise TypeError("kernel environment keys and values must be strings")
+    reserved = sorted(RESERVED_KERNEL_ENV_NAMES.intersection(explicit))
+    if reserved:
+        raise ValueError(f"kernel environment contains reserved names: {reserved}")
+
+    kernel_env = {
+        key: value
+        for key, value in source.items()
+        if key in _KERNEL_BASE_ENV_NAMES or key.startswith("LC_")
+    }
+    kernel_env.update(explicit)
+    kernel_env["NO_COLOR"] = "1"
+    if private_dir is not None:
+        root = Path(private_dir)
+        private_paths = {
+            "IPYTHONDIR": root / "ipython",
+            "JUPYTER_CONFIG_DIR": root / "jupyter-config",
+            "JUPYTER_DATA_DIR": root / "jupyter-data",
+            "JUPYTER_RUNTIME_DIR": root / "jupyter-runtime",
+        }
+        for path in private_paths.values():
+            path.mkdir(mode=0o700, exist_ok=True)
+        kernel_env.update({name: str(path) for name, path in private_paths.items()})
+    return kernel_env
 
 
 class IpythonTool:
@@ -142,14 +225,14 @@ class IPythonREPL:
         self,
         cwd: str,
         session: "Session | None" = None,
-        env: dict[str, str] | None = None,
+        kernel_env: Mapping[str, str] | None = None,
         depth: int | None = None,
         max_depth: int | None = None,
         broker_endpoint: BrokerEndpoint | None = None,
     ):
         self.cwd = cwd
         self.session = session
-        self.env = env or {}
+        self.kernel_env = dict(kernel_env or {})
         self.depth = depth
         self.max_depth = max_depth
         self.broker_endpoint = broker_endpoint
@@ -177,17 +260,10 @@ class IPythonREPL:
             "-f",
             "{connection_file}",
         ]
-        kernel_env = {
-            key: value
-            for key, value in os.environ.items()
-            if key not in _KERNEL_SECRET_ENV
-        }
-        kernel_env.update(
-            {
-                key: value
-                for key, value in self.env.items()
-                if key not in _KERNEL_SECRET_ENV
-            }
+        self._km.kernel_spec.env = {}
+        kernel_env = build_kernel_env(
+            self.kernel_env,
+            private_dir=self._ipc_dir,
         )
         self._km.start_kernel(
             cwd=self.cwd,
@@ -417,8 +493,9 @@ if {allow_recursion!r}:
         if self._kc:
             self._kc.stop_channels()
             self._kc = None
-        if self._km:
+        if self._km and self._km.has_kernel:
             self._km.shutdown_kernel(now=True)
+        if self._km:
             self._km = None
         if self._ipc_dir:
             shutil.rmtree(self._ipc_dir, ignore_errors=True)

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -78,9 +78,11 @@ class ProgrammaticToolCallStats:
         return stats
 
     @classmethod
-    def from_meta(cls, meta: dict) -> ProgrammaticToolCallStats:
+    def from_meta(
+        cls, meta: dict, field: str = "programmatic_tool_call_stats"
+    ) -> ProgrammaticToolCallStats:
         """Load tool-call stats previously persisted via ``to_dict``."""
-        raw = meta.get("programmatic_tool_call_stats", {})
+        raw = meta.get(field, {})
         return cls(
             python_total=int(raw.get("python_total", 0)),
             bash_total=int(raw.get("bash_total", 0)),

--- a/tests/fixtures/mcp_blocking_stdio.py
+++ b/tests/fixtures/mcp_blocking_stdio.py
@@ -1,0 +1,25 @@
+"""Stdio MCP server used to verify cancellation and subsequent reuse."""
+
+import asyncio
+import os
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+server = FastMCP("blocking-stdio-test")
+
+
+@server.tool()
+async def wait(marker: str) -> str:
+    Path(marker).write_text(str(os.getpid()))
+    await asyncio.sleep(30)
+    return "finished"
+
+
+@server.tool()
+def echo(text: str) -> str:
+    return text
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -15,8 +15,14 @@ from acp.schema import EnvVariable, HttpHeader, HttpMcpServer, McpServerStdio
 import pytest
 
 from conftest import DummyClient, DummyMessage, DummyToolCall
-from rlm.acp import RLMACPAgent
+from rlm.acp import (
+    CAPABILITIES_METADATA_KEY,
+    RUNTIME_METADATA_KEY,
+    SESSION_METADATA_KEY,
+    RLMACPAgent,
+)
 from rlm.engine import RLMEngine
+from rlm.config import ExecutionPolicy, InvocationContext, ProviderConfig, RuntimeConfig
 from rlm.session import Session
 from rlm.types import RLMResult, TokenUsage
 
@@ -38,10 +44,14 @@ class _Engine:
         cwd: str,
         session,
         mcp_servers: dict[str, Any],
+        runtime_config=None,
+        lineage_session_id: str | None = None,
     ) -> None:
         self.cwd = cwd
         self.session = session
         self.mcp_servers = mcp_servers
+        self.runtime_config = runtime_config
+        self.lineage_session_id = lineage_session_id
         self.prompts: list[str] = []
         self.prompt_started = asyncio.Event()
         self.closed = False
@@ -66,6 +76,23 @@ class _Engine:
 
     async def aclose(self) -> None:
         self.close()
+
+    def execution_snapshot(self) -> dict[str, Any]:
+        return {
+            "session_id": self.lineage_session_id or self.session.dir.name,
+            "root_invocation_id": "root",
+            "model": "test-model",
+            "turns": len(self.prompts),
+            "usage": {
+                "prompt_tokens": len(self.prompts) * 3,
+                "completion_tokens": len(self.prompts) * 2,
+                "total_tokens": len(self.prompts) * 5,
+            },
+            "metrics": {},
+            "programmatic_tool_call_stats": {},
+            "supervisor": {"subagent_calls": 0, "active_subagent_calls": 0},
+            "limits": {},
+        }
 
 
 async def test_engine_prompt_preserves_conversation(session):
@@ -93,9 +120,59 @@ async def test_engine_prompt_preserves_conversation(session):
         {"role": "user", "content": "two"},
         {"role": "assistant", "content": "second"},
     ]
+    first_headers = client.calls[0]["extra_headers"]
+    second_headers = client.calls[1]["extra_headers"]
+    assert first_headers["X-RLM-Session-ID"] == session.dir.name
+    assert first_headers["X-RLM-Invocation-ID"] == second_headers["X-RLM-Invocation-ID"]
+    assert first_headers["X-RLM-Segment-ID"] != second_headers["X-RLM-Segment-ID"]
+    assert "X-RLM-Parent-Call-ID" not in first_headers
+    assert second_headers["X-RLM-Parent-Call-ID"] == first_headers["X-RLM-Call-ID"]
     meta = json.loads((Path(session.dir) / "meta.json").read_text())
     assert meta["turns"] == 2
     assert meta["answer_preview"] == "second"
+
+
+def test_execution_snapshot_after_finalize_is_numeric_and_credential_free(session):
+    config = RuntimeConfig(
+        model="test-model",
+        provider=ProviderConfig(
+            "http://interceptor",
+            "provider-secret",
+            headers={"X-Task": "header-secret"},
+        ),
+        invocation=InvocationContext(),
+        policy=ExecutionPolicy(max_depth=1),
+        kernel_env=(("TASK_TOKEN", "kernel-secret"),),
+        search_api_key="search-secret",
+    )
+    (session.dir / "programmatic_tool_calls.jsonl").write_text(
+        '{"tool":"demo","source":"python"}\n'
+    )
+    engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+    )
+    engine._has_result = True
+    engine._last_answer = "answer-secret"
+    engine.close()
+
+    snapshot = engine.execution_snapshot()
+
+    assert snapshot["programmatic_tool_call_stats"]["by_tool_python"] == {"demo": 1}
+    assert all(
+        isinstance(value, (int, float)) and not isinstance(value, bool)
+        for value in snapshot["metrics"].values()
+    )
+    serialized = json.dumps(snapshot)
+    for secret in (
+        "provider-secret",
+        "header-secret",
+        "kernel-secret",
+        "search-secret",
+        "answer-secret",
+    ):
+        assert secret not in serialized
 
 
 async def test_engine_prompt_preserves_ipython_kernel(session):
@@ -156,6 +233,56 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},
     ]
+    failed_headers = client.calls[0]["extra_headers"]
+    resumed_headers = client.calls[1]["extra_headers"]
+    assert failed_headers["X-RLM-Call-ID"] != resumed_headers["X-RLM-Call-ID"]
+    assert failed_headers["X-RLM-Segment-ID"] != resumed_headers["X-RLM-Segment-ID"]
+    assert "X-RLM-Parent-Call-ID" not in resumed_headers
+
+
+async def test_model_call_lineage_survives_retries_and_compaction(monkeypatch, session):
+    monkeypatch.setattr("rlm.client._RETRY_DELAYS", (0,))
+    client = DummyClient(
+        [
+            DummyMessage(tool_calls=[DummyToolCall("ipython", {"code": "print(1)"})]),
+            DummyMessage(content="summary"),
+            DummyMessage(content="done"),
+        ]
+    )
+    create = client.create
+    attempts = []
+
+    async def flaky_first_call(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            raise ConnectionResetError("retry")
+        return await create(**kwargs)
+
+    client.create = flaky_first_call
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        summarize_at_tokens=1,
+    )
+
+    try:
+        result = await engine.prompt("compact")
+    finally:
+        engine.close()
+
+    assert result.answer == "done"
+    assert attempts[0]["extra_headers"] == attempts[1]["extra_headers"]
+    turn, compaction, resumed = [call["extra_headers"] for call in client.calls]
+    assert {header["X-RLM-Segment-ID"] for header in (turn, compaction, resumed)} == {
+        turn["X-RLM-Segment-ID"]
+    }
+    assert [
+        turn["X-RLM-Call-Kind"],
+        compaction["X-RLM-Call-Kind"],
+        resumed["X-RLM-Call-Kind"],
+    ] == ["turn", "compaction", "turn"]
+    assert compaction["X-RLM-Parent-Call-ID"] == turn["X-RLM-Call-ID"]
+    assert resumed["X-RLM-Parent-Call-ID"] == compaction["X-RLM-Call-ID"]
 
 
 async def test_engine_failed_prompt_can_be_retried(session):
@@ -195,6 +322,11 @@ async def test_engine_failed_prompt_can_be_retried(session):
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},
     ]
+
+    failed_headers = client.calls[0]["extra_headers"]
+    resumed_headers = client.calls[1]["extra_headers"]
+    assert failed_headers["X-RLM-Call-ID"] != resumed_headers["X-RLM-Call-ID"]
+    assert "X-RLM-Parent-Call-ID" not in resumed_headers
 
 
 async def test_engine_cancel_masks_tool_cleanup_error(monkeypatch, session):
@@ -379,6 +511,9 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     initialized = await agent.initialize(PROTOCOL_VERSION)
     assert initialized.agent_capabilities.mcp_capabilities.http is True
     assert initialized.agent_capabilities.load_session is False
+    assert initialized.field_meta == {
+        CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}
+    }
 
     created = await agent.new_session(
         str(tmp_path),
@@ -419,9 +554,94 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     ]
     assert first.usage.total_tokens == 5
     assert second.stop_reason == "end_turn"
+    created_snapshot = created.field_meta[SESSION_METADATA_KEY]
+    first_snapshot = first.field_meta[SESSION_METADATA_KEY]
+    second_snapshot = second.field_meta[SESSION_METADATA_KEY]
+    assert created_snapshot["status"] == "created"
+    assert created_snapshot["sequence"] == 0
+    assert created_snapshot["final"] is False
+    assert first_snapshot["turns"] == 1
+    assert first_snapshot["status"] == "idle"
+    assert first_snapshot["sequence"] == 1
+    assert first_snapshot["last_stop_reason"] == "done"
+    assert second_snapshot["sequence"] == 2
+    assert created.model_dump(mode="json", by_alias=True)["_meta"] == created.field_meta
 
-    await agent.close_session(created.session_id)
+    closed = await agent.close_session(created.session_id)
+    closed_snapshot = closed.field_meta[SESSION_METADATA_KEY]
+    assert closed_snapshot["status"] == "closed"
+    assert closed_snapshot["sequence"] == 3
+    assert closed_snapshot["final"] is True
     assert engine.closed is True
+
+
+async def test_acp_runtime_metadata_keeps_credentials_out_of_responses(
+    monkeypatch, tmp_path
+):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setenv("RLM_API_KEY", "ambient-provider-secret")
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    metadata = {
+        RUNTIME_METADATA_KEY: {
+            "lineage_session_id": "trace-123",
+            "provider": {
+                "base_url": "http://interceptor",
+                "api_key": "session-provider-secret",
+                "headers": {"X-Task": "header-secret"},
+                "max_retries": 2,
+            },
+            "kernel_env": {"TASK_VISIBLE": "task-secret"},
+            "search_api_key": "search-secret",
+        }
+    }
+
+    created = await agent.new_session(str(tmp_path), **metadata)
+    engine = _Engine.instances[0]
+
+    assert engine.lineage_session_id == "trace-123"
+    assert engine.runtime_config.provider.base_url == "http://interceptor"
+    assert engine.runtime_config.provider.api_key == "session-provider-secret"
+    assert engine.runtime_config.provider.headers == {"X-Task": "header-secret"}
+    assert engine.runtime_config.kernel_env == (("TASK_VISIBLE", "task-secret"),)
+    assert engine.runtime_config.search_api_key == "search-secret"
+    response_json = created.model_dump_json(by_alias=True)
+    for secret in (
+        "session-provider-secret",
+        "header-secret",
+        "task-secret",
+        "search-secret",
+        "ambient-provider-secret",
+    ):
+        assert secret not in response_json
+    assert created.field_meta[SESSION_METADATA_KEY]["session_id"] == "trace-123"
+    await agent.close_session(created.session_id)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"lineage_session_id": "bad id"},
+        {"provider": {}},
+        {
+            "provider": {
+                "api_key": "secret",
+                "headers": {"x-rlm-call-id": "forged"},
+            }
+        },
+        {"kernel_env": {"RLM_API_KEY": "forbidden"}},
+        {"unknown": "value"},
+    ],
+)
+async def test_acp_rejects_invalid_runtime_metadata(monkeypatch, tmp_path, payload):
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    agent = RLMACPAgent()
+
+    with pytest.raises(RequestError):
+        await agent.new_session(str(tmp_path), **{RUNTIME_METADATA_KEY: payload})
+
+    assert agent._sessions == {}
 
 
 async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
@@ -439,13 +659,108 @@ async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
     await engine.prompt_started.wait()
     await agent.cancel(created.session_id)
 
-    assert (await pending).stop_reason == "cancelled"
+    cancelled = await pending
+    assert cancelled.stop_reason == "cancelled"
+    assert cancelled.field_meta[SESSION_METADATA_KEY]["status"] == "idle"
+    assert cancelled.field_meta[SESSION_METADATA_KEY]["last_stop_reason"] == "cancelled"
     assert engine.closed is False
     resumed = await agent.prompt(created.session_id, [text_block("after")])
     assert resumed.stop_reason == "end_turn"
     assert engine.prompts == ["wait", "after"]
 
     await agent.close_session(created.session_id)
+
+
+async def test_acp_transport_cancellation_propagates(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+    engine = _Engine.instances[0]
+
+    pending = asyncio.create_task(
+        agent.prompt(created.session_id, [text_block("wait")])
+    )
+    await engine.prompt_started.wait()
+    pending.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    resumed = await agent.prompt(created.session_id, [text_block("after")])
+    assert resumed.stop_reason == "end_turn"
+    await agent.close_session(created.session_id)
+
+
+async def test_acp_close_cancels_blocked_answer_delivery(monkeypatch, tmp_path):
+    class BlockingClient(_Client):
+        def __init__(self):
+            super().__init__()
+            self.started = asyncio.Event()
+
+        async def session_update(
+            self, session_id: str, update: Any, **kwargs: Any
+        ) -> None:
+            self.started.set()
+            await asyncio.Future()
+
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    client = BlockingClient()
+    agent = RLMACPAgent()
+    agent.on_connect(client)  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+
+    pending = asyncio.create_task(agent.prompt(created.session_id, [text_block("one")]))
+    await client.started.wait()
+    await agent.cancel(created.session_id)
+    await asyncio.sleep(0)
+    assert pending.done() is False
+    closed = await asyncio.wait_for(agent.close_session(created.session_id), timeout=1)
+
+    assert (await pending).stop_reason == "cancelled"
+    assert closed.field_meta[SESSION_METADATA_KEY]["status"] == "closed"
+    assert _Engine.instances[0].closed is True
+
+
+async def test_acp_cancelled_close_remains_owned_by_shutdown(monkeypatch, tmp_path):
+    class SlowCancelEngine(_Engine):
+        release = asyncio.Event()
+
+        async def prompt(self, prompt: str) -> RLMResult:
+            self.prompts.append(prompt)
+            self.prompt_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                await self.release.wait()
+                raise
+
+    SlowCancelEngine.instances.clear()
+    SlowCancelEngine.release = asyncio.Event()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", SlowCancelEngine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+    engine = SlowCancelEngine.instances[0]
+    pending = asyncio.create_task(
+        agent.prompt(created.session_id, [text_block("wait")])
+    )
+    await engine.prompt_started.wait()
+    closing = asyncio.create_task(agent.close_session(created.session_id))
+    await asyncio.sleep(0)
+    closing.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await closing
+
+    SlowCancelEngine.release.set()
+    assert (await pending).stop_reason == "cancelled"
+    await agent.shutdown()
+    assert engine.closed is True
+    assert agent._sessions == {}
 
 
 async def test_acp_failed_prompt_keeps_session_reusable(monkeypatch, tmp_path):
@@ -465,7 +780,25 @@ async def test_acp_failed_prompt_keeps_session_reusable(monkeypatch, tmp_path):
     assert engine.prompts == ["fail", "after"]
     assert engine.closed is False
 
-    await agent.close_session(created.session_id)
+    closed = await agent.close_session(created.session_id)
+    assert closed.field_meta[SESSION_METADATA_KEY]["last_stop_reason"] == "done"
+
+
+async def test_acp_close_reports_last_prompt_failure(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="transient failure"):
+        await agent.prompt(created.session_id, [text_block("fail")])
+    closed = await agent.close_session(created.session_id)
+
+    snapshot = closed.field_meta[SESSION_METADATA_KEY]
+    assert snapshot["last_stop_reason"] == "error"
+    assert snapshot["final"] is True
 
 
 async def test_acp_close_rejects_queued_prompt(monkeypatch, tmp_path):
@@ -504,7 +837,14 @@ async def test_acp_stdio_lifecycle(tmp_path):
         _process,
     ):
         initialized = await connection.initialize(PROTOCOL_VERSION)
-        created = await connection.new_session(cwd=str(tmp_path), mcp_servers=[])
-        await connection.close_session(created.session_id)
+        created = await connection.new_session(
+            cwd=str(tmp_path),
+            mcp_servers=[],
+            **{RUNTIME_METADATA_KEY: {"lineage_session_id": "wire-session"}},
+        )
+        closed = await connection.close_session(created.session_id)
 
     assert initialized.agent_info.name == "rlm"
+    assert created.field_meta[SESSION_METADATA_KEY]["status"] == "created"
+    assert created.field_meta[SESSION_METADATA_KEY]["session_id"] == "wire-session"
+    assert closed.field_meta[SESSION_METADATA_KEY]["status"] == "closed"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -511,9 +511,14 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     initialized = await agent.initialize(PROTOCOL_VERSION)
     assert initialized.agent_capabilities.mcp_capabilities.http is True
     assert initialized.agent_capabilities.load_session is False
-    assert initialized.field_meta == {
-        CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}
+    assert initialized.agent_capabilities.field_meta == {
+        CAPABILITIES_METADATA_KEY: {
+            "runtime_versions": [1],
+            "session_snapshot_versions": [1],
+            "lineage_versions": [1],
+        }
     }
+    assert initialized.field_meta is None
 
     created = await agent.new_session(
         str(tmp_path),

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -2,12 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+
 import pytest
 
+from conftest import DummyClient, DummyMessage, DummyToolCall, tool_result
+
+from rlm import broker
+from rlm.config import (
+    ExecutionPolicy,
+    InvocationContext,
+    ProviderConfig,
+    RuntimeConfig,
+)
+from rlm.engine import RLMEngine
+from rlm.session import Session
 from rlm.skills import available_builtin_skills, enable_builtin_skills
 from rlm.skills.edit import run as edit
 from rlm.skills.search import format_results
 from rlm.skills.search import run as run_search
+from rlm.skills.search import run_with_api_key
 
 
 async def test_edit_replaces_unique_string(tmp_path):
@@ -42,10 +57,10 @@ def test_enable_unknown_skill_raises(tmp_path):
         enable_builtin_skills(["nope"], tmp_path)
 
 
-def test_search_enable_writes_stub(tmp_path):
+def test_search_enable_is_supervisor_owned(tmp_path):
     assert "search" in available_builtin_skills()
     assert enable_builtin_skills(["search"], tmp_path) == ["search"]
-    assert (tmp_path / "search.py").read_text() == "from rlm.skills.search import run\n"
+    assert not (tmp_path / "search.py").exists()
 
 
 async def test_search_missing_api_key_returns_error(monkeypatch):
@@ -68,3 +83,157 @@ def test_search_format_results():
 
 def test_search_format_results_empty():
     assert format_results([], "q") == "No results returned for query: q"
+
+
+async def test_search_transport_errors_do_not_expose_key(monkeypatch):
+    secret = "search-secret-do-not-leak"
+
+    class FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, *args, **kwargs):
+            raise RuntimeError(f"transport failed with {secret}")
+
+    monkeypatch.setattr("rlm.skills.search.httpx.AsyncClient", FailingClient)
+    with pytest.raises(RuntimeError, match="web search is unavailable") as exc:
+        await run_with_api_key(secret, "query")
+    assert secret not in str(exc.value)
+
+
+async def test_real_kernel_search_is_brokered_without_key(monkeypatch, session):
+    secret = "search-secret-do-not-leak"
+    requests = []
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "organic": [
+                    {
+                        "title": "Result",
+                        "link": "https://example.com",
+                        "snippet": "Found it",
+                    }
+                ]
+            }
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, **kwargs):
+            requests.append((url, kwargs))
+            return Response()
+
+    monkeypatch.setattr("rlm.skills.search.httpx.AsyncClient", FakeClient)
+    monkeypatch.setenv("SERPER_API_KEY", secret)
+    config = RuntimeConfig(
+        model="test-model",
+        provider=ProviderConfig("http://interceptor", "inference-secret"),
+        invocation=InvocationContext(),
+        policy=ExecutionPolicy(),
+        skills=("search",),
+        search_api_key=secret,
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": """
+import os, subprocess
+print(await search(query='needle'))
+child_env = subprocess.check_output(['env'], text=True)
+print('SERPER_API_KEY' not in os.environ)
+print('SERPER_API_KEY=' not in child_env)
+"""
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="done"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+    )
+
+    result = await engine.run("search")
+
+    output = tool_result(client)
+    assert result.answer == "done"
+    assert "Result 1: Result" in output
+    assert output.strip().splitlines()[-2:] == ["True", "True"]
+    assert requests[0][1]["headers"]["X-API-KEY"] == secret
+    source = (session.dir / "search.py").read_text()
+    assert secret not in source
+    meta = json.loads((session.dir / "meta.json").read_text())
+    assert meta["programmatic_tool_call_stats"]["by_tool_python"] == {"search": 1}
+
+
+async def test_supervisor_close_cancels_active_search(monkeypatch, tmp_path):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class BlockingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, *args, **kwargs):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+    monkeypatch.setattr("rlm.skills.search.httpx.AsyncClient", BlockingClient)
+    session = Session(tmp_path / "session")
+    config = RuntimeConfig(
+        model="test-model",
+        provider=ProviderConfig("http://interceptor", "inference-secret"),
+        invocation=InvocationContext(),
+        policy=ExecutionPolicy(),
+        skills=("search",),
+        search_api_key="search-secret",
+    )
+    from rlm.supervisor import SessionTreeSupervisor
+
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(tmp_path),
+    )
+    await supervisor.start()
+    scope = await supervisor.open_scope(supervisor.root_id)
+    broker.configure(supervisor.endpoint_for(supervisor.root_id))
+    broker.set_scope(scope)
+    capability = next(iter(supervisor._brokered_skills))
+    call = asyncio.create_task(broker.call_skill(capability, {"query": "slow"}))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await asyncio.wait_for(supervisor.aclose(), timeout=1)
+        await asyncio.wait_for(cancelled.wait(), timeout=1)
+        await asyncio.gather(call, return_exceptions=True)
+    finally:
+        call.cancel()
+        await asyncio.gather(call, return_exceptions=True)
+        broker.set_scope(None)
+        broker.configure(None)
+        await supervisor.aclose()
+        session.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rlm.client import make_client
+from rlm.client import make_client, model_call_headers
 from rlm.config import (
     KERNEL_ENV_CONFIG_ENV,
     PI_INFERENCE_BASE_URL,
@@ -32,6 +32,38 @@ def test_provider_config_keeps_keys_paired_with_provider():
         {"X-Prime-Team-ID": "team"},
     )
     assert (openai.base_url, openai.api_key) == ("http://openai", "openai-secret")
+
+    with pytest.raises(ValueError, match="reserved names"):
+        ProviderConfig(
+            "http://interceptor",
+            "secret",
+            headers={"x-RlM-Parent-Invocation-ID": "forged"},
+        )
+
+
+def test_model_call_headers_encode_versioned_lineage():
+    headers = model_call_headers(
+        session_id="session",
+        invocation_id="child",
+        parent_invocation_id="parent",
+        segment_id="segment",
+        call_id="call",
+        parent_call_id="parent-call",
+        depth=2,
+        call_kind="compaction",
+    )
+
+    assert headers == {
+        "X-RLM-Lineage-Version": "1",
+        "X-RLM-Session-ID": "session",
+        "X-RLM-Invocation-ID": "child",
+        "X-RLM-Parent-Invocation-ID": "parent",
+        "X-RLM-Segment-ID": "segment",
+        "X-RLM-Call-ID": "call",
+        "X-RLM-Parent-Call-ID": "parent-call",
+        "X-RLM-Depth": "2",
+        "X-RLM-Call-Kind": "compaction",
+    }
 
 
 def test_runtime_config_resolves_environment_once():
@@ -102,6 +134,10 @@ def test_make_client_uses_explicit_invocation_depth(monkeypatch):
         "max_retries": 7,
         "default_headers": {"X-RLM-Depth": "3", "X-Test": "yes"},
     }
+
+    provider.headers["X-RLM-Call-ID"] = "forged-after-construction"
+    with pytest.raises(ValueError, match="reserved names"):
+        make_client(provider, InvocationContext(depth=3))
 
 
 def test_runtime_config_validates_recursive_limits():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import pytest
 
 from rlm.client import make_client
 from rlm.config import (
+    KERNEL_ENV_CONFIG_ENV,
     PI_INFERENCE_BASE_URL,
     ExecutionPolicy,
     InvocationContext,
@@ -47,6 +48,8 @@ def test_runtime_config_resolves_environment_once():
             "RLM_MAX_TOKENS": "500",
             "RLM_MAX_COMPACTIONS": "3",
             "RLM_SKILLS": "search, edit",
+            KERNEL_ENV_CONFIG_ENV: '{"TASK_TOKEN": "task-secret"}',
+            "SERPER_API_KEY": "search-secret",
         },
     )
 
@@ -63,6 +66,11 @@ def test_runtime_config_resolves_environment_once():
         max_subagent_calls=64,
     )
     assert config.skills == ("search", "edit")
+    assert config.kernel_env == (("TASK_TOKEN", "task-secret"),)
+    assert config.search_api_key == "search-secret"
+    assert "task-secret" not in repr(config)
+    assert "search-secret" not in repr(config)
+    assert "test-key" not in repr(config.provider)
 
 
 @pytest.mark.parametrize("value", [0, -1, "bad", True])
@@ -115,3 +123,12 @@ def test_direct_policy_construction_validates_recursive_limits():
         ExecutionPolicy(max_subagent_calls=0)
     with pytest.raises(ValueError, match="depth must be non-negative"):
         InvocationContext(depth=-1)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ['["not", "an object"]', '{"NUMBER": 1}', "not-json"],
+)
+def test_runtime_config_rejects_invalid_kernel_environment(value):
+    with pytest.raises((ValueError, TypeError)):
+        RuntimeConfig.from_env(environ={KERNEL_ENV_CONFIG_ENV: value})

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,21 +1,31 @@
-"""Tests for MCP-tools-as-skills (``rlm.mcp``).
-
-Covers config parsing, JSON-schema → signature rendering, generation of importable skill
-modules, and a live stdio transport round-trip. The streamable-HTTP path is exercised
-end-to-end by the general-agent-v1 eval.
-"""
+"""Tests for supervisor-owned MCP tools exposed as IPython skills."""
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import inspect
 import json
+import os
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 from mcp.types import Tool
 
-from rlm import mcp
+from conftest import DummyClient, DummyMessage, DummyToolCall, tool_result
+from rlm import broker, mcp
+from rlm.config import (
+    ExecutionPolicy,
+    InvocationContext,
+    ProviderConfig,
+    RuntimeConfig,
+)
+from rlm.engine import RLMEngine
+from rlm.session import Session
+from rlm.supervisor import SessionTreeSupervisor
 
 SCHEMA = {
     "type": "object",
@@ -26,6 +36,39 @@ SCHEMA = {
     },
     "required": ["day"],
 }
+
+
+def _config() -> RuntimeConfig:
+    return RuntimeConfig(
+        model="test-model",
+        provider=ProviderConfig("http://interceptor", "secret"),
+        invocation=InvocationContext(),
+        policy=ExecutionPolicy(),
+    )
+
+
+def _stdio_server(prefix: str = "stdio") -> dict:
+    return {
+        "command": sys.executable,
+        "args": [str(Path(__file__).parent / "fixtures" / "mcp_stdio.py")],
+        "env": {"TEST_PREFIX": prefix},
+    }
+
+
+def _blocking_stdio_server() -> dict:
+    return {
+        "command": sys.executable,
+        "args": [str(Path(__file__).parent / "fixtures" / "mcp_blocking_stdio.py")],
+        "env": {},
+    }
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
 
 
 def test_load_mcp_servers(monkeypatch):
@@ -65,41 +108,113 @@ def test_load_mcp_servers(monkeypatch):
     }
 
 
-async def test_stdio_transport(monkeypatch, tmp_path):
+async def test_registry_keeps_transport_private_and_calls_stdio(tmp_path):
     server_cwd = tmp_path / "server"
     server_cwd.mkdir()
-    caller_cwd = tmp_path / "caller"
-    caller_cwd.mkdir()
-    server = {
-        "command": sys.executable,
-        "args": [str(Path(__file__).parent / "fixtures" / "mcp_stdio.py")],
-        "env": {"TEST_PREFIX": "stdio"},
-    }
-    found = await mcp.discover_tools({"local": server}, str(server_cwd))
-    skills_dir = tmp_path / "skills"
-    mcp.write_skill_modules(found, skills_dir, str(server_cwd))
-    monkeypatch.setenv(mcp.MCP_CONFIG_ENV, mcp.dump_mcp_servers({"local": server}))
-    monkeypatch.chdir(caller_cwd)
+    registry = mcp.MCPRegistry(
+        {"local": _stdio_server("stdio-secret")}, str(server_cwd)
+    )
+    descriptors = await registry.discover()
 
-    assert list(found) == ["local_echo"]
+    assert len(descriptors) == 1
+    descriptor = descriptors[0]
+    assert descriptor.name == "local_echo"
+    assert descriptor.input_schema["required"] == ["text"]
+    assert await registry.call(descriptor.capability, {"text": "hello"}) == (
+        f"stdio-secret:True:{server_cwd}:hello"
+    )
+    with pytest.raises(PermissionError, match="unknown MCP tool capability"):
+        registry.descriptor("invalid")
+
+    skills_dir = tmp_path / "skills"
+    assert registry.write_skill_modules(skills_dir) == ["local_echo"]
+    source = (skills_dir / "local_echo.py").read_text()
+    for private_value in (
+        "stdio-secret",
+        str(server_cwd),
+        sys.executable,
+        "mcp_stdio.py",
+        "TEST_PREFIX",
+    ):
+        assert private_value not in source
+
     sys.path.insert(0, str(skills_dir))
     try:
         skill = importlib.import_module("local_echo")
-        assert await skill.run(text="hello") == f"stdio:True:{server_cwd}:hello"
+        assert inspect.iscoroutinefunction(skill.run)
+        assert str(inspect.signature(skill.run)) == "(*, text: str)"
+        assert skill.__rlm_brokered__ is True
     finally:
         sys.path.remove(str(skills_dir))
         sys.modules.pop("local_echo", None)
 
 
-def test_skill_name():
-    assert mcp._skill_name("tools", "add_event") == "tools_add_event"
-    assert mcp._skill_name("web", "search.run") == "web_search_run"
-    assert mcp._skill_name("", "2fa") == "_2fa"
+async def test_registry_rejects_normalized_and_existing_name_collisions(
+    monkeypatch, tmp_path
+):
+    tool = Tool(name="echo", description="Echo.", inputSchema=SCHEMA)
+
+    class FakeSession:
+        async def initialize(self):
+            return None
+
+        async def list_tools(self):
+            return SimpleNamespace(tools=[tool])
+
+    @asynccontextmanager
+    async def fake_client_session(server, cwd=None):
+        yield FakeSession()
+
+    monkeypatch.setattr(mcp, "_client_session", fake_client_session)
+    duplicate = mcp.MCPRegistry({"a-b": "one", "a_b": "two"})
+    with pytest.raises(ValueError, match="duplicate normalized MCP tool name"):
+        await duplicate.discover()
+
+    registry = mcp.MCPRegistry({"local": "one"})
+    await registry.discover()
+    with pytest.raises(ValueError, match="conflict with existing skills"):
+        registry.write_skill_modules(tmp_path, {"local_echo"})
+
+
+async def test_registry_redacts_discovery_errors_and_bounds_metadata(monkeypatch):
+    sentinel = "https://secret.example/mcp?token=do-not-leak"
+
+    @asynccontextmanager
+    async def failing_client_session(server, cwd=None):
+        raise RuntimeError(sentinel)
+        yield
+
+    monkeypatch.setattr(mcp, "_client_session", failing_client_session)
+    with pytest.raises(
+        RuntimeError, match="MCP server 'public' discovery failed"
+    ) as exc:
+        await mcp.MCPRegistry({"public": "ignored"}).discover()
+    assert sentinel not in str(exc.value)
+
+    tools = [
+        Tool(name="one", description="One.", inputSchema=SCHEMA),
+        Tool(name="two", description="Two.", inputSchema=SCHEMA),
+    ]
+
+    class FakeSession:
+        async def initialize(self):
+            return None
+
+        async def list_tools(self):
+            return SimpleNamespace(tools=tools)
+
+    @asynccontextmanager
+    async def fake_client_session(server, cwd=None):
+        yield FakeSession()
+
+    monkeypatch.setattr(mcp, "_client_session", fake_client_session)
+    monkeypatch.setattr(mcp, "MAX_MCP_TOOLS", 1)
+    with pytest.raises(ValueError, match="tool count exceeds 1"):
+        await mcp.MCPRegistry({"public": "ignored"}).discover()
 
 
 def test_build_signature():
     params = mcp.build_signature(SCHEMA).parameters
-    # non-identifier property is skipped; required comes before optional.
     assert list(params) == ["day", "count"]
     assert all(p.kind is inspect.Parameter.KEYWORD_ONLY for p in params.values())
     assert params["day"].default is inspect.Parameter.empty
@@ -108,21 +223,164 @@ def test_build_signature():
     assert params["count"].annotation is int
 
 
-def test_write_skill_modules(tmp_path):
-    tool = Tool(
-        name="add_event", description="Add an event.\ndetails", inputSchema=SCHEMA
+async def test_broker_round_trip_records_trusted_metric(tmp_path):
+    server_cwd = tmp_path / "server"
+    server_cwd.mkdir()
+    session = Session(tmp_path / "session")
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=_config(),
+        cwd=str(server_cwd),
+        mcp_servers={"local": _stdio_server()},
     )
-    names = mcp.write_skill_modules({"tools_add_event": ("tools", tool)}, tmp_path)
-    assert names == ["tools_add_event"]
-    # the directory is the source of truth — the modules are readable back from it.
-    assert mcp.list_skill_modules(tmp_path) == ["tools_add_event"]
-
-    sys.path.insert(0, str(tmp_path))
+    await supervisor.start()
+    skills_dir = tmp_path / "skills"
+    supervisor.write_mcp_skill_modules(skills_dir)
+    sys.path.insert(0, str(skills_dir))
+    skill = importlib.import_module("local_echo")
+    scope = await supervisor.open_scope(supervisor.root_id)
+    endpoint = supervisor.endpoint_for(supervisor.root_id)
+    broker.configure(endpoint)
+    broker.set_scope(scope)
     try:
-        module = importlib.import_module("tools_add_event")
-        assert inspect.iscoroutinefunction(module.run)
-        assert str(inspect.signature(module.run)) == "(*, day: str, count: int = None)"
-        assert module.run.__doc__ == "Add an event.\ndetails"
+        results = await asyncio.gather(
+            skill.run(text="one"),
+            skill.run(text="two"),
+        )
+        with pytest.raises(RuntimeError, match="unknown MCP tool capability"):
+            await broker.call_skill("invalid", {})
+        broker.configure(broker.BrokerEndpoint(endpoint.socket_path, "invalid"))
+        with pytest.raises(RuntimeError, match="invalid broker capability"):
+            await skill.run(text="forbidden")
+        broker.configure(endpoint)
+        await supervisor.close_scope(scope)
+        with pytest.raises(RuntimeError, match="invalid broker capability"):
+            await skill.run(text="stale")
     finally:
-        sys.path.remove(str(tmp_path))
-        sys.modules.pop("tools_add_event", None)
+        broker.set_scope(None)
+        broker.configure(None)
+        await supervisor.close_scope(scope)
+        await supervisor.aclose()
+        session.close()
+        sys.path.remove(str(skills_dir))
+        sys.modules.pop("local_echo", None)
+
+    assert results == [
+        f"stdio:True:{server_cwd}:one",
+        f"stdio:True:{server_cwd}:two",
+    ]
+    stats, child_stats = supervisor.programmatic_tool_call_stats(supervisor.root_id)
+    assert stats.python_total == 2
+    assert stats.by_tool_python == {"local_echo": 2}
+    assert child_stats.python_total == 0
+
+
+async def test_real_kernel_uses_mcp_without_transport_secrets(monkeypatch, tmp_path):
+    server_cwd = tmp_path / "server"
+    server_cwd.mkdir()
+    session = Session(tmp_path / "session")
+    servers = {"local": _stdio_server("stdio-secret")}
+    monkeypatch.setenv(mcp.MCP_CONFIG_ENV, mcp.dump_mcp_servers(servers))
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": """
+import inspect, os, subprocess
+print(await local_echo(text='hello'))
+print(inspect.signature(local_echo))
+print('RLM_MCP_CONFIG' not in os.environ)
+print('RLM_MCP_CONFIG=' not in subprocess.check_output(['env'], text=True))
+"""
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="done"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=_config(),
+        cwd=str(server_cwd),
+    )
+
+    result = await engine.run("use the tool")
+
+    assert result.answer == "done"
+    assert tool_result(client).strip().splitlines() == [
+        f"stdio-secret:True:{server_cwd}:hello",
+        "(*, text: str)",
+        "True",
+        "True",
+    ]
+    source = (session.dir / "local_echo.py").read_text()
+    assert "stdio-secret" not in source
+    assert str(Path(__file__).parent / "fixtures" / "mcp_stdio.py") not in source
+    meta = json.loads((session.dir / "meta.json").read_text())
+    assert meta["programmatic_tool_call_stats"]["python_total"] == 1
+    assert meta["programmatic_tool_call_stats"]["by_tool_python"] == {"local_echo": 1}
+
+
+async def test_cancelled_kernel_mcp_call_stops_server_and_session_reuses(tmp_path):
+    marker = tmp_path / "started"
+    session = Session(tmp_path / "session")
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {"code": f"await local_wait(marker={str(marker)!r})"},
+                    )
+                ]
+            ),
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {"code": "print(await local_echo(text='reused'))"},
+                    )
+                ]
+            ),
+            DummyMessage(content="done"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=_config(),
+        mcp_servers={"local": _blocking_stdio_server()},
+        cwd=str(tmp_path),
+    )
+
+    pending = asyncio.create_task(engine.prompt("wait"))
+    for _ in range(100):
+        if marker.exists():
+            break
+        await asyncio.sleep(0.05)
+    assert marker.exists()
+    server_pid = int(marker.read_text())
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(pending, timeout=10)
+    for _ in range(100):
+        if not _process_exists(server_pid):
+            break
+        await asyncio.sleep(0.02)
+
+    result = await engine.prompt("retry")
+    await engine.aclose()
+
+    assert _process_exists(server_pid) is False
+    assert result.answer == "done"
+    tool_messages = [
+        message for message in client.calls[-1]["messages"] if message["role"] == "tool"
+    ]
+    assert tool_messages[-1]["content"].strip() == "reused"
+    meta = json.loads((session.dir / "meta.json").read_text())
+    assert meta["programmatic_tool_call_stats"]["python_total"] == 2

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -235,7 +235,7 @@ async def test_broker_round_trip_records_trusted_metric(tmp_path):
     )
     await supervisor.start()
     skills_dir = tmp_path / "skills"
-    supervisor.write_mcp_skill_modules(skills_dir)
+    supervisor.write_brokered_skill_modules(skills_dir)
     sys.path.insert(0, str(skills_dir))
     skill = importlib.import_module("local_echo")
     scope = await supervisor.open_scope(supervisor.root_id)
@@ -247,7 +247,7 @@ async def test_broker_round_trip_records_trusted_metric(tmp_path):
             skill.run(text="one"),
             skill.run(text="two"),
         )
-        with pytest.raises(RuntimeError, match="unknown MCP tool capability"):
+        with pytest.raises(RuntimeError, match="unknown brokered skill capability"):
             await broker.call_skill("invalid", {})
         broker.configure(broker.BrokerEndpoint(endpoint.socket_path, "invalid"))
         with pytest.raises(RuntimeError, match="invalid broker capability"):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -90,3 +90,18 @@ def test_search_skill_prompt_included_only_when_search_is_installed():
     assert SEARCH_SKILL_PROMPT not in _prompt(
         [_Tool("ipython")], installed_skills=["search_docs"]
     )
+
+
+def test_prompt_only_advertises_actual_shell_skills():
+    prompt = build_system_prompt(
+        "/repo",
+        None,
+        ["edit", "uploaded"],
+        "/repo/messages.jsonl",
+        allow_recursion=False,
+        active_tools=[_Tool("ipython")],
+        shell_skills=["uploaded"],
+    )
+
+    assert "Shell-enabled installed skills: `uploaded`" in prompt
+    assert "Other listed skills are IPython-only" in prompt

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -327,6 +327,47 @@ async def test_shutdown_closes_incomplete_broker_connections(tmp_path):
         session.close()
 
 
+async def test_incomplete_broker_connections_are_bounded_and_time_out(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr("rlm.supervisor.MAX_BROKER_CONNECTIONS", 1)
+    monkeypatch.setattr("rlm.supervisor.BROKER_INITIAL_FRAME_TIMEOUT_SECONDS", 0.05)
+    session = Session(tmp_path / "root")
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=_config(max_depth=1),
+        cwd=str(tmp_path),
+        engine_factory=_FastEngine,
+    )
+    await supervisor.start()
+    endpoint = supervisor.endpoint_for(supervisor.root_id)
+    first_reader, first_writer = await asyncio.open_unix_connection(
+        endpoint.socket_path
+    )
+    for _ in range(100):
+        if supervisor._connection_tasks:
+            break
+        await asyncio.sleep(0.001)
+    second_reader, second_writer = await asyncio.open_unix_connection(
+        endpoint.socket_path
+    )
+
+    try:
+        assert await asyncio.wait_for(second_reader.read(), timeout=1) == b""
+        assert await broker.read_frame(first_reader) == {
+            "error": "broker request timed out"
+        }
+        assert await asyncio.wait_for(first_reader.read(), timeout=1) == b""
+        assert supervisor._connection_tasks == set()
+    finally:
+        first_writer.close()
+        second_writer.close()
+        await first_writer.wait_closed()
+        await second_writer.wait_closed()
+        await supervisor.aclose()
+        session.close()
+
+
 async def test_real_kernel_uses_brokered_rlm_callable(monkeypatch, session):
     _FastEngine.state = _EngineState()
     for name in (

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -99,6 +99,14 @@ class _SometimesBlockingEngine(_FastEngine):
             state.active -= 1
 
 
+class _CaptureLineageEngine(_FastEngine):
+    constructors = []
+
+    def __init__(self, *, runtime_config, session, **kwargs):
+        super().__init__(runtime_config=runtime_config, session=session)
+        self.constructors.append(kwargs)
+
+
 class _NestedEngine:
     def __init__(
         self,
@@ -145,6 +153,48 @@ def test_depth_capacities_reserve_every_level():
     assert depth_capacities(max_depth=4, limit=3, root_depth=2) == {3: 2, 4: 1}
     with pytest.raises(ValueError, match="every recursive depth"):
         depth_capacities(max_depth=3, limit=2)
+
+
+async def test_child_inherits_trusted_session_segment_and_parent_call(tmp_path):
+    _CaptureLineageEngine.constructors = []
+    session = Session(tmp_path / "root")
+    config = _config(max_depth=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(tmp_path),
+        engine_factory=_CaptureLineageEngine,
+        lineage_session_id="trace-session",
+    )
+    await supervisor.start()
+    root_engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+    )
+    assert root_engine.execution_snapshot()["session_id"] == "trace-session"
+    scope = await supervisor.open_scope(
+        supervisor.root_id,
+        parent_call_id="spawn-call",
+        segment_id="outer-segment",
+    )
+    endpoint = supervisor.endpoint_for(supervisor.root_id)
+    try:
+        child = await supervisor._start_child(
+            endpoint.capability, scope, "delegate", {}
+        )
+        await child
+    finally:
+        await supervisor.close_scope(scope)
+        await supervisor.aclose()
+        root_engine.close()
+
+    constructor = _CaptureLineageEngine.constructors[0]
+    assert constructor["parent_invocation_id"] == supervisor.root_id
+    assert constructor["parent_call_id"] == "spawn-call"
+    assert constructor["lineage_session_id"] == "trace-session"
+    assert constructor["segment_id"] == "outer-segment"
 
 
 async def test_parallel_children_respect_depth_capacity(tmp_path):
@@ -270,9 +320,10 @@ async def test_client_disconnect_cancels_child(tmp_path):
     _BlockingEngine.state = _EngineState()
     _BlockingEngine.started = asyncio.Event()
     session = Session(tmp_path / "root")
+    config = _config(max_depth=1)
     supervisor = SessionTreeSupervisor(
         root_session=session,
-        runtime_config=_config(max_depth=1),
+        runtime_config=config,
         cwd=str(tmp_path),
         engine_factory=_BlockingEngine,
     )
@@ -282,6 +333,26 @@ async def test_client_disconnect_cancels_child(tmp_path):
     broker.set_scope(scope)
     pending = asyncio.create_task(broker.run("wait"))
     await asyncio.wait_for(_BlockingEngine.started.wait(), timeout=2)
+    root_engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    active_snapshot = root_engine.execution_snapshot()
+    assert active_snapshot["supervisor"] == {
+        "subagent_calls": 1,
+        "active_subagent_calls": 1,
+    }
+    assert active_snapshot["limits"] == {
+        "max_depth": 1,
+        "max_concurrent_subagents": 4,
+        "max_subagent_calls": 16,
+        "max_tokens": None,
+        "summarize_at_tokens": None,
+        "max_compactions": None,
+    }
     pending.cancel()
     with pytest.raises(asyncio.CancelledError):
         await pending
@@ -292,12 +363,15 @@ async def test_client_disconnect_cancels_child(tmp_path):
     try:
         assert supervisor.active_calls == 0
         assert _BlockingEngine.state.cancelled == 1
+        assert (
+            root_engine.execution_snapshot()["supervisor"]["active_subagent_calls"] == 0
+        )
     finally:
         broker.set_scope(None)
         broker.configure(None)
         await supervisor.close_scope(scope)
         await supervisor.aclose()
-        session.close()
+        root_engine.close()
 
 
 async def test_shutdown_closes_incomplete_broker_connections(tmp_path):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -78,19 +78,19 @@ def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     repl = IPythonREPL(cwd=str(session.dir), session=session)
     repl.start()
     try:
-        result = repl.execute(
+        repl.execute(
             "import os; "
             "stdout_written = os.write(1, b'123\\n'); "
-            "stderr_written = os.write(2, b'kernel stderr\\n'); "
-            "print(stdout_written, stderr_written)"
+            "stderr_written = os.write(2, b'kernel stderr\\n')"
         )
+        result = repl.execute("print(stdout_written, stderr_written)")
     finally:
         repl.shutdown()
 
     captured = capfd.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    assert "4 14" in result
+    assert result.strip() == "4 14"
 
 
 def test_kernel_environment_is_explicit_and_reserves_supervisor_names(tmp_path):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -17,6 +17,7 @@ from conftest import (
 )
 
 from rlm.engine import RLMEngine
+from rlm.tools.ipython import IPythonREPL, build_kernel_env
 
 
 async def test_valid_tool(session):
@@ -74,8 +75,6 @@ async def test_tool_raises(session):
 
 def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     """Kernel writes outside IOPub must not corrupt an enclosing ACP transport."""
-    from rlm.tools.ipython import IPythonREPL
-
     repl = IPythonREPL(cwd=str(session.dir), session=session)
     repl.start()
     try:
@@ -91,4 +90,82 @@ def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     captured = capfd.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    assert result.strip() == "4 14"
+    assert "4 14" in result
+
+
+def test_kernel_environment_is_explicit_and_reserves_supervisor_names(tmp_path):
+    source = {
+        "PATH": "/bin",
+        "HOME": "/home/task",
+        "LC_ALL": "C",
+        "GITHUB_TOKEN": "ambient-secret",
+        "SUPERVISOR_ONLY": "hidden",
+        "SERPER_API_KEY": "search-secret",
+    }
+    kernel_env = build_kernel_env(
+        {"TASK_VISIBLE": "yes", "GITHUB_TOKEN": "explicit-task-token"},
+        environ=source,
+        private_dir=str(tmp_path),
+    )
+
+    assert kernel_env["PATH"] == "/bin"
+    assert kernel_env["HOME"] == "/home/task"
+    assert kernel_env["LC_ALL"] == "C"
+    assert kernel_env["TASK_VISIBLE"] == "yes"
+    assert kernel_env["GITHUB_TOKEN"] == "explicit-task-token"
+    assert "SUPERVISOR_ONLY" not in kernel_env
+    assert "SERPER_API_KEY" not in kernel_env
+    assert all(
+        str(tmp_path) in kernel_env[name]
+        for name in (
+            "IPYTHONDIR",
+            "JUPYTER_CONFIG_DIR",
+            "JUPYTER_DATA_DIR",
+            "JUPYTER_RUNTIME_DIR",
+        )
+    )
+    with pytest.raises(ValueError, match="reserved names"):
+        build_kernel_env({"RLM_API_KEY": "forbidden"}, environ=source)
+
+
+def test_real_kernel_and_subprocess_receive_only_explicit_environment(
+    monkeypatch, session
+):
+    from jupyter_client import KernelManager
+
+    original_init = KernelManager.__init__
+
+    def init_with_host_kernel_environment(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.kernel_spec.env = {
+            "KERNELSPEC_SENTINEL": "hidden",
+            "RLM_API_KEY": "kernelspec-secret",
+        }
+
+    monkeypatch.setattr(KernelManager, "__init__", init_with_host_kernel_environment)
+    monkeypatch.setenv("SUPERVISOR_ONLY", "hidden")
+    monkeypatch.setenv("SERPER_API_KEY", "search-secret")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-cloud-secret")
+    repl = IPythonREPL(
+        cwd=str(session.dir),
+        session=session,
+        kernel_env={"TASK_VISIBLE": "yes"},
+    )
+    repl.start()
+    code = f"""
+import os, subprocess
+child_env = subprocess.check_output(['env'], text=True)
+print(os.environ.get('TASK_VISIBLE'))
+print(all(name not in os.environ for name in ('SUPERVISOR_ONLY', 'SERPER_API_KEY', 'AWS_SECRET_ACCESS_KEY', 'KERNELSPEC_SENTINEL', 'RLM_API_KEY')))
+print(all(f'{{name}}=' not in child_env for name in ('SUPERVISOR_ONLY', 'SERPER_API_KEY', 'AWS_SECRET_ACCESS_KEY', 'KERNELSPEC_SENTINEL', 'RLM_API_KEY')))
+print(all(os.environ.get(name, '').startswith({repl._ipc_dir!r}) for name in ('IPYTHONDIR', 'JUPYTER_CONFIG_DIR', 'JUPYTER_DATA_DIR', 'JUPYTER_RUNTIME_DIR')))
+"""
+    try:
+        first = repl.execute(code)
+        repl.restart_kernel()
+        second = repl.execute(code)
+    finally:
+        repl.shutdown()
+
+    assert first.strip().splitlines() == ["yes", "True", "True", "True"]
+    assert second.strip().splitlines() == ["yes", "True", "True", "True"]


### PR DESCRIPTION
## Summary

- discover and invoke MCP tools in the trusted session supervisor instead of the model-controlled kernel
- expose only public schemas and opaque tool capabilities through generated proxy modules
- keep MCP URLs, headers, stdio commands, environments, and credentials out of kernel environments and session artifacts
- authenticate every call with an invocation capability, a live cell scope, and a tool capability
- cancel MCP transports on cell/session cancellation and retain accepted-call metrics in supervisor memory until finalization
- bound discovery metadata, live broker connections, frame sizes, and initial-frame wait time

Depends on the session supervisor introduced by the base branch.

## Validation

- `uv run pytest tests/` (126 passed)
- `uv run ruff check src tests`
- live stdio MCP discovery/calls, concurrent calls, real Jupyter proxy calls, wrong/stale authorization, cancellation with subprocess cleanup, session reuse, redaction, and resource-bound coverage
