### PR TITLE
docs: add mermaid architecture documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # AGENTS.md
 
+## Documentation
+
+- Architecture, concepts, user flows, and configuration reference live in [`docs/`](docs/README.md), with Mermaid diagrams grounded in `src/rlm/`.
+- Keep the diagrams in sync when changing the engine loop, tool registry, supervisor, or config schema.
+
 ## Writing code
 
 - **Minimal try/except**: let errors propagate — silent failures hide bugs. Only catch for intentional fault tolerance (retries, robustness).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,142 @@
+# Architecture
+
+System shape of nano-rlm, grounded in `src/rlm/`. Diagrams use Mermaid and render natively on GitHub.
+
+## System overview
+
+`RLMEngine` (`src/rlm/engine.py`) is the central orchestrator. It bridges natural-language reasoning with a concrete execution space: a persistent IPython kernel, a small set of built-in tools, and a session record on disk.
+
+```mermaid
+flowchart TB
+    subgraph Entry["Entry points"]
+        CLI["rlm CLI<br/>cli.py"]
+        ACP["ACP server<br/>acp.py"]
+        API["Python API<br/>rlm.run — api.py"]
+    end
+
+    subgraph Core["Agent core"]
+        ENGINE["RLMEngine<br/>engine.py"]
+        CLIENT["LLM client<br/>client.py"]
+        PROMPT["System prompt builder<br/>prompt.py"]
+    end
+
+    subgraph Exec["Execution environment"]
+        REG["Tool registry<br/>tools/registry.py"]
+        BASH["bash tool"]
+        EDIT["edit tool"]
+        IPTOOL["ipython tool"]
+        REPL["IPythonREPL<br/>tools/ipython.py"]
+        KERNEL[("Persistent<br/>IPython kernel")]
+        GUARD["GitHistoryGuard<br/>tools/git_block.py"]
+    end
+
+    subgraph Rec["Recursion"]
+        SUP["SessionTreeSupervisor<br/>supervisor.py"]
+        BRK["Broker<br/>broker.py<br/>(unix socket, framed JSON RPC)"]
+    end
+
+    subgraph State["Persistence"]
+        SES["Session<br/>session.py"]
+        FS[("$RLM_HOME/sessions/&lt;id&gt;<br/>meta.json · messages.jsonl")]
+    end
+
+    CLI --> ENGINE
+    ACP --> ENGINE
+    API --> ENGINE
+    ENGINE <--> CLIENT
+    PROMPT --> ENGINE
+    ENGINE --> REG
+    REG --> BASH & EDIT & IPTOOL
+    BASH & IPTOOL --> GUARD
+    IPTOOL --> REPL
+    REPL <--> KERNEL
+    KERNEL <--> BRK
+    BRK <--> SUP
+    SUP -->|spawns| ENGINE
+    ENGINE --> SES
+    SES --> FS
+```
+
+## Key components
+
+| Component | Responsibility | Source |
+| ----------- | --------------- | -------- |
+| `RLMEngine` | Agent loop: conversation history, tool dispatch, auto-compaction, recursion depth | `src/rlm/engine.py` |
+| `IPythonREPL` | Lifecycle of the persistent Jupyter kernel (ZMQ/IPC transport) | `src/rlm/tools/ipython.py` |
+| Tool registry | Active built-in tools: `bash`, `edit`, `ipython` | `src/rlm/tools/registry.py` |
+| `Session` | On-disk persistence: `meta.json`, `messages.jsonl`, metrics aggregation | `src/rlm/session.py` |
+| Skills system | Discovers and injects callable skills (built-in, installed, MCP) into the kernel | `src/rlm/skills/`, `src/rlm/mcp.py` |
+| `GitHistoryGuard` | Blocks broad git-history access (`git log --all`, `--reflog`, …) in shell and Python | `src/rlm/tools/git_block.py` |
+| `SessionTreeSupervisor` | Owns the recursion tree, depth semaphores, brokered skill calls | `src/rlm/supervisor.py` |
+| Broker | Framed JSON RPC over a unix socket between kernels and the supervisor | `src/rlm/broker.py` |
+
+## The turn loop
+
+`_run_loop()` (`engine.py:368`) is an act–observe cycle. Exactly one built-in tool call is allowed per turn.
+
+```mermaid
+sequenceDiagram
+    participant E as RLMEngine
+    participant L as LLM (client.py)
+    participant T as Tool (bash/edit/ipython)
+    participant S as Session
+
+    loop for each turn
+        E->>L: chat.completions.create(messages, tools)<br/>Idempotency-Key: call_id
+        L-->>E: assistant message (+ usage)
+        E->>S: log_assistant
+        alt no tool calls
+            E->>E: stop_reason = "done"
+        else more than one tool call
+            E->>E: error feedback to all calls
+        else one tool call
+            E->>T: execute(args, ToolContext)<br/>(asyncio.shield + to_thread)
+            T-->>E: ToolOutcome
+            E->>S: log_tool_result
+        end
+        opt prompt_tokens ≥ RLM_SUMMARIZE_AT_TOKENS
+            E->>L: compaction call (tool_choice="none")
+            L-->>E: handoff summary
+            E->>E: messages := [system, summary]<br/>kernel NOT restarted
+            E->>S: log compaction event
+        end
+    end
+```
+
+Tool cancellation is cooperative: on interruption the engine interrupts the kernel (`repl.interrupt()`), and recovers by restarting the kernel only if it does not return to idle within 2 seconds.
+
+## Recursion tree
+
+Sub-agents never spawn engines themselves — recursion always goes through the supervisor.
+
+```mermaid
+flowchart LR
+    subgraph K0["Root kernel (depth 0)"]
+        R0["await rlm('sub-task')"]
+    end
+    R0 -->|rlm.run RPC| BROKER["Broker<br/>(unix socket)"]
+    BROKER --> SUP["SessionTreeSupervisor"]
+    SUP -->|"capability + scope check<br/>depth & call limits"| CHK{allowed?}
+    CHK -->|no| LIM["RLMResult<br/>[depth limit reached]"]
+    CHK -->|yes| SEM["depth semaphore<br/>depth_capacities()"]
+    SEM --> E1["Child RLMEngine<br/>depth + 1"]
+    E1 --> K1[("Child kernel<br/>sub-&lt;uuid8&gt;/")]
+    K1 -->|"RLMResult(answer, usage, …)"| R0
+```
+
+Guard rails: `RLM_MAX_DEPTH` (default 0 = no sub-agents), `RLM_MAX_SUBAGENT_CALLS` (default 64 per tree), `RLM_MAX_CONCURRENT_SUBAGENTS` (per-depth semaphores so nested calls cannot deadlock).
+
+## Session layout on disk
+
+```mermaid
+flowchart TB
+    HOME["$RLM_HOME (default ~/.rlm)"] --> S["sessions/&lt;uuid12&gt;/"]
+    S --> M["meta.json<br/>id · model · depth · status<br/>usage · metrics · answer_preview"]
+    S --> J["messages.jsonl<br/>assistant · tool_result · sub_spawn<br/>compaction · prompt_rollback · done"]
+    S --> P["programmatic_tool_calls.jsonl<br/>skill calls from kernel/CLI wrappers"]
+    S --> SK["skill modules<br/>(built-in re-exports, MCP proxies)"]
+    S --> C1["sub-&lt;uuid8&gt;/<br/>(child session, same layout)"]
+    C1 --> C2["sub-&lt;uuid8&gt;/ …"]
+```
+
+`meta.json` is written atomically (`.tmp` + rename). `aggregate_child_metrics()` recursively merges child stats into the parent session.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,0 +1,121 @@
+# Concepts
+
+The design pillars of nano-rlm, per the [official documentation](https://deepwiki.com/PrimeIntellect-ai/nano-rlm) and the source.
+
+## 1. Minimal tool interface
+
+Instead of a large suite of specialized tools (`read_file`, `write_file`, `execute_shell`, …), the model gets a small set of high-capability built-ins — with the `ipython` tool as the centerpiece. The active set is chosen by tooling presets (`RLM_TOOLING` / `RLM_BUILTIN_TOOLS`):
+
+```mermaid
+flowchart LR
+    MODEL["LLM"] -->|"one tool call per turn"| REG{"Tool registry"}
+    REG --> BASH["bash<br/>fresh bash -c subshell"]
+    REG --> EDIT["edit<br/>single-occurrence replace"]
+    REG --> IPY["ipython<br/>persistent kernel"]
+    IPY --> PY["Python"]
+    IPY --> SH["!cmd / %%bash"]
+    IPY --> SK["skills + await rlm()"]
+```
+
+The `dual` preset (default) exposes all three tools plus the `bash`/`edit` skills. Because `ipython` runs a real kernel, the agent has the full power of Python — file manipulation, data processing, HTTP, shell escapes — without bespoke tools.
+
+## 2. Persistent state
+
+The IPython kernel stays alive for the entire session lifecycle. Variables, imports, and in-memory data survive across turns — and across context compactions.
+
+```mermaid
+flowchart TB
+    subgraph S["Session lifecycle"]
+        T1["turn 1<br/>df = pandas.read_csv(...)"] --> T2["turn 2<br/>df.describe()"]
+        T2 --> C{"context too large?"}
+        C -->|yes| COMP["compaction:<br/>messages := [system, summary]"]
+        COMP --> T3["turn 3<br/>df still in memory ✓"]
+        C -->|no| T3
+    end
+    K[("single persistent kernel<br/>never restarted by compaction")] -.-> T1 & T2 & T3
+```
+
+The kernel is also credential-isolated: `build_kernel_env()` passes a whitelist of environment variables (PATH, HOME, locale, cert vars, explicit `RLM_KERNEL_ENV` entries) — credentials are de-ambiented by omission, not filtered by name.
+
+## 3. Context compaction
+
+When a turn's `prompt_tokens` reaches `RLM_SUMMARIZE_AT_TOKENS`, the engine triggers a compaction turn:
+
+```mermaid
+sequenceDiagram
+    participant E as RLMEngine
+    participant L as LLM
+    participant K as IPython kernel
+
+    E->>E: prompt_tokens ≥ summarize_at_tokens<br/>(and max_compactions not exhausted)
+    E->>E: append CHECKPOINT_COMPACTION_PROMPT
+    E->>L: summary call (tool_choice="none")
+    L-->>E: handoff summary
+    E->>E: messages := [system, framing + summary]<br/>log compaction event + CompactionApplied metric
+    Note over K: kernel untouched —<br/>all variables intact
+    E->>L: loop resumes from summary
+```
+
+If the agent stalls on the summary, a `REPL_RESTART_NOTE` reminds it that the kernel state is still available.
+
+## 4. Native recursion
+
+Agents spawn sub-agents by calling `await rlm("...")` inside their own kernel — hierarchical task decomposition without external orchestration.
+
+```mermaid
+sequenceDiagram
+    participant K as Parent kernel
+    participant B as Broker (unix socket)
+    participant S as SessionTreeSupervisor
+    participant E2 as Child RLMEngine
+
+    K->>B: rlm.run(prompt)<br/>rlm.broker over framed JSON RPC
+    B->>S: BrokerRunRequest
+    S->>S: validate capability + scope<br/>check depth / call limits
+    S->>E2: spawn (depth + 1, child session dir)
+    E2-->>S: RLMResult(answer, usage, metrics)
+    S-->>B: response
+    B-->>K: RLMResult
+```
+
+- Depth and concurrency are bounded (`RLM_MAX_DEPTH`, `RLM_MAX_SUBAGENT_CALLS`, per-depth semaphores).
+- Each child gets its own session directory (`sub-<uuid8>/`) and kernel.
+- `asyncio.gather` over multiple `rlm()` calls gives parallel sub-agents.
+
+## 5. Skills system
+
+Three skill sources are unified into pre-imported, callable modules in the kernel namespace:
+
+```mermaid
+flowchart TB
+    subgraph Sources
+        BI["Built-in<br/>rlm/skills/<br/>bash · edit · search"]
+        INST["Installed<br/>rlm-skill-* packages<br/>(uv tool install --with-editable)"]
+        MCP["MCP servers<br/>RLM_MCP_CONFIG"]
+    end
+    BI -->|"re-export module"| DIR["session dir<br/>*.py modules"]
+    MCP -->|"proxy module<br/>__rlm_brokered__ = True"| DIR
+    INST --> KER
+    DIR --> KER["Kernel startup injection<br/>_CallableModule wrapper"]
+    KER -->|"await skill(...) == await skill.run(...)"| AGENT["Agent code"]
+    AGENT -->|"brokered: skill.call RPC"| SUP["Supervisor<br/>(credentials stay out of kernel)"]
+```
+
+Name collisions across sources raise an error at discovery. Every programmatic skill call is logged to `programmatic_tool_calls.jsonl` for telemetry.
+
+## 6. Git history guard
+
+Active unless `RLM_ALLOW_GIT=1`. It blocks broad-history `git log` (e.g. `--all`, `--reflog`, `--branches`) — not git in general — so evaluation agents can't mine task solutions from history.
+
+```mermaid
+flowchart LR
+    CODE["agent-generated code"] --> CHK{"find_blocked_*"}
+    CHK -->|"bash tool / !cmd / %%bash"| SH["shell parser:<br/>split && || ; |<br/>shlex per segment"]
+    CHK -->|"python code"| AST["AST visitor:<br/>tracks subprocess/os aliases<br/>literal argv only"]
+    SH --> DEC{blocked?}
+    AST --> DEC
+    DEC -->|yes| REFUSE["REFUSAL_TEMPLATE error"]
+    DEC -->|no| EXEC["execute normally"]
+```
+
+Documented bypasses (`getattr`, multi-hop reassignment, `__import__`) are accepted as out of scope — the guard is a tripwire, not a sandbox.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,144 @@
+# Configuration
+
+nano-rlm is configured entirely through environment variables, resolved by `RuntimeConfig.from_env()` (`src/rlm/config.py`). This table is generated from the source and is the authoritative reference.
+
+## Precedence
+
+```mermaid
+flowchart LR
+    CLI["CLI flags<br/>(--model, --system-prompt-path, …)"] -->|"writes env vars"| ENV["Environment<br/>RLM_* variables"]
+    ENV --> CFG["RuntimeConfig.from_env()<br/>pydantic, strict, extra-forbid"]
+    DEF["Defaults"] --> CFG
+    CFG --> ENG["RLMEngine"]
+    ACPM["ACP _meta<br/>ai.prime.rlm/runtime-v1"] -.->|"bypasses env entirely"| ENG
+```
+
+## Provider resolution
+
+The provider is resolved in priority order (`config.py:81-102`):
+
+```mermaid
+flowchart TD
+    A["RLM_API_KEY (+ RLM_BASE_URL)"] -->|set| P1["Explicit provider<br/>(base_url defaults to SDK default)"]
+    A -->|unset| B["PRIME_API_KEY<br/>(+ PRIME_TEAM_ID → X-Prime-Team-ID header)"]
+    B -->|set| P2["Prime Intellect Inference<br/>api.pinference.ai/api/v1"]
+    B -->|unset| C["OPENAI_API_KEY (+ OPENAI_BASE_URL)"]
+    C -->|set| P3["OpenAI-compatible endpoint"]
+    C -->|unset| P4["Fallback: PI Inference<br/>with placeholder key (fails on use)"]
+```
+
+## Settings reference
+
+### Model and provider
+
+| Variable | Default | Meaning |
+| ---------- | --------- | --------- |
+| `RLM_MODEL` | `openai/gpt-5-mini` | Model slug passed to the chat completions API |
+| `RLM_API_KEY` / `RLM_BASE_URL` | — | Explicit provider credentials (highest priority) |
+| `PRIME_API_KEY` / `PRIME_TEAM_ID` | — | Prime Intellect Inference key / team header |
+| `OPENAI_API_KEY` / `OPENAI_BASE_URL` | — | OpenAI-compatible credentials |
+| `RLM_SDK_MAX_RETRIES` | `5` | Per-request SDK retries (outer wrapper retries up to ~5 min more) |
+
+### Recursion policy
+
+| Variable | Default | Meaning |
+| ---------- | --------- | --------- |
+| `RLM_MAX_DEPTH` | `0` | Max sub-agent depth; `0` disables recursion |
+| `RLM_MAX_CONCURRENT_SUBAGENTS` | `max(4, RLM_MAX_DEPTH)` | Live sub-agent cap; must be ≥ `RLM_MAX_DEPTH` |
+| `RLM_MAX_SUBAGENT_CALLS` | `64` | Total accepted recursive calls per session tree |
+| `RLM_DEPTH` | `0` | Current depth identity — set by the supervisor in-kernel, not by users |
+
+### Execution and budget
+
+| Variable | Default | Meaning |
+| ---------- | --------- | --------- |
+| `RLM_EXEC_TIMEOUT` | `300` | Seconds per `ipython`/`bash` execution (ipython hard cap: 600) |
+| `RLM_MAX_TOKENS` | unset | Completion-token budget; unset/`0` disables |
+| `RLM_SUMMARIZE_AT_TOKENS` | unset | Prompt-token threshold that triggers auto-compaction |
+| `RLM_MAX_COMPACTIONS` | unset | Cap on compaction turns per session |
+
+### Tools and skills
+
+| Variable | Default | Meaning |
+| ---------- | --------- | --------- |
+| `RLM_TOOLING` | `dual` | Tooling preset (see below) |
+| `RLM_BUILTIN_TOOLS` | preset | Comma-separated tool allowlist; overrides the preset |
+| `RLM_SKILLS` | preset skills | Built-in skills to enable (`bash`, `edit`, `search`) |
+| `RLM_MCP_CONFIG` | — | Standard `mcpServers` JSON; tools become brokered skills |
+| `SERPER_API_KEY` | — | Serper key for the brokered `search` skill (supervisor-only, never enters the kernel) |
+
+### Prompt and behavior
+
+| Variable | Default | Meaning |
+| ---------- | --------- | --------- |
+| `RLM_SYSTEM_PROMPT_PATH` | — | File whose contents replace the built-in system prompt |
+| `RLM_APPEND_TO_SYSTEM_PROMPT` | — | Text appended to the system prompt (ignored if path is set) |
+| `RLM_ALLOW_GIT` | unset | `1` disables the git-history guard |
+
+### Environment and storage
+
+| Variable | Default | Meaning |
+| ---------- | --------- | --------- |
+| `RLM_HOME` | `~/.rlm` | Root for session storage |
+| `RLM_SESSION_DIR` | auto | Session dir override; set in-kernel, read by the engine |
+| `RLM_KERNEL_ENV` | — | JSON object of extra env vars passed to the kernel (whitelist-based) |
+| `RLM_EXTRA_UV_ARGS` | — | Extra `uv tool install` args at bootstrap (`install.sh`) |
+
+## Tooling presets
+
+Selected by `RLM_TOOLING`, overridable with `RLM_BUILTIN_TOOLS` (`tools/registry.py`):
+
+| Preset | Built-in tools | Built-in skills |
+| -------- | --------------- | ----------------- |
+| `dual` (default) | `bash`, `edit`, `ipython` | `bash`, `edit` |
+| `tools` | `bash`, `edit`, `ipython` | — |
+| `skills` | `ipython` | `bash`, `edit` |
+
+```mermaid
+flowchart TD
+    T{"RLM_BUILTIN_TOOLS set?"} -->|yes| O["explicit tool allowlist"]
+    T -->|no| P{"RLM_TOOLING preset"}
+    P --> D["dual: tools + skills parity"]
+    P --> TO["tools: model-facing tools only"]
+    P --> SK["skills: ipython tool,<br/>bash/edit via skill calls"]
+```
+
+## Configuration shape
+
+`RuntimeConfig` composes three frozen pydantic models:
+
+```mermaid
+classDiagram
+    class RuntimeConfig {
+        +model: str
+        +provider: ProviderConfig
+        +invocation: InvocationContext
+        +policy: ExecutionPolicy
+        +from_env()$
+    }
+    class ProviderConfig {
+        +api_key
+        +base_url
+        +max_retries = 5
+        +default_headers
+    }
+    class InvocationContext {
+        +depth = 0
+        +child()
+    }
+    class ExecutionPolicy {
+        +max_depth = 0
+        +max_concurrent_subagents
+        +max_subagent_calls = 64
+        +exec_timeout = 300
+        +max_tokens
+        +summarize_at_tokens
+        +max_compactions
+        +allow_git = false
+    }
+    RuntimeConfig *-- ProviderConfig
+    RuntimeConfig *-- InvocationContext
+    RuntimeConfig *-- ExecutionPolicy
+```
+
+All models are frozen, strict, and forbid extra fields — a typo'd setting fails fast instead of being silently ignored.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# nano-rlm Documentation
+
+Mermaid-based documentation for nano-rlm, a minimalistic CLI coding agent built around a persistent IPython execution environment and native recursion.
+
+Grounded in the [official deepwiki documentation](https://deepwiki.com/PrimeIntellect-ai/nano-rlm) and verified against the source under `src/rlm/`. All diagrams render natively on GitHub.
+
+| Document | Contents |
+| ---------- | ---------- |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | System components, the agent turn loop, session layout on disk |
+| [CONCEPTS.md](CONCEPTS.md) | Single-tool interface, persistent state, context compaction, native recursion, skills, git guard |
+| [USER_FLOW.md](USER_FLOW.md) | CLI flows (headless, ACP), recursion flow, lifecycle sequence diagrams |
+| [CONFIGURATION.md](CONFIGURATION.md) | Every `RLM_*` setting, provider resolution, tooling presets, precedence rules |

--- a/docs/USER_FLOW.md
+++ b/docs/USER_FLOW.md
@@ -1,0 +1,111 @@
+# User Flow
+
+How a user (or a host application) drives nano-rlm, from invocation to a finished session.
+
+## Entry flow
+
+The `rlm` console script (`cli.py:main`) has three modes:
+
+```mermaid
+flowchart TD
+    START["rlm [flags] [prompt]"] --> FLAGS["apply CLI flags<br/>--model → RLM_MODEL<br/>--system-prompt-path → RLM_SYSTEM_PROMPT_PATH<br/>--append-to-system-prompt → RLM_APPEND_TO_SYSTEM_PROMPT"]
+    FLAGS --> MODE{mode?}
+    MODE -->|"--acp (no prompt)"| ACP["serve_acp()<br/>ACP over stdio"]
+    MODE -->|"prompt given"| HEADLESS["rlm.run(prompt)<br/>print answer"]
+    MODE -->|"no prompt"| TUI["interactive mode<br/>(TUI placeholder)"]
+```
+
+CLI flags simply write environment variables before config resolution, so precedence is always: CLI flag > environment > default.
+
+## Headless run
+
+The most common flow — one prompt, one answer:
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as rlm CLI
+    participant E as RLMEngine
+    participant L as LLM
+    participant K as IPython kernel
+    participant S as Session
+
+    U->>C: rlm "fix the failing test"
+    C->>E: rlm.run(prompt)
+    E->>S: create session dir<br/>write meta.json
+    E->>K: start kernel<br/>inject skills + rlm callable
+    loop act–observe turns
+        E->>L: messages + tool schemas
+        L-->>E: assistant msg + tool call
+        E->>K: execute code
+        K-->>E: output
+        E->>S: log assistant + tool_result
+    end
+    L-->>E: final answer (no tool calls)
+    E->>S: finalize meta.json<br/>(usage, metrics, answer_preview)
+    E-->>C: RLMResult
+    C-->>U: print answer
+```
+
+## Stop reasons
+
+Every run ends with a `stop_reason` recorded in metrics:
+
+```mermaid
+flowchart LR
+    RUN["run loop"] --> D["done<br/>model stopped calling tools"]
+    RUN --> TB["token_budget<br/>RLM_MAX_TOKENS exhausted"]
+    RUN --> DL["depth_limit<br/>depth > RLM_MAX_DEPTH"]
+    RUN --> RTL["request_too_large<br/>context exceeded model limit<br/>and compaction unavailable/exhausted"]
+```
+
+## Recursion flow (user perspective)
+
+With `RLM_MAX_DEPTH ≥ 1`, the agent can decompose work itself:
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant P as Parent agent (depth 0)
+    participant C1 as Child agent (depth 1)
+    participant C2 as Child agent (depth 1)
+
+    U->>P: "audit the repo and summarize"
+    P->>P: plan: split by subsystem
+    par parallel sub-agents via asyncio.gather
+        P->>C1: await rlm("audit src/rlm/tools")
+    and
+        P->>C2: await rlm("audit src/rlm/engine.py")
+    end
+    C1-->>P: RLMResult(answer, usage)
+    C2-->>P: RLMResult(answer, usage)
+    P->>P: synthesize findings
+    P-->>U: final answer<br/>(metrics aggregate child sessions)
+```
+
+## ACP flow (host applications)
+
+`rlm --acp` speaks the Agent Client Protocol over stdio for editor/agent-host integration:
+
+```mermaid
+sequenceDiagram
+    participant H as ACP client (editor)
+    participant A as RLMACPAgent
+    participant E as RLMEngine
+
+    H->>A: initialize
+    A-->>H: capabilities + ai.prime.rlm/contract-v1
+    H->>A: session/new<br/>_meta: ai.prime.rlm/runtime-v1<br/>(session_id, model, provider, policy, …)
+    A->>E: create Session + RLMEngine
+    loop prompting
+        H->>A: session/prompt (text blocks)
+        A->>E: engine.prompt(text)
+        E-->>A: answer + usage
+        A-->>H: session_update + PromptResponse<br/>_meta: session snapshot
+    end
+    H->>A: session/close
+    A->>E: aclose() (finalize session)
+    A-->>H: ai.prime.rlm/session-v1 snapshot<br/>(authoritative, credential-free)
+```
+
+ACP sessions bypass environment-variable config entirely: the runtime contract in `_meta` is the full configuration. There is no `session/load` by design — sessions are not resumable over ACP.


### PR DESCRIPTION
## Summary

Adds a `docs/` knowledge base with Mermaid diagrams (rendered natively on GitHub), grounded in the source under `src/rlm/`:

- `docs/ARCHITECTURE.md` — system component graph, the act–observe turn loop, recursion tree (broker/supervisor), on-disk session layout
- `docs/CONCEPTS.md` — minimal tool interface, persistent kernel state, context compaction, native recursion (`await rlm()`), skills system, git-history guard
- `docs/USER_FLOW.md` — CLI entry modes, headless run, stop reasons, recursion flow, ACP session lifecycle
- `docs/CONFIGURATION.md` — full `RLM_*` env-var reference with defaults, provider resolution order, tooling presets (`dual`/`tools`/`skills`), config model diagram
- `AGENTS.md` — pointer to `docs/`

## Notes

- Docs-only change; no code touched. `markdownlint-cli2` passes (0 issues).
- `docs/CONFIGURATION.md` documents the current source behavior, which fixes two stale README claims without touching the README itself: `RLM_MAX_OUTPUT`/`RLM_MAX_TOOL_OUTPUT_CHARS` were removed in d4ce3e1, and the default `dual` preset enables the `bash`/`edit` skills.