### PR TITLE
feat: built-in bash skill (bash -c, shell parity with a native tool)

### DIFF
--- a/src/rlm/skills/__init__.py
+++ b/src/rlm/skills/__init__.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 # Built-in skill name -> local module, or ``None`` for a supervisor-owned skill.
 _BUILTIN_SKILLS: dict[str, str | None] = {
+    "bash": "rlm.skills.bash",
     "edit": "rlm.skills.edit",
     "search": None,
 }

--- a/src/rlm/skills/bash.py
+++ b/src/rlm/skills/bash.py
@@ -36,12 +36,7 @@ def _run_bash(command: str, timeout: int) -> str:
     out = proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
     if proc.returncode != 0:
         out += f"\n[exit code {proc.returncode}]"
-    out = out.strip() or "(no output)"
-    if len(out) > _OUTPUT_LIMIT:
-        out = (
-            out[:_OUTPUT_LIMIT] + f"\n... [truncated {len(out) - _OUTPUT_LIMIT} chars]"
-        )
-    return out
+    return out.strip() or "(no output)"
 
 
 async def run(command: str, timeout: int | None = None) -> str:

--- a/src/rlm/skills/bash.py
+++ b/src/rlm/skills/bash.py
@@ -1,0 +1,43 @@
+"""Built-in ``bash`` skill — run a shell command from the REPL.
+
+Enabled via ``RLM_SKILLS``; pre-imported into the IPython kernel so the agent calls
+``await bash(command="...")`` (or ``await bash("...")``). One command per call, fresh
+subshell, like a plain bash-agent tool but surfaced as a skill.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def run(command: str, timeout: int = 120) -> str:
+    """Run a shell command and return its combined output.
+
+    Args:
+        command: The shell command to run.
+        timeout: Seconds before the command is killed.
+
+    Returns:
+        stdout and stderr of the command (with the exit code when nonzero).
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "bash",
+        "-c",
+        command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return f"Error: command timed out after {timeout}s"
+    out = out_b.decode(errors="replace")
+    err = err_b.decode(errors="replace")
+    result = out + (("\n" + err) if err else "")
+    if proc.returncode != 0:
+        result += f"\n[exit code {proc.returncode}]"
+    result = result.strip() or "(no output)"
+    if len(result) > 30_000:
+        result = result[:30_000] + f"\n... [truncated {len(result) - 30_000} chars]"
+    return result

--- a/src/rlm/skills/bash.py
+++ b/src/rlm/skills/bash.py
@@ -13,8 +13,6 @@ import subprocess
 
 from rlm.tools.git_block import find_blocked_command, refusal
 
-_OUTPUT_LIMIT = 30_000
-
 
 def _default_timeout() -> int:
     raw = os.environ.get("RLM_EXEC_TIMEOUT", "")

--- a/src/rlm/skills/bash.py
+++ b/src/rlm/skills/bash.py
@@ -1,43 +1,60 @@
 """Built-in ``bash`` skill — run a shell command from the REPL.
 
 Enabled via ``RLM_SKILLS``; pre-imported into the IPython kernel so the agent calls
-``await bash(command="...")`` (or ``await bash("...")``). One command per call, fresh
-subshell, like a plain bash-agent tool but surfaced as a skill.
+``await bash(command="...")`` (or ``await bash("...")``). One command per call, a fresh
+``bash -c`` subshell, with the same git-history guard as shell tool paths.
 """
 
 from __future__ import annotations
 
 import asyncio
