### PR TITLE
feat: terse persona prompt, bash+ipython default tools, actionable compaction handoff

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -204,7 +204,7 @@ class RLMEngine:
         self.skills = (
             [s.strip() for s in raw_skills.split(",") if s.strip()]
             if raw_skills is not None
-            else ["edit"]
+            else ["bash", "edit"]
         )
 
         # Token budget

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -23,6 +23,7 @@ from rlm.mcp import (
 from rlm.prompt import build_system_prompt
 from rlm.session import Session
 from rlm.skills import enable_builtin_skills
+from rlm.tools.registry import preset_skills
 from rlm.tools import (
     SKILLS_DIR,
     BuiltinTool,
@@ -204,7 +205,7 @@ class RLMEngine:
         self.skills = (
             [s.strip() for s in raw_skills.split(",") if s.strip()]
             if raw_skills is not None
-            else ["bash", "edit"]
+            else list(preset_skills())
         )
 
         # Token budget

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -341,6 +341,8 @@ class RLMEngine:
             depth=self.depth,
             max_depth=self.max_depth,
             broker_endpoint=broker_endpoint,
+            exec_timeout=self.exec_timeout,
+            allow_git=self.allow_git,
         )
         try:
             self._repl.start()

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -45,16 +45,19 @@ logger = logging.getLogger(__name__)
 # the message is compacted in place of them.
 CHECKPOINT_COMPACTION_PROMPT = (
     "You are performing a CONTEXT CHECKPOINT COMPACTION. "
-    "Create a handoff summary for another LLM that will resume the task.\n"
+    "Create a handoff summary another LLM can ACT on immediately to resume the task.\n"
     "\n"
-    "Include:\n"
-    "- Current progress and key decisions made\n"
-    "- Important context, constraints, or user preferences\n"
-    "- What remains to be done (clear next steps)\n"
-    "- Any critical data, examples, or references needed to continue\n"
+    "It MUST contain, as fenced code blocks (not prose):\n"
+    "- The exact shell/test command(s) to reproduce and verify — copy-pasteable, "
+    "with the real path and test filter\n"
+    "- Any edit still to apply, as the concrete "
+    "`await edit(path=..., old_str=..., new_str=...)` call\n"
     "\n"
-    "Be concise, structured, and focused on helping the next LLM "
-    "seamlessly continue the work."
+    "Then:\n"
+    "- A NUMBERED list of remaining next steps\n"
+    "- Current progress, key decisions, and constraints\n"
+    "\n"
+    "Be concise and concrete: prefer runnable commands over descriptions."
 )
 
 # Appended to the checkpoint prompt when the IPython REPL is active.
@@ -200,8 +203,8 @@ class RLMEngine:
         raw_skills = os.environ.get("RLM_SKILLS")
         self.skills = (
             [s.strip() for s in raw_skills.split(",") if s.strip()]
-            if raw_skills
-            else []
+            if raw_skills is not None
+            else ["edit"]
         )
 
         # Token budget

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -37,33 +37,10 @@ GIT_HISTORY_GUARD_PROMPT = (
     "be refused."
 )
 IPYTHON_CONTROL_PROMPT = (
-    "IPython is the agent's long-lived notebook: a persistent control "
-    "environment for reasoning, context management, state, tool orchestration, "
-    "and recursive subcalls. Use it to keep intermediate variables, inspect "
-    "and transform outputs, write small helper functions, and preserve useful "
-    "state across turns or compaction.\n\n"
-    "Do not assume IPython is the native runtime of the external thing being "
-    "investigated. A repository, package, service, dataset, paper, website, "
-    "benchmark, or API may have its own environment and normal interface. "
-    "Evaluate external systems through their own interface, then use IPython "
-    "to coordinate the process and analyze what comes back.\n\n"
-    "When running shell commands from IPython, use `%%bash` cells. If you use "
-    "`%%bash`, it must be the first line of the code cell: no comments, "
-    "spaces, blank lines, imports, or Python statements before it. Avoid "
-    "`!cmd` shell escapes for project commands so shell behavior is explicit "
-    "and multi-line commands share one shell context.\n\n"
-    "Important: do not install dependencies into the IPython kernel just to "
-    "make an external project import or run there. If a project import, test, "
-    "script, CLI, or dependency check is needed, run it through that project's "
-    "own environment and normal command interface. For example, in a Python "
-    "repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, "
-    "or the active project interpreter from the repo root. Treat failures from "
-    "that native environment as the relevant result."
-    "\n\n"
-    "Use Python for reading, searching, and editing files — it gives you "
-    "reusable variables you can slice, filter, and act on without re-reading. "
-    "Always assign read/search results to named variables so you can revisit "
-    "them later."
+    "Run shell commands with `%%bash` as the very first line of a code cell "
+    "(no comments, imports, or statements before it). Run project code through "
+    "the project's own environment (e.g. `uv run ...`, `.venv/bin/python ...`), "
+    "not the kernel's."
 )
 EDIT_SKILL_PROMPT = (
     "For targeted existing-file edits, prefer the pre-imported async `edit` "
@@ -97,8 +74,7 @@ def build_system_prompt(
     every request.
     """
     parts: list[str] = [
-        "You are a general purpose agent that uses code to solve tasks.",
-        "You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.",
+        "You are a coding agent. Your tool is a persistent IPython REPL: variables, imports, and function definitions persist across calls.",
         "When you are done, stop calling tools and state your final answer.",
         "",
         f"Working directory: {cwd}",

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -37,8 +37,9 @@ GIT_HISTORY_GUARD_PROMPT = (
     "be refused."
 )
 PROJECT_ENV_PROMPT = (
-    "Run project code through the project's own environment "
-    "(e.g. `uv run ...`, `.venv/bin/python ...`), not the kernel's."
+    "The ipython kernel is an isolated venv without the project's packages — "
+    "never import project modules there. Everything that executes project code "
+    "(tests, repros, imports) goes through bash with the project's interpreter."
 )
 IPYTHON_CONTROL_PROMPT = (
     "Run shell commands with `%%bash` as the very first line of a code cell "

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -124,6 +124,13 @@ def build_system_prompt(
                 "it returns the output as a string, useful when mixing shell and Python "
                 "in one cell or avoiding shell quoting."
             )
+        elif "bash" in installed_skills:
+            skill_lines.append(
+                "Run shell with `out = await bash('''command here''')` — always "
+                "triple-quote the command so shell quotes and multi-line scripts never "
+                "need escaping. It returns the output as a string; no need for "
+                "`subprocess` or `%%bash`. Chain related commands with && in one call."
+            )
         if "edit" in installed_skills:
             skill_lines.append(EDIT_SKILL_PROMPT)
         if "search" in installed_skills:
@@ -140,7 +147,7 @@ def build_system_prompt(
             ]
         )
 
-    if has_ipython and not has_bash:
+    if has_ipython and not has_bash and "bash" not in (installed_skills or []):
         parts.extend(["", IPYTHON_CONTROL_PROMPT])
     elif has_ipython:
         parts.extend(["", PROJECT_ENV_PROMPT])

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -45,11 +45,9 @@ IPYTHON_CONTROL_PROMPT = (
     "(no comments, imports, or statements before it). " + PROJECT_ENV_PROMPT
 )
 EDIT_SKILL_PROMPT = (
-    "For targeted existing-file edits, prefer the pre-imported async `edit` "
-    "skill from IPython: `old = '''...'''; new = '''...'''; await "
-    'edit(path="pkg/file.py", old_str=old, new_str=new)`. Use exact '
-    "old/new strings; if the text contains triple double quotes, use triple "
-    "single-quoted variables or build `old`/`new` from inspected file slices."
+    "Inside ipython you can also edit files with the pre-imported async `edit` "
+    'skill: `await edit(path="pkg/file.py", old_str=..., new_str=...)` — handy '
+    "for multiline or quote-heavy replacements built from Python strings."
 )
 SEARCH_SKILL_PROMPT = (
     "For web search, use the pre-imported async `search` skill from IPython: "
@@ -76,10 +74,16 @@ def build_system_prompt(
     every request.
     """
     has_bash = _has_tool(active_tools, "bash")
+    has_edit = _has_tool(active_tools, "edit")
     has_ipython = _has_tool(active_tools, "ipython")
     role = "You are a coding agent."
     if has_bash:
         role += " You have access to a bash tool for running shell commands."
+    if has_edit:
+        role += (
+            " You also have an edit tool for single-occurrence string "
+            "replacement in a file."
+        )
     if has_ipython:
         role += (
             " You also have an ipython tool: a persistent Python REPL "
@@ -112,6 +116,12 @@ def build_system_prompt(
             skill_lines.append(
                 f"Skills with shell commands: {commands}. "
                 "Discover CLI usage with `<skill> --help`."
+            )
+        if "bash" in installed_skills and _has_tool(active_tools, "bash"):
+            skill_lines.append(
+                "Inside ipython you can also run shell with `await bash(command=...)` — "
+                "it returns the output as a string, useful when mixing shell and Python "
+                "in one cell or avoiding shell quoting."
             )
         if "edit" in installed_skills:
             skill_lines.append(EDIT_SKILL_PROMPT)

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -36,11 +36,13 @@ GIT_HISTORY_GUARD_PROMPT = (
     "`--glob`, `--alternate-refs`, `--reflog`, `--walk-reflogs`, or `-g` will "
     "be refused."
 )
+PROJECT_ENV_PROMPT = (
+    "Run project code through the project's own environment "
+    "(e.g. `uv run ...`, `.venv/bin/python ...`), not the kernel's."
+)
 IPYTHON_CONTROL_PROMPT = (
     "Run shell commands with `%%bash` as the very first line of a code cell "
-    "(no comments, imports, or statements before it). Run project code through "
-    "the project's own environment (e.g. `uv run ...`, `.venv/bin/python ...`), "
-    "not the kernel's."
+    "(no comments, imports, or statements before it). " + PROJECT_ENV_PROMPT
 )
 EDIT_SKILL_PROMPT = (
     "For targeted existing-file edits, prefer the pre-imported async `edit` "
@@ -73,8 +75,18 @@ def build_system_prompt(
     per-tool schemas, so redundant tool guidance here just inflates
     every request.
     """
+    has_bash = _has_tool(active_tools, "bash")
+    has_ipython = _has_tool(active_tools, "ipython")
+    role = "You are a coding agent."
+    if has_bash:
+        role += " You have access to a bash tool for running shell commands."
+    if has_ipython:
+        role += (
+            " You also have an ipython tool: a persistent Python REPL "
+            "(variables, imports, and function definitions persist across calls)."
+        )
     parts: list[str] = [
-        "You are a coding agent. Your tool is a persistent IPython REPL: variables, imports, and function definitions persist across calls.",
+        role,
         "When you are done, stop calling tools and state your final answer.",
         "",
         f"Working directory: {cwd}",
@@ -117,8 +129,10 @@ def build_system_prompt(
             ]
         )
 
-    if _has_tool(active_tools, "ipython"):
+    if has_ipython and not has_bash:
         parts.extend(["", IPYTHON_CONTROL_PROMPT])
+    elif has_ipython:
+        parts.extend(["", PROJECT_ENV_PROMPT])
 
     if _should_include_git_history_guard(active_tools):
         parts.extend(["", GIT_HISTORY_GUARD_PROMPT])

--- a/src/rlm/skills/__init__.py
+++ b/src/rlm/skills/__init__.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 # Built-in skill name -> module its ``run`` is re-exported from.
 _BUILTIN_SKILLS: dict[str, str] = {
+    "bash": "rlm.skills.bash",
     "edit": "rlm.skills.edit",
     "search": "rlm.skills.search",
 }

--- a/src/rlm/skills/bash.py
+++ b/src/rlm/skills/bash.py
@@ -1,0 +1,41 @@
+"""Built-in ``bash`` skill — run a shell command from the REPL.
+
+Enabled via ``RLM_SKILLS``; pre-imported into the IPython kernel so the agent calls
+``await bash(command="...")`` (or ``await bash("...")``). One command per call, fresh
+subshell, like a plain bash-agent tool but surfaced as a skill.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def run(command: str, timeout: int = 120) -> str:
+    """Run a shell command and return its combined output.
+
+    Args:
+        command: The shell command to run.
+        timeout: Seconds before the command is killed.
+
+    Returns:
+        stdout and stderr of the command (with the exit code when nonzero).
+    """
+    proc = await asyncio.create_subprocess_shell(
+        command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return f"Error: command timed out after {timeout}s"
+    out = out_b.decode(errors="replace")
+    err = err_b.decode(errors="replace")
+    result = out + (("\n" + err) if err else "")
+    if proc.returncode != 0:
+        result += f"\n[exit code {proc.returncode}]"
+    result = result.strip() or "(no output)"
+    if len(result) > 30_000:
+        result = result[:30_000] + f"\n... [truncated {len(result) - 30_000} chars]"
+    return result

--- a/src/rlm/skills/bash.py
+++ b/src/rlm/skills/bash.py
@@ -20,7 +20,9 @@ async def run(command: str, timeout: int = 120) -> str:
     Returns:
         stdout and stderr of the command (with the exit code when nonzero).
     """
-    proc = await asyncio.create_subprocess_shell(
+    proc = await asyncio.create_subprocess_exec(
+        "bash",
+        "-c",
         command,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/src/rlm/skills/bash.py
+++ b/src/rlm/skills/bash.py
@@ -1,43 +1,33 @@
 """Built-in ``bash`` skill — run a shell command from the REPL.
 
 Enabled via ``RLM_SKILLS``; pre-imported into the IPython kernel so the agent calls
-``await bash(command="...")`` (or ``await bash("...")``). One command per call, fresh
-subshell, like a plain bash-agent tool but surfaced as a skill.
+``await bash(command="...")`` (or ``await bash("...")``). Identical semantics to the
+``bash`` tool — same ``bash -c`` execution, git-history guard, and output contract —
+via the shared runner in ``rlm.tools.bash``.
 """
 
 from __future__ import annotations
 
 import asyncio
+import os
+
+from rlm.tools.bash import run_bash
 
 
-async def run(command: str, timeout: int = 120) -> str:
+def _default_timeout() -> int:
+    raw = os.environ.get("RLM_EXEC_TIMEOUT", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else 300
+
+
+async def run(command: str, timeout: int | None = None) -> str:
     """Run a shell command and return its combined output.
 
     Args:
-        command: The shell command to run.
-        timeout: Seconds before the command is killed.
+        command: The shell command to run (executed with ``bash -c``).
+        timeout: Seconds before the command is killed (default: the harness
+            exec timeout via ``RLM_EXEC_TIMEOUT``, else 300).
 
     Returns:
         stdout and stderr of the command (with the exit code when nonzero).
     """
-    proc = await asyncio.create_subprocess_exec(
-        "bash",
-        "-c",
-        command,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    try:
-        out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
-        proc.kill()
-        return f"Error: command timed out after {timeout}s"
-    out = out_b.decode(errors="replace")
-    err = err_b.decode(errors="replace")
-    result = out + (("\n" + err) if err else "")
-    if proc.returncode != 0:
-        result += f"\n[exit code {proc.returncode}]"
-    result = result.strip() or "(no output)"
-    if len(result) > 30_000:
-        result = result[:30_000] + f"\n... [truncated {len(result) - 30_000} chars]"
-    return result
+    return await asyncio.to_thread(run_bash, command, timeout or _default_timeout())

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -6,6 +6,7 @@ Enabled by default alongside ipython; override the tool set with ``RLM_BUILTIN_T
 
 from __future__ import annotations
 
+import os
 import subprocess
 from typing import Any
 
@@ -54,11 +55,16 @@ EDIT_SCHEMA = {
 }
 
 
-def run_bash(command: str, timeout: int, cwd: str | None = None) -> str:
+def run_bash(
+    command: str,
+    timeout: int,
+    cwd: str | None = None,
+    allow_git: bool | None = None,
+) -> str:
     """Guarded ``bash -c`` execution shared by the bash tool and the bash skill."""
     if not isinstance(command, str) or not command.strip():
         return "Error: empty command"
-    blocked = find_blocked_command(command)
+    blocked = find_blocked_command(command, allow_git=allow_git)
     if blocked:
         return refusal(blocked)
     try:
@@ -88,7 +94,10 @@ class BashTool:
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
         return ToolOutcome(
             content=run_bash(
-                args.get("command", ""), context.exec_timeout, cwd=context.cwd
+                args.get("command", ""),
+                context.exec_timeout,
+                cwd=context.cwd,
+                allow_git=context.allow_git,
             )
         )
 
@@ -105,6 +114,8 @@ class EditTool:
         path, old, new = args.get("path"), args.get("old_str"), args.get("new_str")
         if not path or old is None or new is None:
             return ToolOutcome(content="Error: path, old_str and new_str are required")
+        if context.cwd and not os.path.isabs(path):
+            path = os.path.join(context.cwd, path)
         try:
             text = open(path, encoding="utf-8").read()
         except OSError as e:

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -30,6 +30,29 @@ BASH_SCHEMA = {
     },
 }
 
+EDIT_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "edit",
+        "description": (
+            "Replace a string in a file. old_str must occur exactly once in the file; "
+            "the file is rewritten with old_str replaced by new_str."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path of the file to edit."},
+                "old_str": {
+                    "type": "string",
+                    "description": "Exact string to replace (must be unique).",
+                },
+                "new_str": {"type": "string", "description": "Replacement string."},
+            },
+            "required": ["path", "old_str", "new_str"],
+        },
+    },
+}
+
 _OUTPUT_LIMIT = 30_000
 
 
@@ -70,3 +93,30 @@ class BashTool:
             return ToolOutcome(
                 content=f"Error: command timed out after {context.exec_timeout}s"
             )
+
+
+class EditTool:
+    """Single-occurrence string replacement, mirroring the edit skill semantics."""
+
+    name = "edit"
+
+    def schema(self) -> dict[str, Any]:
+        return EDIT_SCHEMA
+
+    def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
+        path, old, new = args.get("path"), args.get("old_str"), args.get("new_str")
+        if not path or old is None or new is None:
+            return ToolOutcome(content="Error: path, old_str and new_str are required")
+        try:
+            text = open(path, encoding="utf-8").read()
+        except OSError as e:
+            return ToolOutcome(content=f"Error: cannot read {path}: {e}")
+        count = text.count(old)
+        if count == 0:
+            return ToolOutcome(content=f"Error: old_str not found in {path}")
+        if count > 1:
+            return ToolOutcome(
+                content=f"Error: old_str occurs {count} times in {path}; must be unique"
+            )
+        open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+        return ToolOutcome(content=f"Edited {path} (1 replacement).")

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -53,14 +53,6 @@ EDIT_SCHEMA = {
     },
 }
 
-_OUTPUT_LIMIT = 30_000
-
-
-def _clip(text: str) -> str:
-    if len(text) <= _OUTPUT_LIMIT:
-        return text
-    return text[:_OUTPUT_LIMIT] + f"\n... [truncated {len(text) - _OUTPUT_LIMIT} chars]"
-
 
 def run_bash(command: str, timeout: int, cwd: str | None = None) -> str:
     """Guarded ``bash -c`` execution shared by the bash tool and the bash skill."""
@@ -82,7 +74,7 @@ def run_bash(command: str, timeout: int, cwd: str | None = None) -> str:
     out = proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
     if proc.returncode != 0:
         out += f"\n[exit code {proc.returncode}]"
-    return _clip(out.strip() or "(no output)")
+    return out.strip() or "(no output)"
 
 
 class BashTool:

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -1,0 +1,67 @@
+"""Native ``bash`` builtin tool.
+
+Runs one shell command per call in a fresh subshell, like a plain bash agent.
+Enabled by default alongside ipython; override the tool set with ``RLM_BUILTIN_TOOLS``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+from rlm.tools.base import ToolContext, ToolOutcome
+from rlm.tools.git_block import find_blocked_command, refusal
+
+BASH_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "bash",
+        "description": "Run a shell command and return its output (stdout and stderr).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string", "description": "The shell command to run."},
+            },
+            "required": ["command"],
+        },
+    },
+}
+
+_OUTPUT_LIMIT = 30_000
+
+
+def _clip(text: str) -> str:
+    if len(text) <= _OUTPUT_LIMIT:
+        return text
+    return text[:_OUTPUT_LIMIT] + f"\n... [truncated {len(text) - _OUTPUT_LIMIT} chars]"
+
+
+class BashTool:
+    """One shell command per call, fresh subshell, cwd-anchored."""
+
+    name = "bash"
+
+    def schema(self) -> dict[str, Any]:
+        return BASH_SCHEMA
+
+    def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
+        command = args.get("command", "")
+        if not isinstance(command, str) or not command.strip():
+            return ToolOutcome(content="Error: empty command")
+        blocked = find_blocked_command(command)
+        if blocked:
+            return ToolOutcome(content=refusal(blocked))
+        try:
+            proc = subprocess.run(
+                ["bash", "-c", command],
+                capture_output=True,
+                text=True,
+                timeout=context.exec_timeout,
+                cwd=context.cwd or None,
+            )
+            out = proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
+            if proc.returncode != 0:
+                out += f"\n[exit code {proc.returncode}]"
+            return ToolOutcome(content=_clip(out.strip() or "(no output)"))
+        except subprocess.TimeoutExpired:
+            return ToolOutcome(content=f"Error: command timed out after {context.exec_timeout}s")

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -62,6 +62,29 @@ def _clip(text: str) -> str:
     return text[:_OUTPUT_LIMIT] + f"\n... [truncated {len(text) - _OUTPUT_LIMIT} chars]"
 
 
+def run_bash(command: str, timeout: int, cwd: str | None = None) -> str:
+    """Guarded ``bash -c`` execution shared by the bash tool and the bash skill."""
+    if not isinstance(command, str) or not command.strip():
+        return "Error: empty command"
+    blocked = find_blocked_command(command)
+    if blocked:
+        return refusal(blocked)
+    try:
+        proc = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd or None,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Error: command timed out after {timeout}s"
+    out = proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
+    if proc.returncode != 0:
+        out += f"\n[exit code {proc.returncode}]"
+    return _clip(out.strip() or "(no output)")
+
+
 class BashTool:
     """One shell command per call, fresh subshell, cwd-anchored."""
 
@@ -71,28 +94,11 @@ class BashTool:
         return BASH_SCHEMA
 
     def execute(self, args: dict[str, Any], context: ToolContext) -> ToolOutcome:
-        command = args.get("command", "")
-        if not isinstance(command, str) or not command.strip():
-            return ToolOutcome(content="Error: empty command")
-        blocked = find_blocked_command(command)
-        if blocked:
-            return ToolOutcome(content=refusal(blocked))
-        try:
-            proc = subprocess.run(
-                ["bash", "-c", command],
-                capture_output=True,
-                text=True,
-                timeout=context.exec_timeout,
-                cwd=context.cwd or None,
+        return ToolOutcome(
+            content=run_bash(
+                args.get("command", ""), context.exec_timeout, cwd=context.cwd
             )
-            out = proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
-            if proc.returncode != 0:
-                out += f"\n[exit code {proc.returncode}]"
-            return ToolOutcome(content=_clip(out.strip() or "(no output)"))
-        except subprocess.TimeoutExpired:
-            return ToolOutcome(
-                content=f"Error: command timed out after {context.exec_timeout}s"
-            )
+        )
 
 
 class EditTool:

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -20,7 +20,10 @@ BASH_SCHEMA = {
         "parameters": {
             "type": "object",
             "properties": {
-                "command": {"type": "string", "description": "The shell command to run."},
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to run.",
+                },
             },
             "required": ["command"],
         },
@@ -64,4 +67,6 @@ class BashTool:
                 out += f"\n[exit code {proc.returncode}]"
             return ToolOutcome(content=_clip(out.strip() or "(no output)"))
         except subprocess.TimeoutExpired:
-            return ToolOutcome(content=f"Error: command timed out after {context.exec_timeout}s")
+            return ToolOutcome(
+                content=f"Error: command timed out after {context.exec_timeout}s"
+            )

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -180,6 +180,8 @@ class IPythonREPL:
         depth: int | None = None,
         max_depth: int | None = None,
         broker_endpoint: BrokerEndpoint | None = None,
+        exec_timeout: int | None = None,
+        allow_git: bool | None = None,
     ):
         self.cwd = cwd
         self.session = session
@@ -187,6 +189,8 @@ class IPythonREPL:
         self.depth = depth
         self.max_depth = max_depth
         self.broker_endpoint = broker_endpoint
+        self.exec_timeout = exec_timeout
+        self.allow_git = allow_git
         self._km = None
         self._kc = None
         self._ipc_dir = None
@@ -256,6 +260,10 @@ if {bool(session_dir)!r}:
 os.environ['RLM_SESSION_DIR'] = {session_dir!r} or ''
 os.environ['RLM_DEPTH'] = str({depth!r} + 1)
 os.environ['NO_COLOR'] = '1'
+if {self.exec_timeout!r} is not None:
+    os.environ['RLM_EXEC_TIMEOUT'] = str({self.exec_timeout!r})
+if {self.allow_git!r} is not None:
+    os.environ['RLM_ALLOW_GIT'] = '1' if {self.allow_git!r} else '0'
 
 import nest_asyncio
 nest_asyncio.apply()

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -1,9 +1,9 @@
 """Builtin tool registry.
 
-rlm's default tool set is a native ``bash`` tool plus the persistent IPython REPL:
-plain shell work goes through ``bash``; Python logic, skills (e.g. ``edit``), and
-state live in ``ipython``. ``RLM_BUILTIN_TOOLS`` (comma-separated: ``bash``,
-``ipython``) overrides the set, e.g. ``ipython`` for a REPL-only agent.
+rlm's default tool set is native ``bash`` and ``edit`` tools plus the persistent
+IPython REPL. Shell and edits are ALSO available as REPL skills (``await bash(...)``,
+``await edit(...)``) for mixing with Python in one cell. ``RLM_BUILTIN_TOOLS``
+(comma-separated) overrides the set, e.g. ``ipython`` for a REPL-only agent.
 """
 
 from __future__ import annotations
@@ -11,16 +11,17 @@ from __future__ import annotations
 import os
 
 from rlm.tools.base import BuiltinTool
-from rlm.tools.bash import BashTool
+from rlm.tools.bash import BashTool, EditTool
 from rlm.tools.ipython import IpythonTool
 
 # All registered tools by name. Tests (and extensions) may add entries; names
 # listed in RLM_BUILTIN_TOOLS or the default set become active.
 _TOOLS_BY_NAME: dict[str, BuiltinTool] = {
     "bash": BashTool(),
+    "edit": EditTool(),
     "ipython": IpythonTool(),
 }
-_DEFAULT = ("bash", "ipython")
+_DEFAULT = ("bash", "edit", "ipython")
 
 
 def _selected() -> tuple[BuiltinTool, ...]:

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -24,6 +24,32 @@ _TOOLS_BY_NAME: dict[str, BuiltinTool] = {
 _DEFAULT = ("bash", "edit", "ipython")
 
 
+_TOOLING_PRESETS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    # preset -> (builtin tools, builtin skills)
+    "dual": (("bash", "edit", "ipython"), ("bash", "edit")),
+    "tools": (("bash", "edit", "ipython"), ()),
+    "skills": (("ipython",), ("bash", "edit")),
+}
+
+
+def tooling_preset() -> str:
+    """The RLM_TOOLING preset name: dual (default), tools, or skills."""
+    preset = os.environ.get("RLM_TOOLING", "dual").strip() or "dual"
+    if preset not in _TOOLING_PRESETS:
+        raise ValueError(
+            f"RLM_TOOLING must be one of {sorted(_TOOLING_PRESETS)}, got {preset!r}"
+        )
+    return preset
+
+
+def preset_tools() -> tuple[str, ...]:
+    return _TOOLING_PRESETS[tooling_preset()][0]
+
+
+def preset_skills() -> tuple[str, ...]:
+    return _TOOLING_PRESETS[tooling_preset()][1]
+
+
 def _selected() -> tuple[BuiltinTool, ...]:
     spec = os.environ.get("RLM_BUILTIN_TOOLS", "").strip()
     if spec:
@@ -35,9 +61,11 @@ def _selected() -> tuple[BuiltinTool, ...]:
                 f"available: {sorted(_TOOLS_BY_NAME)}"
             )
         return tuple(_TOOLS_BY_NAME[n] for n in names)
-    # default: the standard set plus any extra registered tools (fixtures/extensions)
+    # default: the RLM_TOOLING preset's tools plus any extra registered tools
+    # (fixtures/extensions).
+    preset = preset_tools()
     extras = [n for n in _TOOLS_BY_NAME if n not in _DEFAULT]
-    return tuple(_TOOLS_BY_NAME[n] for n in [*_DEFAULT, *extras])
+    return tuple(_TOOLS_BY_NAME[n] for n in [*preset, *extras])
 
 
 def get_active_builtin_tools() -> list[BuiltinTool]:

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -1,29 +1,57 @@
 """Builtin tool registry.
 
-rlm exposes a single builtin tool: the persistent IPython REPL. Shell work and file edits
-go through it (``!cmd`` / ``%%bash``, Python, or the built-in ``edit`` skill). The tool set
-is not configurable.
+rlm's default tool set is a native ``bash`` tool plus the persistent IPython REPL:
+plain shell work goes through ``bash``; Python logic, skills (e.g. ``edit``), and
+state live in ``ipython``. ``RLM_BUILTIN_TOOLS`` (comma-separated: ``bash``,
+``ipython``) overrides the set, e.g. ``ipython`` for a REPL-only agent.
 """
 
 from __future__ import annotations
 
+import os
+
 from rlm.tools.base import BuiltinTool
+from rlm.tools.bash import BashTool
 from rlm.tools.ipython import IpythonTool
 
-_BUILTIN_TOOLS: tuple[BuiltinTool, ...] = (IpythonTool(),)
-_TOOLS_BY_NAME: dict[str, BuiltinTool] = {tool.name: tool for tool in _BUILTIN_TOOLS}
+# All registered tools by name. Tests (and extensions) may add entries; names
+# listed in RLM_BUILTIN_TOOLS or the default set become active.
+_TOOLS_BY_NAME: dict[str, BuiltinTool] = {
+    "bash": BashTool(),
+    "ipython": IpythonTool(),
+}
+_DEFAULT = ("bash", "ipython")
+
+
+def _selected() -> tuple[BuiltinTool, ...]:
+    spec = os.environ.get("RLM_BUILTIN_TOOLS", "").strip()
+    if spec:
+        names = [n.strip() for n in spec.split(",") if n.strip()]
+        unknown = [n for n in names if n not in _TOOLS_BY_NAME]
+        if unknown:
+            raise ValueError(
+                f"RLM_BUILTIN_TOOLS: unknown tool(s) {unknown}; "
+                f"available: {sorted(_TOOLS_BY_NAME)}"
+            )
+        return tuple(_TOOLS_BY_NAME[n] for n in names)
+    # default: the standard set plus any extra registered tools (fixtures/extensions)
+    extras = [n for n in _TOOLS_BY_NAME if n not in _DEFAULT]
+    return tuple(_TOOLS_BY_NAME[n] for n in [*_DEFAULT, *extras])
 
 
 def get_active_builtin_tools() -> list[BuiltinTool]:
-    """Return the active builtin-tool instances (always just ipython)."""
-    return list(_BUILTIN_TOOLS)
+    """Return the active builtin-tool instances (default: bash + ipython)."""
+    return list(_selected())
 
 
 def get_active_tools() -> list[dict]:
     """Return OpenAI tool schemas for the active builtins."""
-    return [tool.schema() for tool in _BUILTIN_TOOLS]
+    return [tool.schema() for tool in _selected()]
 
 
 def get_builtin_tool(name: str) -> BuiltinTool | None:
     """Look up a builtin tool handler by name (None if unknown)."""
-    return _TOOLS_BY_NAME.get(name)
+    for tool in _selected():
+        if tool.name == name:
+            return tool
+    return None

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from rlm.skills import available_builtin_skills, enable_builtin_skills
+from rlm.skills.bash import run as bash
 from rlm.skills.edit import run as edit
 from rlm.skills.search import format_results
 from rlm.skills.search import run as run_search
@@ -68,3 +69,14 @@ def test_search_format_results():
 
 def test_search_format_results_empty():
     assert format_results([], "q") == "No results returned for query: q"
+
+
+async def test_bash_skill_enforces_git_history_guard():
+    out = await bash("git log --all --oneline")
+    assert "refused" in out.lower() or "--all" in out
+    assert "commit" not in out.splitlines()[0].lower()
+
+
+async def test_bash_skill_timeout_reports_error():
+    out = await bash("sleep 5", timeout=1)
+    assert "timed out" in out

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -61,11 +61,8 @@ def test_ipython_control_prompt_included_for_ipython_tool():
     prompt = _prompt([_Tool("ipython")])
 
     assert IPYTHON_CONTROL_PROMPT in prompt
-    assert "long-lived notebook" in prompt
-    assert "native runtime" in prompt
-    assert "use `%%bash` cells" in prompt
-    assert "must be the first line of the code cell" in prompt
-    assert "do not install dependencies into the IPython kernel" in prompt
+    assert "`%%bash` as the very first line" in prompt
+    assert "project's own environment" in prompt
 
 
 def test_ipython_control_prompt_omitted_without_ipython_tool():

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -73,8 +73,7 @@ def test_edit_skill_prompt_included_only_when_edit_is_installed():
     prompt = _prompt([_Tool("ipython")], installed_skills=["edit"])
 
     assert EDIT_SKILL_PROMPT in prompt
-    assert 'await edit(path="pkg/file.py", old_str=old, new_str=new)' in prompt
-    assert "triple double quotes" in prompt
+    assert 'await edit(path="pkg/file.py", old_str=..., new_str=...)' in prompt
     assert EDIT_SKILL_PROMPT not in _prompt(
         [_Tool("ipython")], installed_skills=["search_docs"]
     )

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -62,7 +62,7 @@ def test_ipython_control_prompt_included_for_ipython_tool():
 
     assert IPYTHON_CONTROL_PROMPT in prompt
     assert "`%%bash` as the very first line" in prompt
-    assert "project's own environment" in prompt
+    assert "project's interpreter" in prompt
 
 
 def test_ipython_control_prompt_omitted_without_ipython_tool():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -195,3 +195,20 @@ def test_bash_tool_honors_explicit_allow_git(monkeypatch):
     )
     assert "not allowed" in refused.content
     assert "not allowed" not in allowed.content
+
+
+def test_kernel_receives_policy_env(session):
+    repl = IPythonREPL(
+        cwd=str(session.dir),
+        session=session,
+        exec_timeout=42,
+        allow_git=True,
+    )
+    repl.start()
+    try:
+        out = repl.execute(
+            "import os; print(os.environ.get('RLM_EXEC_TIMEOUT'), os.environ.get('RLM_ALLOW_GIT'))"
+        )
+    finally:
+        repl.shutdown()
+    assert out.strip() == "42 1"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -92,3 +92,23 @@ def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     assert captured.out == ""
     assert captured.err == ""
     assert result.strip() == "4 14"
+
+
+def test_tooling_presets(monkeypatch):
+    from rlm.tools.registry import preset_skills, preset_tools
+
+    monkeypatch.delenv("RLM_TOOLING", raising=False)
+    assert preset_tools() == ("bash", "edit", "ipython")
+    assert preset_skills() == ("bash", "edit")
+
+    monkeypatch.setenv("RLM_TOOLING", "tools")
+    assert preset_skills() == ()
+
+    monkeypatch.setenv("RLM_TOOLING", "skills")
+    assert preset_tools() == ("ipython",)
+
+    monkeypatch.setenv("RLM_TOOLING", "bogus")
+    import pytest
+
+    with pytest.raises(ValueError):
+        preset_tools()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -154,3 +154,44 @@ print(all(os.environ.get(name, '').startswith({repl._ipc_dir!r}) for name in ('I
 
     assert first.strip().splitlines() == ["yes", "True", "True", "True"]
     assert second.strip().splitlines() == ["yes", "True", "True", "True"]
+
+
+def _tool_ctx(**overrides):
+    from rlm.tools.base import ToolContext
+    from rlm.types import RLMMetrics, TokenUsage
+
+    kwargs = dict(
+        messages=[],
+        metrics=RLMMetrics(),
+        total_usage=TokenUsage(),
+        last_prompt_tokens=0,
+        exec_timeout=10,
+    )
+    kwargs.update(overrides)
+    return ToolContext(**kwargs)
+
+
+def test_edit_tool_resolves_relative_path_against_cwd(tmp_path):
+    from rlm.tools.bash import EditTool
+
+    (tmp_path / "f.txt").write_text("hello world")
+    out = EditTool().execute(
+        {"path": "f.txt", "old_str": "hello", "new_str": "goodbye"},
+        _tool_ctx(cwd=str(tmp_path)),
+    )
+    assert "Edited" in out.content
+    assert (tmp_path / "f.txt").read_text() == "goodbye world"
+
+
+def test_bash_tool_honors_explicit_allow_git(monkeypatch):
+    from rlm.tools.bash import BashTool
+
+    monkeypatch.delenv("RLM_ALLOW_GIT", raising=False)
+    refused = BashTool().execute(
+        {"command": "git log --all"}, _tool_ctx(allow_git=False)
+    )
+    allowed = BashTool().execute(
+        {"command": "git log --all"}, _tool_ctx(allow_git=True)
+    )
+    assert "not allowed" in refused.content
+    assert "not allowed" not in allowed.content


### PR DESCRIPTION
## Summary

The rlm harness, rebuilt on evidence from a k3-focused ablation campaign (9 models, up to 128 tasks/arm, SWE-rebench-V2):

1. **Terse coding-agent persona** replaces the verbose default system prompt (~3.2kB -> ~1.4kB)
2. **`RLM_TOOLING` preset — `dual` (default) | `tools` | `skills`** — one knob for how shell/edit are exposed
3. **Kernel-isolation prompt line** (stops project imports into the kernel venv)
4. **Actionable compaction handoff** (fenced command blocks + numbered next steps)
5. bash tool/skill share one guarded runner (`bash -c`, git-history guard, harness timeout); output-clipping removed

## The starting point: something was wrong

kimi-k3 on stock rlm vs a plain bash+edit agent, same tasks:

| setup | solve (easy 32) | reasoning tok/turn | solve (SWE-bench Pro 32) |
|---|---|---|---|
| stock rlm (ipython-only, stock prompt) | 0.53 | 327 | 0.75 |
| bash+edit agent (verifiers harness) | 0.69 | 268 | 0.94 |

Ablations isolated the cause: **the verbose prompt** (not the ipython interface, not `%%bash` syntax). Same tools, persona prompt: 209-232 tok/turn, solve 0.62-0.75. Frontier models are insensitive either way; kimi-k3 and opus-5 are prompt-sensitive (~2x reasoning inflation under the stock prompt).

## Final ablation: the three `RLM_TOOLING` presets (128 tasks, kimi-k3, same seeded set)

| preset | n | solve | turns | reason/turn | error turns |
|---|---|---|---|---|---|
| `tools` | 128 | 0.711 | 36.1 | 216 | **0.8%** |
| `skills` (with triple-quote guidance) | 125 | 0.704 | **33.5** | 256 | 2.5% |
| `dual` | 128 | 0.695 | 35.4 | 239 | 2.1% |

Converged on solve and total reasoning (~8k tok). `tools` is cleanest, `skills` fewest turns (REPL cells batch multiple actions), `dual` within noise of both.

The skills preset needed two fixes, each isolated on the same 32 tasks:

| skills variant | turns | error turns |
|---|---|---|
| buggy skill (ran /bin/sh) + no guidance | 53.5 | 4.2% |
| + shell-parity fix (`bash -c`) | 35.9 | 5.0% |
| + triple-quote prompt line | **33.5** | **2.5%** |

The bugfix bought the turns; the prompt line bought the errors. The `skills` preset auto-renders the validated line: *"Run shell with `out = await bash(\'\'\'command here\'\'\')` — always triple-quote the command so shell quotes and multi-line scripts never need escaping..."*

Cross-model check (GLM-5.3 @32): `tools` 0.61/1.3% err, `skills` 0.63 but 2.4x the reasoning tokens and 3.7% err, `dual` 0.59/0.6% err — skills-only is kimi-validated, not universal; hence **`dual` as default** (never the outlier on any model; both alternatives one env var away).

## Kernel-isolation line

kimi imported project modules into the rlm kernel (~25 attempts/32 rollouts, 1 in 5 hitting ModuleNotFoundError). The line "The ipython kernel is an isolated venv without the project's packages... everything that executes project code goes through bash" drops kernel project-imports 5 -> 0, ImportErrors -> 0, at *lower* reasoning (161 vs 182 tok/turn on the probe set) — informational phrasing, no prohibition cost.

## Compaction

`CHECKPOINT_COMPACTION_PROMPT` now demands runnable handoffs (exact repro/test commands + pending edits as fenced code blocks, numbered next steps): validated 0 -> ~4 command blocks per handoff, compacted-rollout solve 0.75-0.88 vs 0.53 under the stock prompt. Also checked: advance compaction notice in the system prompt is unnecessary (models stash state naturally; the at-compaction REPL note suffices; an explicit stash line doubles state-keeping but buys no solve).

## Notes

- Merged with main (absorbs #145 bash skill and #146 knob removal; keeps #134 supervisor semantics — presets respected via `_selected()` in the tool registry, `RLM_SKILLS` default now preset-aware in `RuntimeConfig.from_env`).
- Tests: 125 passed; the 6 `test_acp.py` failures are pre-existing on clean main in this environment. Ruff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default tooling, prompts, and compaction handoffs that directly steer agent behavior; bash/edit run on the host cwd with file writes, though git guards and timeouts are centralized.
> 
> **Overview**
> **Default agent surface** moves from IPython-only to native **`bash`**, **`edit`**, and **`ipython`** tools, with **`RLM_TOOLING`** (`dual` | `tools` | `skills`) and **`RLM_BUILTIN_TOOLS`** to override. When **`RLM_SKILLS`** is unset, skills now follow the preset via **`preset_skills()`** instead of an empty list.
> 
> **`rlm.tools.bash`** adds shared **`run_bash`** (guarded `bash -c`, cwd, `allow_git`) used by **`BashTool`**, **`EditTool`**, and the **`bash`** skill; the IPython kernel gets **`RLM_EXEC_TIMEOUT`** / **`RLM_ALLOW_GIT`** at startup from engine policy.
> 
> **System prompt** is shorter and tool-aware: coding-agent role lines per active tool, kernel-isolation guidance (**`PROJECT_ENV_PROMPT`**), conditional bash-skill triple-quote hints, and trimmed IPython/edit copy. **Compaction** **`CHECKPOINT_COMPACTION_PROMPT`** now requires fenced repro commands, pending **`edit`** calls, and numbered next steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e269887ee68aa8b498327105e91297aae4fa20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->