### PR TITLE
feat: publish ACP snapshots with prompt results

### DIFF
--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -365,6 +365,7 @@ class RLMACPAgent(Agent):
                     input_tokens=result.usage.prompt_tokens,
                     output_tokens=result.usage.completion_tokens,
                 ),
+                field_meta=_session_metadata(state),
             )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -676,7 +676,16 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert first.usage.total_tokens == 5
     assert second.stop_reason == "end_turn"
     assert created.field_meta is None
-    assert first.field_meta is None
+    first_snapshot = first.field_meta[SESSION_METADATA_KEY]
+    assert first_snapshot["session_id"] == "test-session"
+    assert first_snapshot["turns"] == 1
+    assert first_snapshot["usage"]["total_tokens"] == 5
+    assert first_snapshot["last_stop_reason"] == "done"
+    second_snapshot = second.field_meta[SESSION_METADATA_KEY]
+    assert second_snapshot["session_id"] == "test-session"
+    assert second_snapshot["turns"] == 2
+    assert second_snapshot["usage"]["total_tokens"] == 10
+    assert second_snapshot["last_stop_reason"] == "done"
 
     closed = await agent.close_session(created.session_id)
     closed_snapshot = closed.field_meta[SESSION_METADATA_KEY]


### PR DESCRIPTION
## Summary

- publish the cumulative runtime snapshot on each successful ACP `session/prompt` response
- keep the close snapshot available while allowing clients to consume training metrics at the completed-turn boundary
- cover per-turn session, usage, and stop-reason metadata

## Test plan

- `uv run ruff check src/rlm/acp.py tests/test_acp.py`
- `uv run pytest tests/` (123 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive wire metadata on the happy path only; snapshot is already validated and credential-scrubbed via existing `_session_metadata`.
> 
> **Overview**
> Successful ACP **`session/prompt`** responses now include **`field_meta`** with the validated **`ai.prime.rlm/session-v1`** snapshot (same shape as session close), so clients can read cumulative session id, turn count, usage, and **`last_stop_reason`** after each completed turn without waiting for close.
> 
> **`new_session`** and non-success paths (e.g. cancelled prompts) still omit this metadata; close continues to publish the final snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11dcb9c353f1f7c89c8c6f1bc0ddea33b3cffa19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->