### PR TITLE
chore: add markdownlint via pre-commit

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,10 @@
+config:
+  MD013: false
+  MD060:
+    style: compact
+overrides:
+  - filter:
+      - CLAUDE.md
+    config:
+      MD041: false
+    combine: merge

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.23.1
+    hooks:
+      - id: markdownlint-cli2
+
   - repo: local
     hooks:
       - id: ruff-check

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ result = asyncio.run(rlm.run("fix the bug"))
 All configuration is via environment variables:
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| ---------- | --------- | ------------- |
 | `RLM_HOME` | `~/.rlm` | Root directory for sessions and data |
 | `RLM_MODEL` | `openai/gpt-5-mini` | Model name (PI Inference slug). Override with `--model` or `RLM_MODEL` for OpenAI/Anthropic direct (e.g. `gpt-4o`, `claude-sonnet-4-5`) |
 | `RLM_API_KEY` / `RLM_BASE_URL` | — / SDK default (`https://api.openai.com/v1`) | Explicit override (highest priority). Independent: setting `RLM_API_KEY` alone targets the SDK default endpoint; set `RLM_BASE_URL` too for a custom endpoint. For PI, use `PRIME_API_KEY` (below) which owns the full pair. |


### PR DESCRIPTION
## Summary

- add the [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) v0.23.1 pre-commit hook, exactly as wired in verifiers and research-environments
- share their base config: `MD013` (line length) off, `MD060` compact table style, `MD041` off for the `CLAUDE.md` include stub
- fix the one existing violation: the README configuration-table delimiter row was missing pipe spacing for the compact style

## Validation

- `uv run pre-commit run --all-files` — markdownlint-cli2, ruff check, ruff format all pass
- `uv run pytest tests/ -q` — 112 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev tooling and a one-line README table formatting fix; no runtime or security impact.
> 
> **Overview**
> Adds `markdownlint-cli2` to pre-commit so Markdown is linted on commit, matching the shared config used elsewhere (line length off, compact tables, `MD041` off for `CLAUDE.md`).
> 
> Also spaces the README configuration-table delimiter so it satisfies the compact table style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e34deef49642c3231d93b770ab808d8311c8920e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->