### PR TITLE
chore: remove RLM_MAX_OUTPUT and RLM_MAX_TOOL_OUTPUT_CHARS

### DIFF
--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -99,7 +99,6 @@ class _LimitsSnapshot(_ContractModel):
     max_tokens: int | None = Field(default=None, gt=0)
     summarize_at_tokens: int | None = Field(default=None, gt=0)
     max_compactions: int | None = Field(default=None, gt=0)
-    max_tool_output_chars: int | None = Field(default=None, gt=0)
     allow_git: bool
 
 

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -124,21 +124,12 @@ class ExecutionPolicy(_ConfigModel):
 
     max_depth: int = Field(default=0, ge=0)
     exec_timeout: int = Field(default=300, gt=0)
-    max_output: int = -1
     max_tokens: int | None = Field(default=None, gt=0)
     summarize_at_tokens: int | None = Field(default=None, gt=0)
     max_compactions: int | None = Field(default=None, gt=0)
     max_concurrent_subagents: int = Field(default=4, gt=0)
     max_subagent_calls: int = Field(default=64, gt=0)
-    max_tool_output_chars: int | None = Field(default=None, gt=0)
     allow_git: bool = False
-
-    @field_validator("max_output")
-    @classmethod
-    def _validate_max_output(cls, value: int) -> int:
-        if value == 0 or value < -1:
-            raise ValueError("must be positive, or -1 to disable truncation")
-        return value
 
     @model_validator(mode="after")
     def _validate_concurrency(self) -> Self:
@@ -167,11 +158,6 @@ class RuntimeConfig(_ConfigModel):
         environ: Mapping[str, str] | None = None,
     ) -> RuntimeConfig:
         env = os.environ if environ is None else environ
-        max_output = int(env.get("RLM_MAX_OUTPUT", "-1"))
-        if max_output == 0:
-            raise ValueError(
-                "RLM_MAX_OUTPUT must be positive, or -1 to disable truncation"
-            )
         raw_skills = env.get("RLM_SKILLS", "")
         max_depth = int(env.get("RLM_MAX_DEPTH", "0"))
         default_concurrency = max(4, max_depth)
@@ -190,7 +176,6 @@ class RuntimeConfig(_ConfigModel):
             policy=ExecutionPolicy(
                 max_depth=max_depth,
                 exec_timeout=int(env.get("RLM_EXEC_TIMEOUT", "300")),
-                max_output=max_output,
                 max_tokens=_optional_positive_int(
                     env.get("RLM_MAX_TOKENS"), "RLM_MAX_TOKENS"
                 ),
@@ -204,10 +189,6 @@ class RuntimeConfig(_ConfigModel):
                 max_subagent_calls=_positive_int(
                     env.get("RLM_MAX_SUBAGENT_CALLS", "64"),
                     "RLM_MAX_SUBAGENT_CALLS",
-                ),
-                max_tool_output_chars=_optional_positive_int(
-                    env.get("RLM_MAX_TOOL_OUTPUT_CHARS"),
-                    "RLM_MAX_TOOL_OUTPUT_CHARS",
                 ),
                 allow_git=env.get("RLM_ALLOW_GIT") == "1",
             ),

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -141,14 +141,12 @@ class RLMEngine:
         self.model = config.model
         self.cwd = cwd or os.getcwd()
         self.exec_timeout = config.policy.exec_timeout
-        self.max_output = config.policy.max_output
         self.summarize_at_tokens = config.policy.summarize_at_tokens
         self.max_compactions = config.policy.max_compactions
         self.system_prompt_path = config.system_prompt_path
         self.append_to_system_prompt = config.append_to_system_prompt
         self.max_depth = config.policy.max_depth
         self.depth = config.invocation.depth
-        self.max_tool_output_chars = config.policy.max_tool_output_chars
         self.allow_git = config.policy.allow_git
 
         # Task MCP tool servers to expose as IPython skills; kwarg wins, otherwise
@@ -531,9 +529,6 @@ class RLMEngine:
 
             result = tool_result.content
 
-            if self.max_output > 0 and len(result) > self.max_output:
-                result = result[: self.max_output] + "\n... [output truncated]"
-
             self.session.log_tool_result(turn, tool_name, result, duration)
             messages.append(
                 {
@@ -811,7 +806,6 @@ class RLMEngine:
                 "max_tokens": self.runtime_config.policy.max_tokens,
                 "summarize_at_tokens": self.runtime_config.policy.summarize_at_tokens,
                 "max_compactions": self.runtime_config.policy.max_compactions,
-                "max_tool_output_chars": self.runtime_config.policy.max_tool_output_chars,
                 "allow_git": self.runtime_config.policy.allow_git,
             },
         }
@@ -840,7 +834,6 @@ class RLMEngine:
             total_usage=self._total_usage,
             last_prompt_tokens=self._last_prompt_tokens,
             exec_timeout=self.exec_timeout,
-            max_tool_output_chars=self.max_tool_output_chars,
             allow_git=self.allow_git,
             repl=self._repl,
             state=self._tool_state,

--- a/src/rlm/tools/base.py
+++ b/src/rlm/tools/base.py
@@ -25,7 +25,6 @@ class ToolContext:
     total_usage: TokenUsage
     last_prompt_tokens: int
     exec_timeout: int
