### PR TITLE
fix: use stable conversation log path

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -367,8 +367,7 @@ class RLMEngine:
 
             self._active_tools = get_active_builtin_tools()
             self._active_tool_schemas = [tool.schema() for tool in self._active_tools]
-            messages_path = str(self.session.dir / "messages.jsonl")
-            system_prompt = self._load_system_prompt(messages_path, self._active_tools)
+            system_prompt = self._load_system_prompt(self._active_tools)
 
             self._messages = [
                 {"role": "system", "content": system_prompt},
@@ -681,16 +680,13 @@ class RLMEngine:
         self._branch_start_turn = turn + 1
         self._metrics.turns_since_last_compaction = 0
 
-    def _load_system_prompt(
-        self, messages_path: str, active_tools: list[BuiltinTool]
-    ) -> str:
+    def _load_system_prompt(self, active_tools: list[BuiltinTool]) -> str:
         if self.system_prompt_path:
             return Path(self.system_prompt_path).read_text()
         system_prompt = build_system_prompt(
             self.cwd,
             str(SKILLS_DIR) if SKILLS_DIR is not None else None,
             discover_skills(self.session.dir),
-            messages_path,
             allow_recursion=self.depth < self.max_depth,
             active_tools=active_tools,
             cli_skills=get_installed_skills(),

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -84,7 +84,6 @@ def build_system_prompt(
     cwd: str,
     skills_dir: str | None,
     installed_skills: list[str],
-    messages_path: str,
     *,
     allow_recursion: bool,
     active_tools: list[BuiltinTool],
@@ -103,7 +102,7 @@ def build_system_prompt(
         "When you are done, stop calling tools and state your final answer.",
         "",
         f"Working directory: {cwd}",
-        f"Conversation log: {messages_path}",
+        "Conversation log: $RLM_SESSION_DIR/messages.jsonl",
         f"Pre-installed Python packages: {', '.join(BASE_TOOLKIT)}.",
         "Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
     ]

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -28,7 +28,6 @@ def _prompt(
         "/repo",
         None,
         installed_skills or [],
-        "/repo/.rlm/messages.jsonl",
         allow_recursion=False,
         active_tools=active_tools,
         cli_skills=cli_skills,


### PR DESCRIPTION
## Summary

- reference the conversation log through the existing `RLM_SESSION_DIR` environment variable instead of embedding a per-session path
- keep the conversation-log instruction in its original system-prompt position while allowing the full system and initial user prompt to share prefix-cache blocks across sessions
- remove the concrete message path from prompt construction

## Tests

- `uv run pytest tests/`
- `uv run ruff check src/rlm/engine.py src/rlm/prompt.py tests/test_prompt.py`