### PR TITLE
feat: expose training session metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ not advertise `session/load`: an arbitrary live Python kernel cannot be
 reconstructed after the ACP process exits, so clients must keep the process
 alive for the lifetime of a session.
 
+ACP clients can pass trusted per-rollout configuration under the
+`ai.prime.rlm/runtime-v1` key in `session/new._meta`. Supported fields are an
+opaque `lineage_session_id`, explicit provider configuration, `kernel_env`, and
+`search_api_key`. This lets a harness deliver credentials over the private ACP
+stdio channel instead of placing them in the agent process environment. RLM
+never echoes those inputs. `session/new`, `session/prompt`, and `session/close`
+responses carry cumulative, credential-free snapshots under
+`ai.prime.rlm/session-v1`; only the close snapshot with `final: true` is
+authoritative for training metrics.
+
+Every inference request carries versioned `X-RLM-*` provenance headers for its
+session, invocation, prompt segment, logical call, causal parent, depth, and
+call kind (`turn` or `compaction`). IDs remain stable across transport retries
+and recursion inherits the spawning call and segment. These headers are
+observability metadata, not authorization, and are visible to the configured
+inference endpoint.
+
 ## Python SDK
 
 ```python

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -66,6 +66,19 @@ class _SessionState:
     snapshot_sequence: int = 0
 
 
+def _request_is_cancelling(awaited: asyncio.Task[Any]) -> bool:
+    current = asyncio.current_task()
+    cancelling = getattr(current, "cancelling", None)
+    if cancelling is not None:
+        return bool(cancelling())
+    return not awaited.cancelled()
+
+
+async def _cancel_and_wait(task: asyncio.Task[Any]) -> None:
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
 def _session_metadata(
     state: _SessionState, status: SessionStatus, *, final: bool = False
 ) -> dict[str, Any]:
@@ -314,10 +327,10 @@ class RLMACPAgent(Agent):
             task = asyncio.create_task(state.engine.prompt(_prompt_text(prompt)))
             state.prompt_task = task
             try:
-                result = await task
+                result = await asyncio.shield(task)
             except asyncio.CancelledError:
-                current = asyncio.current_task()
-                if current is not None and current.cancelling():
+                if _request_is_cancelling(task):
+                    await _cancel_and_wait(task)
                     raise
                 state.last_stop_reason = "cancelled"
                 return PromptResponse(
@@ -352,10 +365,10 @@ class RLMACPAgent(Agent):
             )
             state.delivery_task = delivery
             try:
-                await delivery
+                await asyncio.shield(delivery)
             except asyncio.CancelledError:
-                current = asyncio.current_task()
-                if current is not None and current.cancelling():
+                if _request_is_cancelling(delivery):
+                    await _cancel_and_wait(delivery)
                     raise
                 if not state.closing:
                     raise

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -50,6 +50,11 @@ from rlm.tools.ipython import RESERVED_KERNEL_ENV_NAMES
 SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
 CAPABILITIES_METADATA_KEY = "ai.prime.rlm/capabilities-v1"
 RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
+CAPABILITIES_METADATA = {
+    "runtime_versions": [1],
+    "session_snapshot_versions": [1],
+    "lineage_versions": [1],
+}
 SessionStatus = Literal["created", "idle", "closing", "closed"]
 _LINEAGE_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 
@@ -266,9 +271,9 @@ class RLMACPAgent(Agent):
                 session_capabilities=SessionCapabilities(
                     close=SessionCloseCapabilities()
                 ),
+                field_meta={CAPABILITIES_METADATA_KEY: CAPABILITIES_METADATA},
             ),
             agent_info=Implementation(name="rlm", title="RLM", version=version("rlm")),
-            field_meta={CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}},
         )
 
     async def new_session(

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
+import re
+from dataclasses import dataclass, field, replace
 from importlib.metadata import version
-from typing import Any
+from typing import Any, Literal
 
 from acp import (
     PROTOCOL_VERSION,
@@ -41,8 +42,16 @@ from acp.schema import (
 )
 
 from rlm.engine import RLMEngine
+from rlm.config import ProviderConfig, RuntimeConfig
 from rlm.mcp import MCPServer
 from rlm.session import Session
+from rlm.tools.ipython import RESERVED_KERNEL_ENV_NAMES
+
+SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
+CAPABILITIES_METADATA_KEY = "ai.prime.rlm/capabilities-v1"
+RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
+SessionStatus = Literal["created", "idle", "closing", "closed"]
+_LINEAGE_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 
 
 @dataclass
@@ -50,7 +59,131 @@ class _SessionState:
     engine: RLMEngine
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     prompt_task: asyncio.Task | None = None
+    delivery_task: asyncio.Task | None = None
+    close_task: asyncio.Task[dict[str, Any]] | None = None
     closing: bool = False
+    last_stop_reason: str | None = None
+    snapshot_sequence: int = 0
+
+
+def _session_metadata(
+    state: _SessionState, status: SessionStatus, *, final: bool = False
+) -> dict[str, Any]:
+    snapshot = {
+        "schema_version": 1,
+        "sequence": state.snapshot_sequence,
+        "status": status,
+        "final": final,
+        "last_stop_reason": state.last_stop_reason,
+        **state.engine.execution_snapshot(),
+    }
+    state.snapshot_sequence += 1
+    return {SESSION_METADATA_KEY: snapshot}
+
+
+def _runtime_config(
+    field_meta: Any,
+) -> tuple[RuntimeConfig, str | None]:
+    config = RuntimeConfig.from_env()
+    if field_meta is None:
+        return config, None
+    if not isinstance(field_meta, dict):
+        raise RequestError.invalid_params({"reason": "ACP _meta must be an object"})
+    payload = field_meta.get(RUNTIME_METADATA_KEY)
+    if payload is None:
+        return config, None
+    if not isinstance(payload, dict):
+        raise RequestError.invalid_params(
+            {"reason": f"{RUNTIME_METADATA_KEY} must be an object"}
+        )
+    unknown = sorted(
+        set(payload)
+        - {"lineage_session_id", "provider", "kernel_env", "search_api_key"}
+    )
+    if unknown:
+        raise RequestError.invalid_params(
+            {"reason": f"{RUNTIME_METADATA_KEY} has unknown fields: {unknown}"}
+        )
+
+    lineage_session_id = payload.get("lineage_session_id")
+    if lineage_session_id is not None and (
+        not isinstance(lineage_session_id, str)
+        or _LINEAGE_ID_RE.fullmatch(lineage_session_id) is None
+    ):
+        raise RequestError.invalid_params(
+            {"reason": "lineage_session_id must be a bounded opaque identifier"}
+        )
+
+    provider = config.provider
+    if "provider" in payload:
+        provider_payload = payload["provider"]
+        if not isinstance(provider_payload, dict):
+            raise RequestError.invalid_params({"reason": "provider must be an object"})
+        provider_unknown = sorted(
+            set(provider_payload) - {"base_url", "api_key", "headers", "max_retries"}
+        )
+        if provider_unknown:
+            raise RequestError.invalid_params(
+                {"reason": f"provider has unknown fields: {provider_unknown}"}
+            )
+        base_url = provider_payload.get("base_url")
+        api_key = provider_payload.get("api_key")
+        headers = provider_payload.get("headers", {})
+        max_retries = provider_payload.get("max_retries", provider.max_retries)
+        if base_url is not None and not isinstance(base_url, str):
+            raise RequestError.invalid_params(
+                {"reason": "provider base_url is invalid"}
+            )
+        if not isinstance(api_key, str) or not api_key:
+            raise RequestError.invalid_params({"reason": "provider api_key is invalid"})
+        if not isinstance(headers, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in headers.items()
+        ):
+            raise RequestError.invalid_params(
+                {"reason": "provider headers are invalid"}
+            )
+        if (
+            not isinstance(max_retries, int)
+            or isinstance(max_retries, bool)
+            or max_retries < 0
+        ):
+            raise RequestError.invalid_params(
+                {"reason": "provider max_retries is invalid"}
+            )
+        try:
+            provider = ProviderConfig(base_url, api_key, headers, max_retries)
+        except ValueError as error:
+            raise RequestError.invalid_params({"reason": str(error)}) from error
+
+    kernel_env = payload.get("kernel_env")
+    if kernel_env is None:
+        resolved_kernel_env = config.kernel_env
+    elif not isinstance(kernel_env, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in kernel_env.items()
+    ):
+        raise RequestError.invalid_params({"reason": "kernel_env must map strings"})
+    else:
+        resolved_kernel_env = tuple(kernel_env.items())
+        reserved_kernel_env = sorted(RESERVED_KERNEL_ENV_NAMES.intersection(kernel_env))
+        if reserved_kernel_env:
+            raise RequestError.invalid_params(
+                {"reason": f"kernel_env contains reserved names: {reserved_kernel_env}"}
+            )
+
+    search_api_key = payload.get("search_api_key", config.search_api_key)
+    if search_api_key is not None and not isinstance(search_api_key, str):
+        raise RequestError.invalid_params({"reason": "search_api_key is invalid"})
+    return (
+        replace(
+            config,
+            provider=provider,
+            kernel_env=resolved_kernel_env,
+            search_api_key=search_api_key,
+        ),
+        lineage_session_id,
+    )
 
 
 def _mcp_servers(
@@ -122,6 +255,7 @@ class RLMACPAgent(Agent):
                 ),
             ),
             agent_info=Implementation(name="rlm", title="RLM", version=version("rlm")),
+            field_meta={CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}},
         )
 
     async def new_session(
@@ -137,6 +271,7 @@ class RLMACPAgent(Agent):
                 {"reason": "RLM does not support additional session directories"}
             )
         resolved_mcp_servers = _mcp_servers(mcp_servers)
+        runtime_config, lineage_session_id = _runtime_config(kwargs)
         session = Session()
         session_id = session.dir.name
         try:
@@ -144,12 +279,18 @@ class RLMACPAgent(Agent):
                 cwd=cwd,
                 session=session,
                 mcp_servers=resolved_mcp_servers,
+                runtime_config=runtime_config,
+                lineage_session_id=lineage_session_id,
             )
         except BaseException:
             session.close()
             raise
-        self._sessions[session_id] = _SessionState(engine=engine)
-        return NewSessionResponse(session_id=session_id)
+        state = _SessionState(engine=engine)
+        self._sessions[session_id] = state
+        return NewSessionResponse(
+            session_id=session_id,
+            field_meta=_session_metadata(state, "created"),
+        )
 
     async def prompt(
         self,
@@ -175,19 +316,56 @@ class RLMACPAgent(Agent):
             try:
                 result = await task
             except asyncio.CancelledError:
-                return PromptResponse(stop_reason="cancelled")
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
+                state.last_stop_reason = "cancelled"
+                return PromptResponse(
+                    stop_reason="cancelled",
+                    field_meta=_session_metadata(
+                        state, "closing" if state.closing else "idle"
+                    ),
+                )
+            except Exception:
+                state.last_stop_reason = "error"
+                raise
             finally:
                 state.prompt_task = None
 
-            await self._client.session_update(
-                session_id=session_id,
-                update=update_agent_message(text_block(result.answer)),
-            )
             stop_reason = (
                 "max_tokens"
                 if state.engine.stop_reason == "token_budget"
                 else "end_turn"
             )
+            state.last_stop_reason = state.engine.stop_reason or stop_reason
+            if state.closing:
+                return PromptResponse(
+                    stop_reason="cancelled",
+                    field_meta=_session_metadata(state, "closing"),
+                )
+
+            delivery = asyncio.create_task(
+                self._client.session_update(
+                    session_id=session_id,
+                    update=update_agent_message(text_block(result.answer)),
+                )
+            )
+            state.delivery_task = delivery
+            try:
+                await delivery
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
+                if not state.closing:
+                    raise
+                return PromptResponse(
+                    stop_reason="cancelled",
+                    field_meta=_session_metadata(state, "closing"),
+                )
+            finally:
+                state.delivery_task = None
+
             return PromptResponse(
                 stop_reason=stop_reason,
                 usage=Usage(
@@ -195,6 +373,7 @@ class RLMACPAgent(Agent):
                     input_tokens=result.usage.prompt_tokens,
                     output_tokens=result.usage.completion_tokens,
                 ),
+                field_meta=_session_metadata(state, "idle"),
             )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
@@ -205,19 +384,41 @@ class RLMACPAgent(Agent):
     async def close_session(
         self, session_id: str, **kwargs: Any
     ) -> CloseSessionResponse:
-        state = self._sessions.pop(session_id, None)
+        state = self._sessions.get(session_id)
         if state is None:
             raise RequestError.resource_not_found(session_id)
-        state.closing = True
-        if state.prompt_task is not None:
-            state.prompt_task.cancel()
-        async with state.lock:
-            await state.engine.aclose()
-        return CloseSessionResponse()
+        if state.close_task is None:
+            state.closing = True
+            state.close_task = asyncio.create_task(
+                self._close_session(session_id, state)
+            )
+        metadata = await asyncio.shield(state.close_task)
+        return CloseSessionResponse(field_meta=metadata)
+
+    async def _close_session(
+        self, session_id: str, state: _SessionState
+    ) -> dict[str, Any]:
+        try:
+            if state.prompt_task is not None:
+                state.prompt_task.cancel()
+            if state.delivery_task is not None:
+                state.delivery_task.cancel()
+            async with state.lock:
+                await state.engine.aclose()
+            return _session_metadata(state, "closed", final=True)
+        finally:
+            if self._sessions.get(session_id) is state:
+                self._sessions.pop(session_id)
 
     async def shutdown(self) -> None:
-        for session_id in list(self._sessions):
-            await self.close_session(session_id)
+        results = await asyncio.gather(
+            *(self.close_session(session_id) for session_id in list(self._sessions)),
+            return_exceptions=True,
+        )
+        if error := next(
+            (result for result in results if isinstance(result, BaseException)), None
+        ):
+            raise error
 
 
 async def serve_acp() -> None:

--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -17,6 +17,16 @@ from pydantic import ValidationError
 from rlm.config import InvocationContext, ProviderConfig
 from rlm.types import TokenUsage
 
+RLM_SESSION_ID_HEADER = "X-RLM-Session-ID"
+RLM_INVOCATION_ID_HEADER = "X-RLM-Invocation-ID"
+RLM_PARENT_INVOCATION_ID_HEADER = "X-RLM-Parent-Invocation-ID"
+RLM_SEGMENT_ID_HEADER = "X-RLM-Segment-ID"
+RLM_CALL_ID_HEADER = "X-RLM-Call-ID"
+RLM_PARENT_CALL_ID_HEADER = "X-RLM-Parent-Call-ID"
+RLM_DEPTH_HEADER = "X-RLM-Depth"
+RLM_CALL_KIND_HEADER = "X-RLM-Call-Kind"
+RLM_LINEAGE_VERSION_HEADER = "X-RLM-Lineage-Version"
+
 _RETRYABLE: tuple[type[BaseException], ...] = (
     APIConnectionError,
     APITimeoutError,
@@ -68,13 +78,46 @@ def make_client(
     """
     provider = provider or ProviderConfig.from_env()
     invocation = invocation or InvocationContext.from_env()
-    headers = {"X-RLM-Depth": str(invocation.depth), **provider.headers}
+    reserved = sorted(
+        name for name in provider.headers if name.lower().startswith("x-rlm-")
+    )
+    if reserved:
+        raise ValueError(f"provider headers contain reserved names: {reserved}")
+    headers = {**provider.headers, RLM_DEPTH_HEADER: str(invocation.depth)}
     return AsyncOpenAI(
         base_url=provider.base_url,
         api_key=provider.api_key,
         max_retries=provider.max_retries,
         default_headers=headers,
     )
+
+
+def model_call_headers(
+    *,
+    session_id: str,
+    invocation_id: str,
+    parent_invocation_id: str | None,
+    segment_id: str,
+    call_id: str,
+    parent_call_id: str | None,
+    depth: int,
+    call_kind: str,
+) -> dict[str, str]:
+    """Build provenance headers for one logical model call."""
+    headers = {
+        RLM_LINEAGE_VERSION_HEADER: "1",
+        RLM_SESSION_ID_HEADER: session_id,
+        RLM_INVOCATION_ID_HEADER: invocation_id,
+        RLM_SEGMENT_ID_HEADER: segment_id,
+        RLM_CALL_ID_HEADER: call_id,
+        RLM_DEPTH_HEADER: str(depth),
+        RLM_CALL_KIND_HEADER: call_kind,
+    }
+    if parent_invocation_id is not None:
+        headers[RLM_PARENT_INVOCATION_ID_HEADER] = parent_invocation_id
+    if parent_call_id is not None:
+        headers[RLM_PARENT_CALL_ID_HEADER] = parent_call_id
+    return headers
 
 
 async def call_with_retries(

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -58,6 +58,13 @@ class ProviderConfig:
     headers: dict[str, str] = field(default_factory=dict, repr=False)
     max_retries: int = 5
 
+    def __post_init__(self) -> None:
+        reserved = sorted(
+            name for name in self.headers if name.lower().startswith("x-rlm-")
+        )
+        if reserved:
+            raise ValueError(f"provider headers contain reserved names: {reserved}")
+
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> ProviderConfig:
         env = os.environ if environ is None else environ

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -8,11 +8,18 @@ import json
 import logging
 import os
 import time
+import uuid
+from copy import deepcopy
 from pathlib import Path
 
 from openai import AsyncOpenAI, BadRequestError
 
-from rlm.client import call_with_retries, extract_usage, make_client
+from rlm.client import (
+    call_with_retries,
+    extract_usage,
+    make_client,
+    model_call_headers,
+)
 from rlm.config import RuntimeConfig
 from rlm.mcp import MCPServer, load_mcp_servers
 from rlm.prompt import build_system_prompt
@@ -30,7 +37,13 @@ from rlm.tools import (
     get_builtin_tool,
     get_installed_skills,
 )
-from rlm.types import CompactionApplied, RLMMetrics, RLMResult, TokenUsage
+from rlm.types import (
+    CompactionApplied,
+    ProgrammaticToolCallStats,
+    RLMMetrics,
+    RLMResult,
+    TokenUsage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +138,10 @@ class RLMEngine:
         runtime_config: RuntimeConfig | None = None,
         supervisor: SessionTreeSupervisor | None = None,
         invocation_id: str | None = None,
+        parent_invocation_id: str | None = None,
+        parent_call_id: str | None = None,
+        lineage_session_id: str | None = None,
+        segment_id: str | None = None,
     ):
         if runtime_config is not None and any(
             value is not None
@@ -171,7 +188,21 @@ class RLMEngine:
         self.client = client or make_client(config.provider, config.invocation)
         self.session = session
         self._supervisor = supervisor
-        self._invocation_id = invocation_id
+        self._invocation_id = invocation_id or (
+            supervisor.root_id if supervisor is not None else uuid.uuid4().hex
+        )
+        self._parent_invocation_id = parent_invocation_id
+        self._last_call_id = parent_call_id
+        if (
+            supervisor is not None
+            and lineage_session_id is not None
+            and lineage_session_id != supervisor.session_id
+        ):
+            raise ValueError("lineage_session_id does not match the session supervisor")
+        self._lineage_session_id = lineage_session_id or (
+            supervisor.session_id if supervisor is not None else None
+        )
+        self._initial_segment_id = segment_id
         self._owns_supervisor = False
         self._total_usage = TokenUsage()
         self._last_prompt_tokens = 0
@@ -242,10 +273,13 @@ class RLMEngine:
             prompt_tokens=self._total_usage.prompt_tokens,
             completion_tokens=self._total_usage.completion_tokens,
         )
+        lineage_head_before = self._last_call_id
 
         self._metrics.stop_reason = ""
+        segment_id = self._initial_segment_id or uuid.uuid4().hex
+        self._initial_segment_id = None
         try:
-            result = await self._run_loop()
+            result = await self._run_loop(segment_id)
         except BaseException as exc:
             attempted_turns = self._turn - turn_before
             try:
@@ -269,6 +303,7 @@ class RLMEngine:
             self._messages[:] = messages_before
             self._branch_start_turn = branch_start_before
             self._turn = turn_before
+            self._last_call_id = lineage_head_before
             if isinstance(exc, asyncio.CancelledError):
                 self._metrics.stop_reason = "cancelled"
             raise
@@ -297,6 +332,8 @@ class RLMEngine:
             prompt_preview=prompt[:200],
             cwd=self.cwd,
         )
+        if self._lineage_session_id is None:
+            self._lineage_session_id = self.session.dir.name
 
         # Credential-free built-ins run locally; privileged skills are brokered.
         local_skills = [name for name in self.skills if name != "search"]
@@ -309,13 +346,12 @@ class RLMEngine:
                     runtime_config=self.runtime_config,
                     cwd=self.cwd,
                     mcp_servers=self.mcp_servers,
+                    root_invocation_id=self._invocation_id,
+                    lineage_session_id=self._lineage_session_id,
                 )
-                self._invocation_id = self._supervisor.root_id
                 self._owns_supervisor = True
             try:
                 await self._supervisor.start()
-                if self._invocation_id is None:
-                    raise RuntimeError("recursive engine has no supervisor invocation")
                 broker_endpoint = self._supervisor.endpoint_for(self._invocation_id)
                 if self.mcp_servers or "search" in self.skills:
                     reserved_names = {"rlm", *local_skills, *discover_skills()}
@@ -331,7 +367,6 @@ class RLMEngine:
                 if self._owns_supervisor:
                     await self._supervisor.aclose()
                     self._supervisor = None
-                    self._invocation_id = None
                     self._owns_supervisor = False
                 raise
 
@@ -362,11 +397,10 @@ class RLMEngine:
             if self._owns_supervisor and self._supervisor is not None:
                 await self._supervisor.aclose()
                 self._supervisor = None
-                self._invocation_id = None
                 self._owns_supervisor = False
             raise
 
-    async def _run_loop(self) -> RLMResult:
+    async def _run_loop(self, segment_id: str) -> RLMResult:
         messages = self._messages
         if messages is None:
             raise RuntimeError("RLM engine is not started")
@@ -376,9 +410,11 @@ class RLMEngine:
         for turn in itertools.count(self._turn):
             self._turn = turn + 1
             # Call LLM
+            call_id = uuid.uuid4().hex
             request_kwargs = {
                 "model": self.model,
                 "messages": messages,
+                "extra_headers": self._model_call_headers(segment_id, call_id, "turn"),
             }
             if self._active_tool_schemas:
                 request_kwargs["tools"] = self._active_tool_schemas
@@ -394,7 +430,6 @@ class RLMEngine:
                 self._metrics.stop_reason = "request_too_large"
                 final_text = "[request body too large]"
                 break
-
             usage = extract_usage(response)
             self._total_usage.prompt_tokens += usage.prompt_tokens
             self._total_usage.completion_tokens += usage.completion_tokens
@@ -408,6 +443,7 @@ class RLMEngine:
             msg_dict = msg.model_dump(exclude_none=True)
             msg_dict.setdefault("content", "")
             messages.append(msg_dict)
+            self._last_call_id = call_id
 
             # Log assistant message; parse tool-call args once, reuse below.
             tool_calls_log: list[dict] | None = None
@@ -479,7 +515,11 @@ class RLMEngine:
                     and self._supervisor is not None
                     and self._invocation_id is not None
                 ):
-                    scope_id = await self._supervisor.open_scope(self._invocation_id)
+                    scope_id = await self._supervisor.open_scope(
+                        self._invocation_id,
+                        parent_call_id=call_id,
+                        segment_id=segment_id,
+                    )
                 try:
                     if scope_id is not None:
                         repl.set_broker_scope(scope_id)
@@ -558,7 +598,7 @@ class RLMEngine:
             ):
                 try:
                     await self._compact_branch(
-                        messages, turn, self._active_tool_schemas
+                        messages, turn, self._active_tool_schemas, segment_id
                     )
                 except BadRequestError as e:
                     if not _is_request_too_large(e):
@@ -649,8 +689,31 @@ class RLMEngine:
             if self._repl is not None:
                 self._repl.shutdown()
 
+    def _programmatic_tool_call_stats(
+        self,
+    ) -> tuple[ProgrammaticToolCallStats, ProgrammaticToolCallStats]:
+        if self.session is None:
+            return ProgrammaticToolCallStats(), ProgrammaticToolCallStats()
+        direct = ProgrammaticToolCallStats.from_log(
+            self.session.dir / "programmatic_tool_calls.jsonl"
+        )
+        child = self.session.aggregate_child_metrics(
+            "local_programmatic_tool_call_stats"
+        ).tool_call_stats
+        if self._supervisor is not None:
+            trusted_direct, trusted_child = (
+                self._supervisor.programmatic_tool_call_stats(self._invocation_id)
+            )
+            direct = direct.merge(trusted_direct)
+            child = child.merge(trusted_child)
+        return direct, child
+
     async def _compact_branch(
-        self, messages: list[dict], turn: int, active_tools: list[dict]
+        self,
+        messages: list[dict],
+        turn: int,
+        active_tools: list[dict],
+        segment_id: str,
     ) -> None:
         """Ask the model for a handoff summary and rebuild ``messages``.
 
@@ -685,14 +748,25 @@ class RLMEngine:
         if self._repl is not None:
             checkpoint_prompt += REPL_RESTART_NOTE
         messages.append({"role": "user", "content": checkpoint_prompt})
-        request_kwargs: dict = {"model": self.model, "messages": messages}
+        call_id = uuid.uuid4().hex
+        request_kwargs: dict = {
+            "model": self.model,
+            "messages": messages,
+            "extra_headers": self._model_call_headers(
+                segment_id, call_id, "compaction"
+            ),
+        }
         if active_tools:
             request_kwargs["tools"] = active_tools
             request_kwargs["tool_choice"] = "none"
-        response = await call_with_retries(
-            self.client.chat.completions.create,
-            **request_kwargs,
-        )
+        try:
+            response = await call_with_retries(
+                self.client.chat.completions.create,
+                **request_kwargs,
+            )
+        except BaseException:
+            messages.pop()
+            raise
         usage = extract_usage(response)
         self._total_usage.prompt_tokens += usage.prompt_tokens
         self._total_usage.completion_tokens += usage.completion_tokens
@@ -732,6 +806,68 @@ class RLMEngine:
         )
         self._branch_start_turn = turn + 1
         self._metrics.turns_since_last_compaction = 0
+        self._last_call_id = call_id
+
+    def _model_call_headers(
+        self, segment_id: str, call_id: str, call_kind: str
+    ) -> dict[str, str]:
+        if self.session is None:
+            raise RuntimeError("RLM session is not initialized")
+        return model_call_headers(
+            session_id=self._lineage_session_id or self.session.dir.name,
+            invocation_id=self._invocation_id,
+            parent_invocation_id=self._parent_invocation_id,
+            segment_id=segment_id,
+            call_id=call_id,
+            parent_call_id=self._last_call_id,
+            depth=self.depth,
+            call_kind=call_kind,
+        )
+
+    def execution_snapshot(self) -> dict:
+        """Return a credential-free snapshot of cumulative execution state."""
+        if self.session is None:
+            raise RuntimeError("RLM session is not initialized")
+        direct_tool_stats, child_tool_stats = self._programmatic_tool_call_stats()
+        metrics = deepcopy(self._metrics)
+        metrics.apply_programmatic_tool_call_stats(direct_tool_stats, child_tool_stats)
+        metric_values = {
+            key: value
+            for key, value in metrics.to_dict().items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        }
+        snapshot = {
+            "session_id": self._lineage_session_id or self.session.dir.name,
+            "root_invocation_id": self._invocation_id,
+            "model": self.model,
+            "turns": self._turn,
+            "usage": {
+                "prompt_tokens": self._total_usage.prompt_tokens,
+                "completion_tokens": self._total_usage.completion_tokens,
+                "total_tokens": self._total_usage.total,
+            },
+            "metrics": metric_values,
+            "programmatic_tool_call_stats": direct_tool_stats.merge(
+                child_tool_stats
+            ).to_dict(),
+            "supervisor": {
+                "subagent_calls": self._supervisor.total_calls
+                if self._supervisor is not None
+                else 0,
+                "active_subagent_calls": self._supervisor.active_calls
+                if self._supervisor is not None
+                else 0,
+            },
+            "limits": {
+                "max_depth": self.runtime_config.policy.max_depth,
+                "max_concurrent_subagents": self.runtime_config.policy.max_concurrent_subagents,
+                "max_subagent_calls": self.runtime_config.policy.max_subagent_calls,
+                "max_tokens": self.runtime_config.policy.max_tokens,
+                "summarize_at_tokens": self.runtime_config.policy.summarize_at_tokens,
+                "max_compactions": self.runtime_config.policy.max_compactions,
+            },
+        }
+        return snapshot
 
     def _load_system_prompt(
         self, messages_path: str, active_tools: list[BuiltinTool]

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -45,6 +45,14 @@ class _Invocation:
     mcp_servers: dict[str, MCPServer]
 
 
+@dataclass
+class _Scope:
+    invocation_id: str
+    parent_call_id: str | None
+    segment_id: str | None
+    tasks: set[asyncio.Task[Any]]
+
+
 def depth_capacities(max_depth: int, limit: int, root_depth: int = 0) -> dict[int, int]:
     """Reserve capacity per descendant depth so nested calls cannot deadlock."""
     levels = max_depth - root_depth
@@ -70,6 +78,8 @@ class SessionTreeSupervisor:
         cwd: str,
         mcp_servers: dict[str, MCPServer] | None = None,
         engine_factory: Callable[..., RLMEngine] | None = None,
+        root_invocation_id: str | None = None,
+        lineage_session_id: str | None = None,
     ) -> None:
         self._engine_factory = engine_factory
         self._server: asyncio.AbstractServer | None = None
@@ -83,7 +93,7 @@ class SessionTreeSupervisor:
         self._child_tasks: set[asyncio.Task[RLMResult]] = set()
         self._connection_tasks: set[asyncio.Task[None]] = set()
         self._connection_writers: set[asyncio.StreamWriter] = set()
-        self._scopes: dict[str, tuple[str, set[asyncio.Task[Any]]]] = {}
+        self._scopes: dict[str, _Scope] = {}
         self._mcp_registry = MCPRegistry(mcp_servers, cwd) if mcp_servers else None
         self._brokered_skills: dict[
             str,
@@ -113,7 +123,8 @@ class SessionTreeSupervisor:
             )
             self._brokered_skills[capability] = (descriptor, self._call_search)
 
-        root_id = uuid.uuid4().hex
+        root_id = root_invocation_id or uuid.uuid4().hex
+        self.session_id = lineage_session_id or root_session.dir.name
         root = _Invocation(
             id=root_id,
             parent_id=None,
@@ -209,18 +220,25 @@ class SessionTreeSupervisor:
         invocation = self._invocations[invocation_id]
         return BrokerEndpoint(self._socket_path, invocation.capability)
 
-    async def open_scope(self, invocation_id: str) -> str:
+    async def open_scope(
+        self,
+        invocation_id: str,
+        parent_call_id: str | None = None,
+        segment_id: str | None = None,
+    ) -> str:
         async with self._lock:
             if self._closed or invocation_id not in self._invocations:
                 raise RuntimeError("recursive invocation is no longer active")
             scope_id = secrets.token_urlsafe(24)
-            self._scopes[scope_id] = (invocation_id, set())
+            self._scopes[scope_id] = _Scope(
+                invocation_id, parent_call_id, segment_id, set()
+            )
             return scope_id
 
     async def close_scope(self, scope_id: str) -> None:
         async with self._lock:
             scope = self._scopes.pop(scope_id, None)
-            tasks = list(scope[1]) if scope else []
+            tasks = list(scope.tasks) if scope else []
         for task in tasks:
             task.cancel()
         if tasks:
@@ -234,7 +252,7 @@ class SessionTreeSupervisor:
         async with self._lock:
             parent_id = self._capabilities.get(capability)
             scope = self._scopes.get(scope_id)
-            if parent_id is None or scope is None or scope[0] != parent_id:
+            if parent_id is None or scope is None or scope.invocation_id != parent_id:
                 raise PermissionError("invalid recursive RLM capability")
             parent = self._invocations[parent_id]
             child_depth = parent.runtime_config.invocation.depth + 1
@@ -247,13 +265,17 @@ class SessionTreeSupervisor:
                     self._limit_result(parent, "recursive call limit reached")
                 )
             self._total_calls += 1
-            task = asyncio.create_task(self._run_child(parent_id, prompt))
+            task = asyncio.create_task(
+                self._run_child(
+                    parent_id, prompt, scope.parent_call_id, scope.segment_id
+                )
+            )
             self._tasks.add(task)
             self._child_tasks.add(task)
-            scope[1].add(task)
+            scope.tasks.add(task)
             task.add_done_callback(self._tasks.discard)
             task.add_done_callback(self._child_tasks.discard)
-            task.add_done_callback(scope[1].discard)
+            task.add_done_callback(scope.tasks.discard)
             return task
 
     async def _start_skill_call(
@@ -266,7 +288,11 @@ class SessionTreeSupervisor:
         async with self._lock:
             invocation_id = self._capabilities.get(capability)
             scope = self._scopes.get(scope_id)
-            if invocation_id is None or scope is None or scope[0] != invocation_id:
+            if (
+                invocation_id is None
+                or scope is None
+                or scope.invocation_id != invocation_id
+            ):
                 raise PermissionError("invalid broker capability")
             try:
                 descriptor, handler = self._brokered_skills[skill_capability]
@@ -281,15 +307,21 @@ class SessionTreeSupervisor:
             )
             task = asyncio.create_task(handler(arguments))
             self._tasks.add(task)
-            scope[1].add(task)
+            scope.tasks.add(task)
             task.add_done_callback(self._tasks.discard)
-            task.add_done_callback(scope[1].discard)
+            task.add_done_callback(scope.tasks.discard)
             return task
 
     async def _limit_result(self, parent: _Invocation, message: str) -> RLMResult:
         return RLMResult(answer=f"[{message}]", session_dir=parent.session.dir)
 
-    async def _run_child(self, parent_id: str, prompt: str) -> RLMResult:
+    async def _run_child(
+        self,
+        parent_id: str,
+        prompt: str,
+        parent_call_id: str | None,
+        segment_id: str | None,
+    ) -> RLMResult:
         parent = self._invocations[parent_id]
         child_context = parent.runtime_config.invocation.child()
         semaphore = self._semaphores[child_context.depth]
@@ -330,6 +362,10 @@ class SessionTreeSupervisor:
                     runtime_config=child.runtime_config,
                     supervisor=self,
                     invocation_id=child.id,
+                    parent_invocation_id=parent_id,
+                    parent_call_id=parent_call_id,
+                    lineage_session_id=self.session_id,
+                    segment_id=segment_id,
                 )
                 return await engine.run(prompt)
             finally:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -15,8 +15,14 @@ from acp.schema import EnvVariable, HttpHeader, HttpMcpServer, McpServerStdio
 import pytest
 
 from conftest import DummyClient, DummyMessage, DummyToolCall
-from rlm.acp import RLMACPAgent
+from rlm.acp import (
+    CAPABILITIES_METADATA_KEY,
+    RUNTIME_METADATA_KEY,
+    SESSION_METADATA_KEY,
+    RLMACPAgent,
+)
 from rlm.engine import RLMEngine
+from rlm.config import ExecutionPolicy, InvocationContext, ProviderConfig, RuntimeConfig
 from rlm.session import Session
 from rlm.types import RLMResult, TokenUsage
 
@@ -38,10 +44,14 @@ class _Engine:
         cwd: str,
         session,
         mcp_servers: dict[str, Any],
+        runtime_config=None,
+        lineage_session_id: str | None = None,
     ) -> None:
         self.cwd = cwd
         self.session = session
         self.mcp_servers = mcp_servers
+        self.runtime_config = runtime_config
+        self.lineage_session_id = lineage_session_id
         self.prompts: list[str] = []
         self.prompt_started = asyncio.Event()
         self.closed = False
@@ -66,6 +76,23 @@ class _Engine:
 
     async def aclose(self) -> None:
         self.close()
+
+    def execution_snapshot(self) -> dict[str, Any]:
+        return {
+            "session_id": self.lineage_session_id or self.session.dir.name,
+            "root_invocation_id": "root",
+            "model": "test-model",
+            "turns": len(self.prompts),
+            "usage": {
+                "prompt_tokens": len(self.prompts) * 3,
+                "completion_tokens": len(self.prompts) * 2,
+                "total_tokens": len(self.prompts) * 5,
+            },
+            "metrics": {},
+            "programmatic_tool_call_stats": {},
+            "supervisor": {"subagent_calls": 0, "active_subagent_calls": 0},
+            "limits": {},
+        }
 
 
 async def test_engine_prompt_preserves_conversation(session):
@@ -93,9 +120,59 @@ async def test_engine_prompt_preserves_conversation(session):
         {"role": "user", "content": "two"},
         {"role": "assistant", "content": "second"},
     ]
+    first_headers = client.calls[0]["extra_headers"]
+    second_headers = client.calls[1]["extra_headers"]
+    assert first_headers["X-RLM-Session-ID"] == session.dir.name
+    assert first_headers["X-RLM-Invocation-ID"] == second_headers["X-RLM-Invocation-ID"]
+    assert first_headers["X-RLM-Segment-ID"] != second_headers["X-RLM-Segment-ID"]
+    assert "X-RLM-Parent-Call-ID" not in first_headers
+    assert second_headers["X-RLM-Parent-Call-ID"] == first_headers["X-RLM-Call-ID"]
     meta = json.loads((Path(session.dir) / "meta.json").read_text())
     assert meta["turns"] == 2
     assert meta["answer_preview"] == "second"
+
+
+def test_execution_snapshot_after_finalize_is_numeric_and_credential_free(session):
+    config = RuntimeConfig(
+        model="test-model",
+        provider=ProviderConfig(
+            "http://interceptor",
+            "provider-secret",
+            headers={"X-Task": "header-secret"},
+        ),
+        invocation=InvocationContext(),
+        policy=ExecutionPolicy(max_depth=1),
+        kernel_env=(("TASK_TOKEN", "kernel-secret"),),
+        search_api_key="search-secret",
+    )
+    (session.dir / "programmatic_tool_calls.jsonl").write_text(
+        '{"tool":"demo","source":"python"}\n'
+    )
+    engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+    )
+    engine._has_result = True
+    engine._last_answer = "answer-secret"
+    engine.close()
+
+    snapshot = engine.execution_snapshot()
+
+    assert snapshot["programmatic_tool_call_stats"]["by_tool_python"] == {"demo": 1}
+    assert all(
+        isinstance(value, (int, float)) and not isinstance(value, bool)
+        for value in snapshot["metrics"].values()
+    )
+    serialized = json.dumps(snapshot)
+    for secret in (
+        "provider-secret",
+        "header-secret",
+        "kernel-secret",
+        "search-secret",
+        "answer-secret",
+    ):
+        assert secret not in serialized
 
 
 async def test_engine_prompt_preserves_ipython_kernel(session):
@@ -156,6 +233,56 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},
     ]
+    failed_headers = client.calls[0]["extra_headers"]
+    resumed_headers = client.calls[1]["extra_headers"]
+    assert failed_headers["X-RLM-Call-ID"] != resumed_headers["X-RLM-Call-ID"]
+    assert failed_headers["X-RLM-Segment-ID"] != resumed_headers["X-RLM-Segment-ID"]
+    assert "X-RLM-Parent-Call-ID" not in resumed_headers
+
+
+async def test_model_call_lineage_survives_retries_and_compaction(monkeypatch, session):
+    monkeypatch.setattr("rlm.client._RETRY_DELAYS", (0,))
+    client = DummyClient(
+        [
+            DummyMessage(tool_calls=[DummyToolCall("ipython", {"code": "print(1)"})]),
+            DummyMessage(content="summary"),
+            DummyMessage(content="done"),
+        ]
+    )
+    create = client.create
+    attempts = []
+
+    async def flaky_first_call(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            raise ConnectionResetError("retry")
+        return await create(**kwargs)
+
+    client.create = flaky_first_call
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        summarize_at_tokens=1,
+    )
+
+    try:
+        result = await engine.prompt("compact")
+    finally:
+        engine.close()
+
+    assert result.answer == "done"
+    assert attempts[0]["extra_headers"] == attempts[1]["extra_headers"]
+    turn, compaction, resumed = [call["extra_headers"] for call in client.calls]
+    assert {header["X-RLM-Segment-ID"] for header in (turn, compaction, resumed)} == {
+        turn["X-RLM-Segment-ID"]
+    }
+    assert [
+        turn["X-RLM-Call-Kind"],
+        compaction["X-RLM-Call-Kind"],
+        resumed["X-RLM-Call-Kind"],
+    ] == ["turn", "compaction", "turn"]
+    assert compaction["X-RLM-Parent-Call-ID"] == turn["X-RLM-Call-ID"]
+    assert resumed["X-RLM-Parent-Call-ID"] == compaction["X-RLM-Call-ID"]
 
 
 async def test_engine_failed_prompt_can_be_retried(session):
@@ -195,6 +322,11 @@ async def test_engine_failed_prompt_can_be_retried(session):
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},
     ]
+
+    failed_headers = client.calls[0]["extra_headers"]
+    resumed_headers = client.calls[1]["extra_headers"]
+    assert failed_headers["X-RLM-Call-ID"] != resumed_headers["X-RLM-Call-ID"]
+    assert "X-RLM-Parent-Call-ID" not in resumed_headers
 
 
 async def test_engine_cancel_masks_tool_cleanup_error(monkeypatch, session):
@@ -379,6 +511,9 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     initialized = await agent.initialize(PROTOCOL_VERSION)
     assert initialized.agent_capabilities.mcp_capabilities.http is True
     assert initialized.agent_capabilities.load_session is False
+    assert initialized.field_meta == {
+        CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}
+    }
 
     created = await agent.new_session(
         str(tmp_path),
@@ -419,9 +554,94 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     ]
     assert first.usage.total_tokens == 5
     assert second.stop_reason == "end_turn"
+    created_snapshot = created.field_meta[SESSION_METADATA_KEY]
+    first_snapshot = first.field_meta[SESSION_METADATA_KEY]
+    second_snapshot = second.field_meta[SESSION_METADATA_KEY]
+    assert created_snapshot["status"] == "created"
+    assert created_snapshot["sequence"] == 0
+    assert created_snapshot["final"] is False
+    assert first_snapshot["turns"] == 1
+    assert first_snapshot["status"] == "idle"
+    assert first_snapshot["sequence"] == 1
+    assert first_snapshot["last_stop_reason"] == "done"
+    assert second_snapshot["sequence"] == 2
+    assert created.model_dump(mode="json", by_alias=True)["_meta"] == created.field_meta
 
-    await agent.close_session(created.session_id)
+    closed = await agent.close_session(created.session_id)
+    closed_snapshot = closed.field_meta[SESSION_METADATA_KEY]
+    assert closed_snapshot["status"] == "closed"
+    assert closed_snapshot["sequence"] == 3
+    assert closed_snapshot["final"] is True
     assert engine.closed is True
+
+
+async def test_acp_runtime_metadata_keeps_credentials_out_of_responses(
+    monkeypatch, tmp_path
+):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setenv("RLM_API_KEY", "ambient-provider-secret")
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    metadata = {
+        RUNTIME_METADATA_KEY: {
+            "lineage_session_id": "trace-123",
+            "provider": {
+                "base_url": "http://interceptor",
+                "api_key": "session-provider-secret",
+                "headers": {"X-Task": "header-secret"},
+                "max_retries": 2,
+            },
+            "kernel_env": {"TASK_VISIBLE": "task-secret"},
+            "search_api_key": "search-secret",
+        }
+    }
+
+    created = await agent.new_session(str(tmp_path), **metadata)
+    engine = _Engine.instances[0]
+
+    assert engine.lineage_session_id == "trace-123"
+    assert engine.runtime_config.provider.base_url == "http://interceptor"
+    assert engine.runtime_config.provider.api_key == "session-provider-secret"
+    assert engine.runtime_config.provider.headers == {"X-Task": "header-secret"}
+    assert engine.runtime_config.kernel_env == (("TASK_VISIBLE", "task-secret"),)
+    assert engine.runtime_config.search_api_key == "search-secret"
+    response_json = created.model_dump_json(by_alias=True)
+    for secret in (
+        "session-provider-secret",
+        "header-secret",
+        "task-secret",
+        "search-secret",
+        "ambient-provider-secret",
+    ):
+        assert secret not in response_json
+    assert created.field_meta[SESSION_METADATA_KEY]["session_id"] == "trace-123"
+    await agent.close_session(created.session_id)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"lineage_session_id": "bad id"},
+        {"provider": {}},
+        {
+            "provider": {
+                "api_key": "secret",
+                "headers": {"x-rlm-call-id": "forged"},
+            }
+        },
+        {"kernel_env": {"RLM_API_KEY": "forbidden"}},
+        {"unknown": "value"},
+    ],
+)
+async def test_acp_rejects_invalid_runtime_metadata(monkeypatch, tmp_path, payload):
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    agent = RLMACPAgent()
+
+    with pytest.raises(RequestError):
+        await agent.new_session(str(tmp_path), **{RUNTIME_METADATA_KEY: payload})
+
+    assert agent._sessions == {}
 
 
 async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
@@ -439,13 +659,108 @@ async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
     await engine.prompt_started.wait()
     await agent.cancel(created.session_id)
 
-    assert (await pending).stop_reason == "cancelled"
+    cancelled = await pending
+    assert cancelled.stop_reason == "cancelled"
+    assert cancelled.field_meta[SESSION_METADATA_KEY]["status"] == "idle"
+    assert cancelled.field_meta[SESSION_METADATA_KEY]["last_stop_reason"] == "cancelled"
     assert engine.closed is False
     resumed = await agent.prompt(created.session_id, [text_block("after")])
     assert resumed.stop_reason == "end_turn"
     assert engine.prompts == ["wait", "after"]
 
     await agent.close_session(created.session_id)
+
+
+async def test_acp_transport_cancellation_propagates(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+    engine = _Engine.instances[0]
+
+    pending = asyncio.create_task(
+        agent.prompt(created.session_id, [text_block("wait")])
+    )
+    await engine.prompt_started.wait()
+    pending.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    resumed = await agent.prompt(created.session_id, [text_block("after")])
+    assert resumed.stop_reason == "end_turn"
+    await agent.close_session(created.session_id)
+
+
+async def test_acp_close_cancels_blocked_answer_delivery(monkeypatch, tmp_path):
+    class BlockingClient(_Client):
+        def __init__(self):
+            super().__init__()
+            self.started = asyncio.Event()
+
+        async def session_update(
+            self, session_id: str, update: Any, **kwargs: Any
+        ) -> None:
+            self.started.set()
+            await asyncio.Future()
+
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    client = BlockingClient()
+    agent = RLMACPAgent()
+    agent.on_connect(client)  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+
+    pending = asyncio.create_task(agent.prompt(created.session_id, [text_block("one")]))
+    await client.started.wait()
+    await agent.cancel(created.session_id)
+    await asyncio.sleep(0)
+    assert pending.done() is False
+    closed = await asyncio.wait_for(agent.close_session(created.session_id), timeout=1)
+
+    assert (await pending).stop_reason == "cancelled"
+    assert closed.field_meta[SESSION_METADATA_KEY]["status"] == "closed"
+    assert _Engine.instances[0].closed is True
+
+
+async def test_acp_cancelled_close_remains_owned_by_shutdown(monkeypatch, tmp_path):
+    class SlowCancelEngine(_Engine):
+        release = asyncio.Event()
+
+        async def prompt(self, prompt: str) -> RLMResult:
+            self.prompts.append(prompt)
+            self.prompt_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                await self.release.wait()
+                raise
+
+    SlowCancelEngine.instances.clear()
+    SlowCancelEngine.release = asyncio.Event()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", SlowCancelEngine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+    engine = SlowCancelEngine.instances[0]
+    pending = asyncio.create_task(
+        agent.prompt(created.session_id, [text_block("wait")])
+    )
+    await engine.prompt_started.wait()
+    closing = asyncio.create_task(agent.close_session(created.session_id))
+    await asyncio.sleep(0)
+    closing.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await closing
+
+    SlowCancelEngine.release.set()
+    assert (await pending).stop_reason == "cancelled"
+    await agent.shutdown()
+    assert engine.closed is True
+    assert agent._sessions == {}
 
 
 async def test_acp_failed_prompt_keeps_session_reusable(monkeypatch, tmp_path):
@@ -465,7 +780,25 @@ async def test_acp_failed_prompt_keeps_session_reusable(monkeypatch, tmp_path):
     assert engine.prompts == ["fail", "after"]
     assert engine.closed is False
 
-    await agent.close_session(created.session_id)
+    closed = await agent.close_session(created.session_id)
+    assert closed.field_meta[SESSION_METADATA_KEY]["last_stop_reason"] == "done"
+
+
+async def test_acp_close_reports_last_prompt_failure(monkeypatch, tmp_path):
+    _Engine.instances.clear()
+    monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))
+    monkeypatch.setattr("rlm.acp.RLMEngine", _Engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    created = await agent.new_session(str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="transient failure"):
+        await agent.prompt(created.session_id, [text_block("fail")])
+    closed = await agent.close_session(created.session_id)
+
+    snapshot = closed.field_meta[SESSION_METADATA_KEY]
+    assert snapshot["last_stop_reason"] == "error"
+    assert snapshot["final"] is True
 
 
 async def test_acp_close_rejects_queued_prompt(monkeypatch, tmp_path):
@@ -504,7 +837,14 @@ async def test_acp_stdio_lifecycle(tmp_path):
         _process,
     ):
         initialized = await connection.initialize(PROTOCOL_VERSION)
-        created = await connection.new_session(cwd=str(tmp_path), mcp_servers=[])
-        await connection.close_session(created.session_id)
+        created = await connection.new_session(
+            cwd=str(tmp_path),
+            mcp_servers=[],
+            **{RUNTIME_METADATA_KEY: {"lineage_session_id": "wire-session"}},
+        )
+        closed = await connection.close_session(created.session_id)
 
     assert initialized.agent_info.name == "rlm"
+    assert created.field_meta[SESSION_METADATA_KEY]["status"] == "created"
+    assert created.field_meta[SESSION_METADATA_KEY]["session_id"] == "wire-session"
+    assert closed.field_meta[SESSION_METADATA_KEY]["status"] == "closed"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -511,9 +511,14 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     initialized = await agent.initialize(PROTOCOL_VERSION)
     assert initialized.agent_capabilities.mcp_capabilities.http is True
     assert initialized.agent_capabilities.load_session is False
-    assert initialized.field_meta == {
-        CAPABILITIES_METADATA_KEY: {"session_snapshot_versions": [1]}
+    assert initialized.agent_capabilities.field_meta == {
+        CAPABILITIES_METADATA_KEY: {
+            "runtime_versions": [1],
+            "session_snapshot_versions": [1],
+            "lineage_versions": [1],
+        }
     }
+    assert initialized.field_meta is None
 
     created = await agent.new_session(
         str(tmp_path),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rlm.client import make_client
+from rlm.client import make_client, model_call_headers
 from rlm.config import (
     KERNEL_ENV_CONFIG_ENV,
     PI_INFERENCE_BASE_URL,
@@ -32,6 +32,38 @@ def test_provider_config_keeps_keys_paired_with_provider():
         {"X-Prime-Team-ID": "team"},
     )
     assert (openai.base_url, openai.api_key) == ("http://openai", "openai-secret")
+
+    with pytest.raises(ValueError, match="reserved names"):
+        ProviderConfig(
+            "http://interceptor",
+            "secret",
+            headers={"x-RlM-Parent-Invocation-ID": "forged"},
+        )
+
+
+def test_model_call_headers_encode_versioned_lineage():
+    headers = model_call_headers(
+        session_id="session",
+        invocation_id="child",
+        parent_invocation_id="parent",
+        segment_id="segment",
+        call_id="call",
+        parent_call_id="parent-call",
+        depth=2,
+        call_kind="compaction",
+    )
+
+    assert headers == {
+        "X-RLM-Lineage-Version": "1",
+        "X-RLM-Session-ID": "session",
+        "X-RLM-Invocation-ID": "child",
+        "X-RLM-Parent-Invocation-ID": "parent",
+        "X-RLM-Segment-ID": "segment",
+        "X-RLM-Call-ID": "call",
+        "X-RLM-Parent-Call-ID": "parent-call",
+        "X-RLM-Depth": "2",
+        "X-RLM-Call-Kind": "compaction",
+    }
 
 
 def test_runtime_config_resolves_environment_once():
@@ -102,6 +134,10 @@ def test_make_client_uses_explicit_invocation_depth(monkeypatch):
         "max_retries": 7,
         "default_headers": {"X-RLM-Depth": "3", "X-Test": "yes"},
     }
+
+    provider.headers["X-RLM-Call-ID"] = "forged-after-construction"
+    with pytest.raises(ValueError, match="reserved names"):
+        make_client(provider, InvocationContext(depth=3))
 
 
 def test_runtime_config_validates_recursive_limits():

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -99,6 +99,14 @@ class _SometimesBlockingEngine(_FastEngine):
             state.active -= 1
 
 
+class _CaptureLineageEngine(_FastEngine):
+    constructors = []
+
+    def __init__(self, *, runtime_config, session, **kwargs):
+        super().__init__(runtime_config=runtime_config, session=session)
+        self.constructors.append(kwargs)
+
+
 class _NestedEngine:
     def __init__(
         self,
@@ -145,6 +153,48 @@ def test_depth_capacities_reserve_every_level():
     assert depth_capacities(max_depth=4, limit=3, root_depth=2) == {3: 2, 4: 1}
     with pytest.raises(ValueError, match="every recursive depth"):
         depth_capacities(max_depth=3, limit=2)
+
+
+async def test_child_inherits_trusted_session_segment_and_parent_call(tmp_path):
+    _CaptureLineageEngine.constructors = []
+    session = Session(tmp_path / "root")
+    config = _config(max_depth=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(tmp_path),
+        engine_factory=_CaptureLineageEngine,
+        lineage_session_id="trace-session",
+    )
+    await supervisor.start()
+    root_engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+    )
+    assert root_engine.execution_snapshot()["session_id"] == "trace-session"
+    scope = await supervisor.open_scope(
+        supervisor.root_id,
+        parent_call_id="spawn-call",
+        segment_id="outer-segment",
+    )
+    endpoint = supervisor.endpoint_for(supervisor.root_id)
+    try:
+        child = await supervisor._start_child(
+            endpoint.capability, scope, "delegate", {}
+        )
+        await child
+    finally:
+        await supervisor.close_scope(scope)
+        await supervisor.aclose()
+        root_engine.close()
+
+    constructor = _CaptureLineageEngine.constructors[0]
+    assert constructor["parent_invocation_id"] == supervisor.root_id
+    assert constructor["parent_call_id"] == "spawn-call"
+    assert constructor["lineage_session_id"] == "trace-session"
+    assert constructor["segment_id"] == "outer-segment"
 
 
 async def test_parallel_children_respect_depth_capacity(tmp_path):
@@ -270,9 +320,10 @@ async def test_client_disconnect_cancels_child(tmp_path):
     _BlockingEngine.state = _EngineState()
     _BlockingEngine.started = asyncio.Event()
     session = Session(tmp_path / "root")
+    config = _config(max_depth=1)
     supervisor = SessionTreeSupervisor(
         root_session=session,
-        runtime_config=_config(max_depth=1),
+        runtime_config=config,
         cwd=str(tmp_path),
         engine_factory=_BlockingEngine,
     )
@@ -282,6 +333,26 @@ async def test_client_disconnect_cancels_child(tmp_path):
     broker.set_scope(scope)
     pending = asyncio.create_task(broker.run("wait"))
     await asyncio.wait_for(_BlockingEngine.started.wait(), timeout=2)
+    root_engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    active_snapshot = root_engine.execution_snapshot()
+    assert active_snapshot["supervisor"] == {
+        "subagent_calls": 1,
+        "active_subagent_calls": 1,
+    }
+    assert active_snapshot["limits"] == {
+        "max_depth": 1,
+        "max_concurrent_subagents": 4,
+        "max_subagent_calls": 16,
+        "max_tokens": None,
+        "summarize_at_tokens": None,
+        "max_compactions": None,
+    }
     pending.cancel()
     with pytest.raises(asyncio.CancelledError):
         await pending
@@ -292,12 +363,15 @@ async def test_client_disconnect_cancels_child(tmp_path):
     try:
         assert supervisor.active_calls == 0
         assert _BlockingEngine.state.cancelled == 1
+        assert (
+            root_engine.execution_snapshot()["supervisor"]["active_subagent_calls"] == 0
+        )
     finally:
         broker.set_scope(None)
         broker.configure(None)
         await supervisor.close_scope(scope)
         await supervisor.aclose()
-        session.close()
+        root_engine.close()
 
 
 async def test_shutdown_closes_incomplete_broker_connections(tmp_path):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -78,19 +78,19 @@ def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     repl = IPythonREPL(cwd=str(session.dir), session=session)
     repl.start()
     try:
-        result = repl.execute(
+        repl.execute(
             "import os; "
             "stdout_written = os.write(1, b'123\\n'); "
-            "stderr_written = os.write(2, b'kernel stderr\\n'); "
-            "print(stdout_written, stderr_written)"
+            "stderr_written = os.write(2, b'kernel stderr\\n')"
         )
+        result = repl.execute("print(stdout_written, stderr_written)")
     finally:
         repl.shutdown()
 
     captured = capfd.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    assert "4 14" in result
+    assert result.strip() == "4 14"
 
 
 def test_kernel_environment_is_explicit_and_reserves_supervisor_names(tmp_path):


### PR DESCRIPTION
## Summary

- expose cumulative, versioned ACP session snapshots with final training metrics on `session/close`
- accept provider credentials and explicit task environment through namespaced `session/new` metadata without echoing secrets
- advertise supported runtime, snapshot, and lineage protocol versions on `AgentCapabilities._meta`
- attach retry-stable session, invocation, segment, call, causal-parent, depth, and call-kind provenance to model requests
- preserve lineage across recursion and compaction while restoring the committed parent on failed or cancelled prompts
- harden ACP prompt/cancel/close/disconnect ownership so cleanup remains joinable and queued work cannot restart a closing session

## Validation

- `uv run ruff format src tests`
- `uv run ruff check src tests`
- `uv run pytest tests/ -q` — 149 passed
- Verifiers Prime VM training-contract E2E against `534fa28d1e297290f6024820ef5a89dbe60b1cc9` — passed