-    max_tool_output_chars: int | None = None
     allow_git: bool = False
     repl: Any | None = None
     state: dict[str, Any] = field(default_factory=dict)

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -160,23 +160,13 @@ class IpythonTool:
             )
 
         return ToolOutcome(
-            content=self._maybe_truncate_output(
-                context.repl.execute(code, timeout=timeout),
-                context.max_tool_output_chars,
-            ),
+            content=context.repl.execute(code, timeout=timeout),
             metric_events=metric_events,
         )
 
     @staticmethod
     def _count_nonempty_lines(code: str) -> int:
         return sum(1 for line in code.splitlines() if line.strip())
-
-    @staticmethod
-    def _maybe_truncate_output(content: str, cap: int | None) -> str:
-        if cap is None or len(content) <= cap:
-            return content
-        head, tail = cap // 2, cap - cap // 2
-        return f"{content[:head]}\n...[{len(content) - cap} chars truncated]...\n{content[-tail:]}"
 
 
 class IPythonREPL:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -41,13 +41,11 @@ def _runtime_metadata(**overrides: Any) -> dict[str, Any]:
         "policy": {
             "max_depth": 0,
             "exec_timeout": 300,
-            "max_output": -1,
             "max_tokens": None,
             "summarize_at_tokens": None,
             "max_compactions": None,
             "max_concurrent_subagents": 4,
             "max_subagent_calls": 64,
-            "max_tool_output_chars": None,
             "allow_git": False,
         },
         "system_prompt_path": None,
@@ -141,7 +139,6 @@ class _Engine:
                 "max_tokens": None,
                 "summarize_at_tokens": None,
                 "max_compactions": None,
-                "max_tool_output_chars": None,
                 "allow_git": False,
             },
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,11 +19,9 @@ def test_runtime_config_resolves_and_redacts_environment():
             "RLM_DEPTH": "2",
             "RLM_MAX_DEPTH": "4",
             "RLM_EXEC_TIMEOUT": "30",
-            "RLM_MAX_OUTPUT": "1200",
             "RLM_MAX_TOKENS": "500",
             "RLM_SUMMARIZE_AT_TOKENS": "2048",
             "RLM_MAX_COMPACTIONS": "3",
-            "RLM_MAX_TOOL_OUTPUT_CHARS": "700",
             "RLM_ALLOW_GIT": "1",
             "RLM_SKILLS": "search, edit",
             KERNEL_ENV_CONFIG_ENV: '{"TASK_TOKEN": "task-secret"}',
@@ -36,13 +34,11 @@ def test_runtime_config_resolves_and_redacts_environment():
     assert config.policy == ExecutionPolicy(
         max_depth=4,
         exec_timeout=30,
-        max_output=1200,
         max_tokens=500,
         summarize_at_tokens=2048,
         max_compactions=3,
         max_concurrent_subagents=4,
         max_subagent_calls=64,
-        max_tool_output_chars=700,
         allow_git=True,
     )
     assert config.skills == ("search", "edit")

--- a/tests/test_git_block.py
+++ b/tests/test_git_block.py
@@ -312,17 +312,15 @@ def test_ipython_tool_uses_explicit_execution_policy(monkeypatch):
             return "abcdefgh"
 
     monkeypatch.setenv("RLM_ALLOW_GIT", "1")
-    monkeypatch.setenv("RLM_MAX_TOOL_OUTPUT_CHARS", "100")
     ctx = _ctx()
     ctx.repl = StubRepl()
     ctx.allow_git = False
-    ctx.max_tool_output_chars = 4
 
     refused = IpythonTool().execute({"code": "!git log --all"}, ctx)
-    truncated = IpythonTool().execute({"code": "print('ignored')"}, ctx)
+    passed = IpythonTool().execute({"code": "print('ignored')"}, ctx)
 
     assert refused.content == REFUSAL
-    assert truncated.content == "ab\n...[4 chars truncated]...\ngh"
+    assert passed.content == "abcdefgh"
     assert (
         "Default: 17s"
         in IpythonTool(17).schema()["function"]["parameters"]["properties"]["timeout"][


### PR DESCRIPTION
Removes the two off-by-default output-truncation knobs (engine-level `RLM_MAX_OUTPUT` clip and ipython `RLM_MAX_TOOL_OUTPUT_CHARS`) and all their plumbing: config fields, validators, env parsing, ToolContext field, acp mirror, and tests. 117 passed; the 6 `test_acp.py` failures are pre-existing on clean main in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tool and IPython outputs can now grow unbounded in conversation context, which may increase token usage or hit request-size limits that truncation previously mitigated.
> 
> **Overview**
> Removes the two optional output-size limits that were off by default: engine-level clipping of tool results (`RLM_MAX_OUTPUT` / `max_output`) and IPython head/tail truncation (`RLM_MAX_TOOL_OUTPUT_CHARS` / `max_tool_output_chars`).
> 
> **Config and contracts:** Drops those fields from `ExecutionPolicy`, env resolution in `RuntimeConfig.from_env`, the `max_output` validator, `ToolContext`, engine snapshots, and ACP `_LimitsSnapshot`.
> 
> **Runtime behavior:** Tool results are no longer truncated in the agent loop after execution, and `IpythonTool` returns full REPL output instead of calling `_maybe_truncate_output` (that helper is deleted).
> 
> Tests and ACP fixture metadata are updated to match the slimmer policy shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3661455790c595157025079d55ca42081aaadc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->