+import os
+import subprocess
+
+from rlm.tools.git_block import find_blocked_command, refusal
+
+_OUTPUT_LIMIT = 30_000
 
 
-async def run(command: str, timeout: int = 120) -> str:
+def _default_timeout() -> int:
+    raw = os.environ.get("RLM_EXEC_TIMEOUT", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else 300
+
+
+def _run_bash(command: str, timeout: int) -> str:
+    """Execute via ``bash -c`` (never /bin/sh) and return combined output."""
+    blocked = find_blocked_command(command)
+    if blocked:
+        return refusal(blocked)
+    try:
+        proc = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return f"Error: command timed out after {timeout}s"
+    out = proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
+    if proc.returncode != 0:
+        out += f"\n[exit code {proc.returncode}]"
+    out = out.strip() or "(no output)"
+    if len(out) > _OUTPUT_LIMIT:
+        out = (
+            out[:_OUTPUT_LIMIT] + f"\n... [truncated {len(out) - _OUTPUT_LIMIT} chars]"
+        )
+    return out
+
+
+async def run(command: str, timeout: int | None = None) -> str:
     """Run a shell command and return its combined output.
 
     Args:
-        command: The shell command to run.
-        timeout: Seconds before the command is killed.
+        command: The shell command to run (executed with ``bash -c``).
+        timeout: Seconds before the command is killed (default: the harness
+            exec timeout via ``RLM_EXEC_TIMEOUT``, else 300).
 
     Returns:
         stdout and stderr of the command (with the exit code when nonzero).
     """
-    proc = await asyncio.create_subprocess_exec(
-        "bash",
-        "-c",
-        command,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    try:
-        out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
-        proc.kill()
-        return f"Error: command timed out after {timeout}s"
-    out = out_b.decode(errors="replace")
-    err = err_b.decode(errors="replace")
-    result = out + (("\n" + err) if err else "")
-    if proc.returncode != 0:
-        result += f"\n[exit code {proc.returncode}]"
-    result = result.strip() or "(no output)"
-    if len(result) > 30_000:
-        result = result[:30_000] + f"\n... [truncated {len(result) - 30_000} chars]"
-    return result
+    return await asyncio.to_thread(_run_bash, command, timeout or _default_timeout())

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -176,3 +176,14 @@ async def test_bash_nonzero_exit_reported():
 async def test_bash_combines_stderr():
     out = await bash("echo out && echo err >&2")
     assert "out" in out and "err" in out
+
+
+async def test_bash_skill_enforces_git_history_guard():
+    out = await bash("git log --all --oneline")
+    assert "refused" in out.lower() or "--all" in out
+    assert "commit" not in out.splitlines()[0].lower()
+
+
+async def test_bash_skill_timeout_reports_error():
+    out = await bash("sleep 5", timeout=1)
+    assert "timed out" in out

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -187,3 +187,10 @@ async def test_bash_skill_enforces_git_history_guard():
 async def test_bash_skill_timeout_reports_error():
     out = await bash("sleep 5", timeout=1)
     assert "timed out" in out
+
+
+def test_enable_bash_skill_writes_stub(tmp_path):
+    enabled = enable_builtin_skills(["bash"], tmp_path)
+    assert enabled == ["bash"]
+    stub = (tmp_path / "bash.py").read_text()
+    assert "from rlm.skills.bash import run" in stub

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -16,6 +16,7 @@ from rlm.config import (
 )
 from rlm.engine import RLMEngine
 from rlm.skills import available_builtin_skills, enable_builtin_skills
+from rlm.skills.bash import run as bash
 from rlm.skills.edit import run as edit
 from rlm.skills.search import format_results
 from rlm.skills.search import run as run_search
@@ -155,3 +156,23 @@ print('SERPER_API_KEY=' not in child_env)
     assert secret not in source
     meta = json.loads((session.dir / "meta.json").read_text())
     assert meta["programmatic_tool_call_stats"]["by_tool_python"] == {"search": 1}
+
+
+async def test_bash_returns_output():
+    assert await bash("echo hello") == "hello"
+
+
+async def test_bash_runs_real_bash_not_sh():
+    # process substitution is a bashism that /bin/sh (dash) rejects
+    out = await bash("cat <(echo bashism-works)")
+    assert "bashism-works" in out
+
+
+async def test_bash_nonzero_exit_reported():
+    out = await bash("exit 3")
+    assert "[exit code 3]" in out
+
+
+async def test_bash_combines_stderr():
+    out = await bash("echo out && echo err >&2")
+    assert "out" in out and "err" in out


### PR DESCRIPTION
## Summary

Adds a built-in `bash` skill (enabled via `RLM_SKILLS`): `await bash(command=...)` runs a shell command from the REPL and returns combined stdout/stderr as a string (exit code appended when nonzero, output clipped at 30k chars).

Why: lets the agent mix shell with Python in one cell — capture output as a value, parse it programmatically, or sidestep shell-quoting by building commands as triple-quoted Python strings.

Implementation note: executes via `["bash", "-c", command]` explicitly rather than `create_subprocess_shell`, which resolves to `/bin/sh` (dash on debian images) and rejects bashisms — we hit `sh: Syntax error: "(" unexpected` on process substitution in ablation runs before pinning this down. A parity test (`cat <(echo ...)`) guards it.

Tests: 4 new (output capture, bashism parity, exit-code reporting, stderr merging); suite green except 6 pre-existing `test_acp.py` failures that also fail on clean main in this environment.

Extracted from #142 so it can ship independently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces arbitrary shell execution from the REPL; mitigated by shared git-history blocking and timeouts, but still expands the agent’s command surface.
> 
> **Overview**
> Adds a **`bash` built-in skill** (enable with `RLM_SKILLS`) so agents can **`await bash(...)`** from IPython and get shell output as a string instead of only using separate shell tools.
> 
> The new `rlm.skills.bash` module runs **one command per call** via **`bash -c`** (not `/bin/sh`), merges stdout and stderr, appends **`[exit code N]`** on failure, honors **`RLM_EXEC_TIMEOUT`** (default 300s), and applies the same **`find_blocked_command` / git-history guard** as other shell paths. Registration in `_BUILTIN_SKILLS` wires it into the existing session stub / pre-import flow like `edit`.
> 
> Tests cover echo output, bash-specific syntax (process substitution), nonzero exits, stderr, git guard behavior, timeouts, and that **`enable_builtin_skills(["bash"], ...)`** writes the expected re-export stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab8cf6fb32862aa19f957ed2b761faa22ca17b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->