### PR TITLE
feat: publish ACP lineage provenance

### DIFF
--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -54,6 +54,7 @@ from rlm.session import Session
 CONTRACT_METADATA_KEY = "ai.prime.rlm/contract-v1"
 SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
 RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
+ACP_LINEAGE_METADATA_KEY = "ai.prime.acp/lineage-v1"
 
 
 class _ContractModel(BaseModel):
@@ -154,7 +155,6 @@ class _SessionSnapshot(_ContractModel):
     programmatic_tool_call_stats: _ProgrammaticToolCallSnapshot
     supervisor: _SupervisorSnapshot
     limits: _LimitsSnapshot
-    lineage: _LineageSnapshot
 
 
 @dataclass
@@ -188,8 +188,12 @@ def _session_metadata(state: _SessionState) -> dict[str, Any]:
         "last_stop_reason": state.last_stop_reason,
         **state.engine.execution_snapshot(),
     }
+    lineage = _LineageSnapshot.model_validate(snapshot.pop("lineage"))
     validated = _SessionSnapshot.model_validate(snapshot)
-    return {SESSION_METADATA_KEY: validated.model_dump(mode="json", exclude_none=True)}
+    return {
+        SESSION_METADATA_KEY: validated.model_dump(mode="json", exclude_none=True),
+        ACP_LINEAGE_METADATA_KEY: lineage.model_dump(mode="json", exclude_none=True),
+    }
 
 
 def _validation_fields(error: ValidationError) -> list[str]:

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 from importlib.metadata import version
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from acp import (
     PROTOCOL_VERSION,
@@ -103,6 +103,47 @@ class _LimitsSnapshot(_ContractModel):
     allow_git: bool
 
 
+class _LineageSessionSnapshot(_ContractModel):
+    session_id: str = Field(min_length=1)
+    parent_session_id: str | None = None
+    depth: int = Field(ge=0)
+    initial_context_id: str = Field(min_length=1)
+    spawned_by_request_id: str | None = None
+    status: Literal["running", "completed", "failed", "cancelled"]
+
+
+class _LineageContextSnapshot(_ContractModel):
+    context_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    previous_context_id: str | None = None
+    transition: Literal["root", "spawn", "compact"]
+    compaction_id: str | None = None
+
+
+class _LineageCompactionSnapshot(_ContractModel):
+    compaction_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    source_context_id: str = Field(min_length=1)
+    target_context_id: str = Field(min_length=1)
+    summary_request_id: str = Field(min_length=1)
+    status: Literal["in_progress", "completed", "failed", "cancelled"]
+
+
+class _LineageRequestSnapshot(_ContractModel):
+    request_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    context_id: str = Field(min_length=1)
+    kind: Literal["turn", "compaction"]
+    compaction_id: str | None = None
+
+
+class _LineageSnapshot(_ContractModel):
+    sessions: list[_LineageSessionSnapshot]
+    contexts: list[_LineageContextSnapshot]
+    compactions: list[_LineageCompactionSnapshot]
+    requests: list[_LineageRequestSnapshot]
+
+
 class _SessionSnapshot(_ContractModel):
     session_id: str = Field(pattern=r"^[A-Za-z0-9._:-]{1,128}$")
     last_stop_reason: str | None
@@ -113,6 +154,7 @@ class _SessionSnapshot(_ContractModel):
     programmatic_tool_call_stats: _ProgrammaticToolCallSnapshot
     supervisor: _SupervisorSnapshot
     limits: _LimitsSnapshot
+    lineage: _LineageSnapshot
 
 
 @dataclass
@@ -147,7 +189,7 @@ def _session_metadata(state: _SessionState) -> dict[str, Any]:
         **state.engine.execution_snapshot(),
     }
     validated = _SessionSnapshot.model_validate(snapshot)
-    return {SESSION_METADATA_KEY: validated.model_dump(mode="json")}
+    return {SESSION_METADATA_KEY: validated.model_dump(mode="json", exclude_none=True)}
 
 
 def _validation_fields(error: ValidationError) -> list[str]:
@@ -287,6 +329,7 @@ class RLMACPAgent(Agent):
                 session=session,
                 mcp_servers=resolved_mcp_servers,
                 runtime_config=runtime_config,
+                invocation_id=external_session_id,
             )
         except BaseException:
             session.close()
@@ -323,7 +366,9 @@ class RLMACPAgent(Agent):
                     await _cancel_and_wait(task)
                     raise
                 state.last_stop_reason = "cancelled"
-                return PromptResponse(stop_reason="cancelled")
+                return PromptResponse(
+                    stop_reason="cancelled", field_meta=_session_metadata(state)
+                )
             except Exception:
                 state.last_stop_reason = "error"
                 raise
@@ -337,7 +382,9 @@ class RLMACPAgent(Agent):
             )
             state.last_stop_reason = state.engine.stop_reason or stop_reason
             if state.closing:
-                return PromptResponse(stop_reason="cancelled")
+                return PromptResponse(
+                    stop_reason="cancelled", field_meta=_session_metadata(state)
+                )
 
             delivery = asyncio.create_task(
                 self._client.session_update(
@@ -354,7 +401,9 @@ class RLMACPAgent(Agent):
                     raise
                 if not state.closing:
                     raise
-                return PromptResponse(stop_reason="cancelled")
+                return PromptResponse(
+                    stop_reason="cancelled", field_meta=_session_metadata(state)
+                )
             finally:
                 state.delivery_task = None
 
@@ -365,6 +414,7 @@ class RLMACPAgent(Agent):
                     input_tokens=result.usage.prompt_tokens,
                     output_tokens=result.usage.completion_tokens,
                 ),
+                field_meta=_session_metadata(state),
             )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -122,10 +122,12 @@ class _LineageContextSnapshot(_ContractModel):
 
 
 class _LineageCompactionSnapshot(_ContractModel):
+    """One attempt; a completed compaction alone publishes its target context."""
+
     compaction_id: str = Field(min_length=1)
     session_id: str = Field(min_length=1)
     source_context_id: str = Field(min_length=1)
-    target_context_id: str = Field(min_length=1)
+    target_context_id: str | None = Field(default=None, min_length=1)
     summary_request_id: str = Field(min_length=1)
     status: Literal["in_progress", "completed", "failed", "cancelled"]
 

--- a/src/rlm/client.py
+++ b/src/rlm/client.py
@@ -15,6 +15,18 @@ from openai import (
 from pydantic import ValidationError
 
 from rlm.config import ProviderConfig
+from rlm.lineage import (
+    COMPACTION_ID_HEADER,
+    CONTEXT_ID_HEADER,
+    DEPTH_HEADER,
+    LINEAGE_HEADER_NAMES,
+    PARENT_SESSION_ID_HEADER,
+    PREVIOUS_CONTEXT_ID_HEADER,
+    REQUEST_ID_HEADER,
+    SESSION_ID_HEADER,
+    TRANSITION_HEADER,
+    RequestProvenance,
+)
 from rlm.types import TokenUsage
 
 IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
@@ -63,7 +75,12 @@ def make_client(provider: ProviderConfig | None = None) -> AsyncOpenAI:
     reserved = sorted(
         name
         for name in provider.headers
-        if name.lower() in {IDEMPOTENCY_KEY_HEADER.lower(), RETRY_COUNT_HEADER}
+        if name.lower()
+        in {
+            IDEMPOTENCY_KEY_HEADER.lower(),
+            RETRY_COUNT_HEADER,
+            *(header.lower() for header in LINEAGE_HEADER_NAMES),
+        }
     )
     if reserved:
         raise ValueError(f"provider headers contain reserved names: {reserved}")
@@ -75,9 +92,25 @@ def make_client(provider: ProviderConfig | None = None) -> AsyncOpenAI:
     )
 
 
-def model_call_headers(call_id: str) -> dict[str, str]:
-    """Build transport headers for one idempotent model call."""
-    return {IDEMPOTENCY_KEY_HEADER: call_id}
+def model_call_headers(provenance: RequestProvenance | str) -> dict[str, str]:
+    """Build transport headers for one idempotent, attributable model call."""
+    if isinstance(provenance, str):
+        return {IDEMPOTENCY_KEY_HEADER: provenance}
+    headers = {
+        IDEMPOTENCY_KEY_HEADER: provenance.request_id,
+        REQUEST_ID_HEADER: provenance.request_id,
+        SESSION_ID_HEADER: provenance.session_id,
+        CONTEXT_ID_HEADER: provenance.context_id,
+        TRANSITION_HEADER: provenance.transition,
+        DEPTH_HEADER: str(provenance.depth),
+    }
+    if provenance.parent_session_id is not None:
+        headers[PARENT_SESSION_ID_HEADER] = provenance.parent_session_id
+    if provenance.previous_context_id is not None:
+        headers[PREVIOUS_CONTEXT_ID_HEADER] = provenance.previous_context_id
+    if provenance.compaction_id is not None:
+        headers[COMPACTION_ID_HEADER] = provenance.compaction_id
+    return headers
 
 
 async def call_with_retries(

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -9,6 +9,8 @@ from typing import Mapping
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Self
 
+from rlm.lineage import LINEAGE_HEADER_NAMES
+
 
 PI_INFERENCE_BASE_URL = "https://api.pinference.ai/api/v1"
 KERNEL_ENV_CONFIG_ENV = "RLM_KERNEL_ENV"
@@ -66,7 +68,11 @@ class ProviderConfig(_ConfigModel):
     @field_validator("headers")
     @classmethod
     def _reserve_transport_headers(cls, headers: dict[str, str]) -> dict[str, str]:
-        reserved_names = {"idempotency-key", "x-stainless-retry-count"}
+        reserved_names = {
+            "idempotency-key",
+            "x-stainless-retry-count",
+            *(header.lower() for header in LINEAGE_HEADER_NAMES),
+        }
         reserved = sorted(name for name in headers if name.lower() in reserved_names)
         if reserved:
             raise ValueError(f"provider headers contain reserved names: {reserved}")

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -21,6 +21,7 @@ from rlm.client import (
     model_call_headers,
 )
 from rlm.config import RuntimeConfig
+from rlm.lineage import LineageTracker
 from rlm.mcp import MCPServer, load_mcp_servers, validate_mcp_servers
 from rlm.prompt import build_system_prompt
 from rlm.session import Session
@@ -135,6 +136,9 @@ class RLMEngine:
         runtime_config: RuntimeConfig | None = None,
         supervisor: SessionTreeSupervisor | None = None,
         invocation_id: str | None = None,
+        lineage: LineageTracker | None = None,
+        parent_session_id: str | None = None,
+        spawned_by_request_id: str | None = None,
     ):
         self.runtime_config = runtime_config or RuntimeConfig.from_env()
         config = self.runtime_config
@@ -168,6 +172,15 @@ class RLMEngine:
         self._supervisor = supervisor
         self._invocation_id = invocation_id or (
             supervisor.root_id if supervisor is not None else uuid.uuid4().hex
+        )
+        self._lineage = lineage or (
+            supervisor.lineage if supervisor is not None else LineageTracker()
+        )
+        self._lineage.register_session(
+            self._invocation_id,
+            parent_session_id=parent_session_id,
+            depth=self.depth,
+            spawned_by_request_id=spawned_by_request_id,
         )
         self._owns_supervisor = False
         self._total_usage = TokenUsage()
@@ -240,6 +253,7 @@ class RLMEngine:
             messages_before = list(self._messages)
             self._messages.append({"role": "user", "content": prompt})
         branch_start_before = self._branch_start_turn
+        context_before = self._lineage.active_context(self._invocation_id)
         turn_before = self._turn
         usage_before = TokenUsage(
             prompt_tokens=self._total_usage.prompt_tokens,
@@ -270,9 +284,12 @@ class RLMEngine:
             # that really ran and remain part of session accounting.
             self._messages[:] = messages_before
             self._branch_start_turn = branch_start_before
+            self._lineage.restore_context(self._invocation_id, context_before)
             self._turn = turn_before
             if isinstance(exc, asyncio.CancelledError):
                 self._metrics.stop_reason = "cancelled"
+            else:
+                self._metrics.stop_reason = "error"
             raise
         result.usage = TokenUsage(
             prompt_tokens=self._total_usage.prompt_tokens - usage_before.prompt_tokens,
@@ -311,6 +328,7 @@ class RLMEngine:
                     cwd=self.cwd,
                     mcp_servers=self.mcp_servers,
                     root_invocation_id=self._invocation_id,
+                    lineage=self._lineage,
                 )
                 self._owns_supervisor = True
             try:
@@ -372,11 +390,15 @@ class RLMEngine:
         for turn in itertools.count(self._turn):
             self._turn = turn + 1
             # Call LLM
-            call_id = uuid.uuid4().hex
+            provenance = self._lineage.start_request(
+                self._invocation_id,
+                kind="turn",
+            )
+            call_id = provenance.request_id
             request_kwargs = {
                 "model": self.model,
                 "messages": messages,
-                "extra_headers": model_call_headers(call_id),
+                "extra_headers": model_call_headers(provenance),
             }
             if self._active_tool_schemas:
                 request_kwargs["tools"] = self._active_tool_schemas
@@ -476,7 +498,9 @@ class RLMEngine:
                     and self._supervisor is not None
                     and self._invocation_id is not None
                 ):
-                    scope_id = await self._supervisor.open_scope(self._invocation_id)
+                    scope_id = await self._supervisor.open_scope(
+                        self._invocation_id, call_id
+                    )
                 try:
                     if scope_id is not None:
                         repl.set_broker_scope(scope_id)
@@ -630,6 +654,7 @@ class RLMEngine:
             self._repl = None
         if self.session is not None:
             if self._has_result:
+                self._lineage.set_session_status(self._invocation_id, "completed")
                 direct_tool_stats = None
                 child_tool_stats = None
                 if self._supervisor is not None and self._invocation_id is not None:
@@ -650,6 +675,12 @@ class RLMEngine:
                     trusted_child_tool_stats=child_tool_stats,
                 )
             else:
+                status = (
+                    "cancelled"
+                    if self._metrics.stop_reason == "cancelled" or not self._started
+                    else "failed"
+                )
+                self._lineage.set_session_status(self._invocation_id, status)
                 self.session.close()
 
     def _programmatic_tool_call_stats(
@@ -711,11 +742,16 @@ class RLMEngine:
         if self._repl is not None:
             checkpoint_prompt += REPL_RESTART_NOTE
         messages.append({"role": "user", "content": checkpoint_prompt})
-        call_id = uuid.uuid4().hex
+        compaction = self._lineage.begin_compaction(self._invocation_id)
+        provenance = self._lineage.start_request(
+            self._invocation_id,
+            kind="compaction",
+            compaction_id=compaction.compaction_id,
+        )
         request_kwargs: dict = {
             "model": self.model,
             "messages": messages,
-            "extra_headers": model_call_headers(call_id),
+            "extra_headers": model_call_headers(provenance),
         }
         if active_tools:
             request_kwargs["tools"] = active_tools
@@ -725,14 +761,17 @@ class RLMEngine:
                 self.client.chat.completions.create,
                 **request_kwargs,
             )
-        except BaseException:
+            usage = extract_usage(response)
+            summary_text = response.choices[0].message.content or ""
+        except BaseException as exc:
+            self._lineage.finish_compaction(
+                compaction.compaction_id,
+                "cancelled" if isinstance(exc, asyncio.CancelledError) else "failed",
+            )
             messages.pop()
             raise
-        usage = extract_usage(response)
         self._total_usage.prompt_tokens += usage.prompt_tokens
         self._total_usage.completion_tokens += usage.completion_tokens
-
-        summary_text = response.choices[0].message.content or ""
 
         system_msg = messages[0]
         compacted_user_content = POST_COMPACTION_FRAMING + "\n\n" + summary_text
@@ -740,6 +779,7 @@ class RLMEngine:
             system_msg,
             {"role": "user", "content": compacted_user_content},
         ]
+        self._lineage.finish_compaction(compaction.compaction_id, "completed")
 
         # Log the compaction for traceability.
         self.session.log(
@@ -814,6 +854,7 @@ class RLMEngine:
                 "max_tool_output_chars": self.runtime_config.policy.max_tool_output_chars,
                 "allow_git": self.runtime_config.policy.allow_git,
             },
+            "lineage": self._lineage.snapshot(),
         }
         return snapshot
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -248,7 +248,13 @@ class RLMEngine:
         self._has_result = False
 
         if not self._started:
-            await self._start(prompt)
+            try:
+                await self._start(prompt)
+            except BaseException as exc:
+                self._metrics.stop_reason = (
+                    "cancelled" if isinstance(exc, asyncio.CancelledError) else "error"
+                )
+                raise
             messages_before = self._messages[:1]
         else:
             messages_before = list(self._messages)
@@ -676,9 +682,7 @@ class RLMEngine:
                 )
             else:
                 status = (
-                    "cancelled"
-                    if self._metrics.stop_reason == "cancelled" or not self._started
-                    else "failed"
+                    "failed" if self._metrics.stop_reason == "error" else "cancelled"
                 )
                 self._lineage.set_session_status(self._invocation_id, status)
                 self.session.close()

--- a/src/rlm/lineage.py
+++ b/src/rlm/lineage.py
@@ -1,0 +1,193 @@
+"""Stable model-call lineage for recursive sessions and context compactions."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Literal
+
+
+ContextTransition = Literal["root", "spawn", "compact"]
+RequestKind = Literal["turn", "compaction"]
+SessionStatus = Literal["running", "completed", "failed", "cancelled"]
+CompactionStatus = Literal["in_progress", "completed", "failed", "cancelled"]
+
+REQUEST_ID_HEADER = "X-RLM-Request-ID"
+SESSION_ID_HEADER = "X-RLM-Session-ID"
+PARENT_SESSION_ID_HEADER = "X-RLM-Parent-Session-ID"
+CONTEXT_ID_HEADER = "X-RLM-Context-ID"
+PREVIOUS_CONTEXT_ID_HEADER = "X-RLM-Previous-Context-ID"
+TRANSITION_HEADER = "X-RLM-Transition"
+COMPACTION_ID_HEADER = "X-RLM-Compaction-ID"
+DEPTH_HEADER = "X-RLM-Depth"
+LINEAGE_HEADER_NAMES = (
+    REQUEST_ID_HEADER,
+    SESSION_ID_HEADER,
+    PARENT_SESSION_ID_HEADER,
+    CONTEXT_ID_HEADER,
+    PREVIOUS_CONTEXT_ID_HEADER,
+    TRANSITION_HEADER,
+    COMPACTION_ID_HEADER,
+    DEPTH_HEADER,
+)
+
+
+@dataclass(frozen=True)
+class RequestProvenance:
+    request_id: str
+    session_id: str
+    parent_session_id: str | None
+    context_id: str
+    previous_context_id: str | None
+    transition: ContextTransition
+    compaction_id: str | None
+    depth: int
+
+
+@dataclass(frozen=True)
+class Compaction:
+    compaction_id: str
+    session_id: str
+    source_context_id: str
+    target_context_id: str
+
+
+class LineageTracker:
+    """Append-only provenance shared by every engine in one recursive tree."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, dict] = {}
+        self._contexts: dict[str, dict] = {}
+        self._pending_contexts: dict[str, dict] = {}
+        self._compactions: dict[str, dict] = {}
+        self._requests: dict[str, dict] = {}
+        self._active_contexts: dict[str, str] = {}
+
+    def register_session(
+        self,
+        session_id: str,
+        *,
+        parent_session_id: str | None,
+        depth: int,
+        spawned_by_request_id: str | None = None,
+    ) -> str:
+        existing = self._sessions.get(session_id)
+        if existing is not None:
+            return existing["initial_context_id"]
+
+        context_id = uuid.uuid4().hex
+        session = {
+            "session_id": session_id,
+            "depth": depth,
+            "initial_context_id": context_id,
+            "status": "running",
+        }
+        if parent_session_id is not None:
+            session["parent_session_id"] = parent_session_id
+        if spawned_by_request_id is not None:
+            session["spawned_by_request_id"] = spawned_by_request_id
+        self._sessions[session_id] = session
+
+        context = {
+            "context_id": context_id,
+            "session_id": session_id,
+            "transition": "root" if parent_session_id is None else "spawn",
+        }
+        self._contexts[context_id] = context
+        self._active_contexts[session_id] = context_id
+        return context_id
+
+    def set_session_status(self, session_id: str, status: SessionStatus) -> None:
+        self._sessions[session_id]["status"] = status
+
+    def active_context(self, session_id: str) -> str:
+        return self._active_contexts[session_id]
+
+    def restore_context(self, session_id: str, context_id: str) -> None:
+        context = self._contexts[context_id]
+        if context["session_id"] != session_id:
+            raise ValueError("context does not belong to session")
+        self._active_contexts[session_id] = context_id
+
+    def start_request(
+        self,
+        session_id: str,
+        *,
+        kind: RequestKind,
+        compaction_id: str | None = None,
+    ) -> RequestProvenance:
+        if kind == "compaction" and compaction_id is None:
+            raise ValueError("compaction requests require a compaction ID")
+        session = self._sessions[session_id]
+        context_id = self._active_contexts[session_id]
+        context = self._contexts[context_id]
+        request_id = uuid.uuid4().hex
+        request = {
+            "request_id": request_id,
+            "session_id": session_id,
+            "context_id": context_id,
+            "kind": kind,
+        }
+        if compaction_id is not None:
+            request["compaction_id"] = compaction_id
+        self._requests[request_id] = request
+
+        if kind == "compaction":
+            self._compactions[compaction_id]["summary_request_id"] = request_id
+
+        return RequestProvenance(
+            request_id=request_id,
+            session_id=session_id,
+            parent_session_id=session.get("parent_session_id"),
+            context_id=context_id,
+            previous_context_id=context.get("previous_context_id"),
+            transition=context["transition"],
+            compaction_id=compaction_id or context.get("compaction_id"),
+            depth=session["depth"],
+        )
+
+    def begin_compaction(self, session_id: str) -> Compaction:
+        compaction_id = uuid.uuid4().hex
+        source_context_id = self._active_contexts[session_id]
+        target_context_id = uuid.uuid4().hex
+        self._pending_contexts[compaction_id] = {
+            "context_id": target_context_id,
+            "session_id": session_id,
+            "previous_context_id": source_context_id,
+            "transition": "compact",
+            "compaction_id": compaction_id,
+        }
+        self._compactions[compaction_id] = {
+            "compaction_id": compaction_id,
+            "session_id": session_id,
+            "source_context_id": source_context_id,
+            "target_context_id": target_context_id,
+            "status": "in_progress",
+        }
+        return Compaction(
+            compaction_id=compaction_id,
+            session_id=session_id,
+            source_context_id=source_context_id,
+            target_context_id=target_context_id,
+        )
+
+    def finish_compaction(self, compaction_id: str, status: CompactionStatus) -> None:
+        compaction = self._compactions[compaction_id]
+        if status == "in_progress":
+            raise ValueError("a compaction cannot finish in progress")
+        compaction["status"] = status
+        self._contexts[compaction["target_context_id"]] = self._pending_contexts.pop(
+            compaction_id
+        )
+        if status == "completed":
+            self._active_contexts[compaction["session_id"]] = compaction[
+                "target_context_id"
+            ]
+
+    def snapshot(self) -> dict[str, list[dict]]:
+        return {
+            "sessions": [entry.copy() for entry in self._sessions.values()],
+            "contexts": [entry.copy() for entry in self._contexts.values()],
+            "compactions": [entry.copy() for entry in self._compactions.values()],
+            "requests": [entry.copy() for entry in self._requests.values()],
+        }

--- a/src/rlm/lineage.py
+++ b/src/rlm/lineage.py
@@ -121,6 +121,7 @@ class LineageTracker:
         session = self._sessions[session_id]
         context_id = self._active_contexts[session_id]
         context = self._contexts[context_id]
+        effective_compaction_id = compaction_id or context.get("compaction_id")
         request_id = uuid.uuid4().hex
         request = {
             "request_id": request_id,
@@ -128,8 +129,8 @@ class LineageTracker:
             "context_id": context_id,
             "kind": kind,
         }
-        if compaction_id is not None:
-            request["compaction_id"] = compaction_id
+        if effective_compaction_id is not None:
+            request["compaction_id"] = effective_compaction_id
         self._requests[request_id] = request
 
         if kind == "compaction":
@@ -142,7 +143,7 @@ class LineageTracker:
             context_id=context_id,
             previous_context_id=context.get("previous_context_id"),
             transition=context["transition"],
-            compaction_id=compaction_id or context.get("compaction_id"),
+            compaction_id=effective_compaction_id,
             depth=session["depth"],
         )
 

--- a/src/rlm/lineage.py
+++ b/src/rlm/lineage.py
@@ -162,7 +162,6 @@ class LineageTracker:
             "compaction_id": compaction_id,
             "session_id": session_id,
             "source_context_id": source_context_id,
-            "target_context_id": target_context_id,
             "status": "in_progress",
         }
         return Compaction(
@@ -177,13 +176,12 @@ class LineageTracker:
         if status == "in_progress":
             raise ValueError("a compaction cannot finish in progress")
         compaction["status"] = status
-        self._contexts[compaction["target_context_id"]] = self._pending_contexts.pop(
-            compaction_id
-        )
+        target = self._pending_contexts.pop(compaction_id)
         if status == "completed":
-            self._active_contexts[compaction["session_id"]] = compaction[
-                "target_context_id"
-            ]
+            target_context_id = target["context_id"]
+            self._contexts[target_context_id] = target
+            compaction["target_context_id"] = target_context_id
+            self._active_contexts[compaction["session_id"]] = target_context_id
 
     def snapshot(self) -> dict[str, list[dict]]:
         return {

--- a/src/rlm/lineage.py
+++ b/src/rlm/lineage.py
@@ -98,7 +98,13 @@ class LineageTracker:
         return context_id
 
     def set_session_status(self, session_id: str, status: SessionStatus) -> None:
-        self._sessions[session_id]["status"] = status
+        session = self._sessions[session_id]
+        # A session has one terminal outcome. Cleanup can observe cancellation after
+        # completed work (for example while awaiting a shielded close task), but that
+        # later observation must not rewrite the execution result.
+        if session["status"] != "running":
+            return
+        session["status"] = status
 
     def active_context(self, session_id: str) -> str:
         return self._active_contexts[session_id]

--- a/src/rlm/lineage.py
+++ b/src/rlm/lineage.py
@@ -1,4 +1,4 @@
-"""Stable model-call lineage for recursive sessions and context compactions."""
+"""Stable ACP model-call lineage for recursive sessions and context compactions."""
 
 from __future__ import annotations
 
@@ -12,14 +12,14 @@ RequestKind = Literal["turn", "compaction"]
 SessionStatus = Literal["running", "completed", "failed", "cancelled"]
 CompactionStatus = Literal["in_progress", "completed", "failed", "cancelled"]
 
-REQUEST_ID_HEADER = "X-RLM-Request-ID"
-SESSION_ID_HEADER = "X-RLM-Session-ID"
-PARENT_SESSION_ID_HEADER = "X-RLM-Parent-Session-ID"
-CONTEXT_ID_HEADER = "X-RLM-Context-ID"
-PREVIOUS_CONTEXT_ID_HEADER = "X-RLM-Previous-Context-ID"
-TRANSITION_HEADER = "X-RLM-Transition"
-COMPACTION_ID_HEADER = "X-RLM-Compaction-ID"
-DEPTH_HEADER = "X-RLM-Depth"
+REQUEST_ID_HEADER = "X-ACP-Lineage-Request-ID"
+SESSION_ID_HEADER = "X-ACP-Lineage-Session-ID"
+PARENT_SESSION_ID_HEADER = "X-ACP-Lineage-Parent-Session-ID"
+CONTEXT_ID_HEADER = "X-ACP-Lineage-Context-ID"
+PREVIOUS_CONTEXT_ID_HEADER = "X-ACP-Lineage-Previous-Context-ID"
+TRANSITION_HEADER = "X-ACP-Lineage-Transition"
+COMPACTION_ID_HEADER = "X-ACP-Lineage-Compaction-ID"
+DEPTH_HEADER = "X-ACP-Lineage-Depth"
 LINEAGE_HEADER_NAMES = (
     REQUEST_ID_HEADER,
     SESSION_ID_HEADER,

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -22,6 +22,7 @@ from rlm.broker import (
     write_frame,
 )
 from rlm.config import RuntimeConfig
+from rlm.lineage import LineageTracker
 from rlm.mcp import (
     MCPRegistry,
     MCPServer,
@@ -49,12 +50,14 @@ class _Invocation:
     runtime_config: RuntimeConfig
     cwd: str
     mcp_servers: dict[str, MCPServer]
+    spawned_by_request_id: str | None = None
 
 
 @dataclass
 class _Scope:
     invocation_id: str
     tasks: set[asyncio.Task[Any]]
+    request_id: str | None = None
 
 
 def depth_capacities(max_depth: int, limit: int, root_depth: int = 0) -> dict[int, int]:
@@ -83,6 +86,7 @@ class SessionTreeSupervisor:
         mcp_servers: dict[str, MCPServer] | None = None,
         engine_factory: Callable[..., RLMEngine] | None = None,
         root_invocation_id: str | None = None,
+        lineage: LineageTracker | None = None,
     ) -> None:
         self._engine_factory = engine_factory
         self._server: asyncio.AbstractServer | None = None
@@ -137,6 +141,12 @@ class SessionTreeSupervisor:
             mcp_servers=dict(mcp_servers or {}),
         )
         self.root_id = root_id
+        self.lineage = lineage or LineageTracker()
+        self.lineage.register_session(
+            root_id,
+            parent_session_id=None,
+            depth=runtime_config.invocation.depth,
+        )
         self._invocations = {root_id: root}
         self._parents = {root_id: None}
         self._tool_stats: dict[str, ProgrammaticToolCallStats] = {}
@@ -222,12 +232,14 @@ class SessionTreeSupervisor:
         invocation = self._invocations[invocation_id]
         return BrokerEndpoint(self._socket_path, invocation.capability)
 
-    async def open_scope(self, invocation_id: str) -> str:
+    async def open_scope(
+        self, invocation_id: str, request_id: str | None = None
+    ) -> str:
         async with self._lock:
             if self._closed or invocation_id not in self._invocations:
                 raise RuntimeError("recursive invocation is no longer active")
             scope_id = secrets.token_urlsafe(24)
-            self._scopes[scope_id] = _Scope(invocation_id, set())
+            self._scopes[scope_id] = _Scope(invocation_id, set(), request_id)
             return scope_id
 
     async def close_scope(self, scope_id: str) -> None:
@@ -258,7 +270,9 @@ class SessionTreeSupervisor:
                     self._limit_result(parent, "recursive call limit reached")
                 )
             self._total_calls += 1
-            task = asyncio.create_task(self._run_child(parent_id, prompt))
+            task = asyncio.create_task(
+                self._run_child(parent_id, prompt, scope.request_id)
+            )
             self._tasks.add(task)
             self._child_tasks.add(task)
             scope.tasks.add(task)
@@ -308,6 +322,7 @@ class SessionTreeSupervisor:
         self,
         parent_id: str,
         prompt: str,
+        spawned_by_request_id: str | None,
     ) -> RLMResult:
         parent = self._invocations[parent_id]
         child_context = parent.runtime_config.invocation.child()
@@ -326,12 +341,19 @@ class SessionTreeSupervisor:
                 runtime_config=child_config,
                 cwd=parent.cwd,
                 mcp_servers=parent.mcp_servers,
+                spawned_by_request_id=spawned_by_request_id,
             )
-            parent.session.log_sub_spawn(child_session.dir.name, "(brokered rlm())")
+            self.lineage.register_session(
+                child_id,
+                parent_session_id=parent_id,
+                depth=child_context.depth,
+                spawned_by_request_id=spawned_by_request_id,
+            )
             # Everything from session creation to here is synchronous; the try
             # must start before the first await so a cancellation while waiting
             # for the lock still closes the session and clears the registry.
             try:
+                parent.session.log_sub_spawn(child_session.dir.name, "(brokered rlm())")
                 async with self._lock:
                     if self._closed:
                         raise asyncio.CancelledError
@@ -351,7 +373,15 @@ class SessionTreeSupervisor:
                     supervisor=self,
                     invocation_id=child.id,
                 )
-                return await engine.run(prompt)
+                result = await engine.run(prompt)
+                self.lineage.set_session_status(child_id, "completed")
+                return result
+            except asyncio.CancelledError:
+                self.lineage.set_session_status(child_id, "cancelled")
+                raise
+            except BaseException:
+                self.lineage.set_session_status(child_id, "failed")
+                raise
             finally:
                 # Close synchronously first: the lock acquisition below can be
                 # interrupted by a second cancellation, but the session handle

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -87,11 +87,13 @@ class _Engine:
         session,
         mcp_servers: dict[str, Any],
         runtime_config=None,
+        invocation_id: str,
     ) -> None:
         self.cwd = cwd
         self.session = session
         self.mcp_servers = mcp_servers
         self.runtime_config = runtime_config
+        self.invocation_id = invocation_id
         self.prompts: list[str] = []
         self.prompt_started = asyncio.Event()
         self.closed = False
@@ -143,6 +145,25 @@ class _Engine:
                 "max_compactions": None,
                 "max_tool_output_chars": None,
                 "allow_git": False,
+            },
+            "lineage": {
+                "sessions": [
+                    {
+                        "session_id": self.invocation_id,
+                        "depth": 0,
+                        "initial_context_id": "test-context",
+                        "status": "completed" if self.closed else "running",
+                    }
+                ],
+                "contexts": [
+                    {
+                        "context_id": "test-context",
+                        "session_id": self.invocation_id,
+                        "transition": "root",
+                    }
+                ],
+                "compactions": [],
+                "requests": [],
             },
         }
 
@@ -334,6 +355,18 @@ async def test_model_call_idempotency_survives_retry_and_compaction(
     assert (
         len({header["Idempotency-Key"] for header in (turn, compaction, resumed)}) == 3
     )
+    assert all(
+        header["Idempotency-Key"] == header["X-RLM-Request-ID"]
+        for header in (turn, compaction, resumed)
+    )
+    assert turn["X-RLM-Session-ID"] == engine._invocation_id
+    assert turn["X-RLM-Context-ID"] == compaction["X-RLM-Context-ID"]
+    assert turn["X-RLM-Transition"] == "root"
+    assert "X-RLM-Compaction-ID" not in turn
+    assert compaction["X-RLM-Compaction-ID"] == resumed["X-RLM-Compaction-ID"]
+    assert resumed["X-RLM-Previous-Context-ID"] == turn["X-RLM-Context-ID"]
+    assert resumed["X-RLM-Context-ID"] != turn["X-RLM-Context-ID"]
+    assert resumed["X-RLM-Transition"] == "compact"
 
 
 async def test_latest_cancelled_prompt_does_not_finalize_prior_result(session):
@@ -429,6 +462,45 @@ async def test_engine_failed_prompt_can_be_retried(session):
         {"role": "user", "content": "continue"},
         {"role": "assistant", "content": "continued"},
     ]
+
+
+async def test_failed_prompt_restores_pre_compaction_context(session):
+    client = DummyClient(
+        [
+            DummyMessage(tool_calls=[DummyToolCall("add", {"a": 1, "b": 2})]),
+            DummyMessage(content="summary"),
+            DummyMessage(tool_calls=[DummyToolCall("boom", {})]),
+            DummyMessage(content="continued"),
+        ]
+    )
+    config = RuntimeConfig(
+        model="test-model",
+        provider=ProviderConfig(base_url=None, api_key="test-key"),
+        invocation=InvocationContext(),
+        policy=ExecutionPolicy(summarize_at_tokens=1),
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await engine.prompt("fail after compacting")
+
+    try:
+        result = await engine.prompt("continue")
+    finally:
+        engine.close()
+
+    initial, summary, compacted, retried = [
+        call["extra_headers"] for call in client.calls
+    ]
+    assert result.answer == "continued"
+    assert summary["X-RLM-Context-ID"] == initial["X-RLM-Context-ID"]
+    assert compacted["X-RLM-Context-ID"] != initial["X-RLM-Context-ID"]
+    assert retried["X-RLM-Context-ID"] == initial["X-RLM-Context-ID"]
+    assert retried["X-RLM-Transition"] == "root"
 
 
 async def test_engine_cancel_masks_tool_cleanup_error(monkeypatch, session):
@@ -676,7 +748,14 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert first.usage.total_tokens == 5
     assert second.stop_reason == "end_turn"
     assert created.field_meta is None
-    assert first.field_meta is None
+    assert first.field_meta[SESSION_METADATA_KEY]["lineage"]["sessions"] == [
+        {
+            "session_id": "test-session",
+            "depth": 0,
+            "initial_context_id": "test-context",
+            "status": "running",
+        }
+    ]
 
     closed = await agent.close_session(created.session_id)
     closed_snapshot = closed.field_meta[SESSION_METADATA_KEY]
@@ -704,7 +783,7 @@ async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
 
     cancelled = await pending
     assert cancelled.stop_reason == "cancelled"
-    assert cancelled.field_meta is None
+    assert SESSION_METADATA_KEY in cancelled.field_meta
     assert engine.closed is False
     resumed = await agent.prompt(created.session_id, [text_block("after")])
     assert resumed.stop_reason == "end_turn"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -766,6 +766,38 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert engine.closed is True
 
 
+async def test_acp_prompt_snapshot_records_resumed_request_compaction(
+    monkeypatch, tmp_path
+):
+    client = DummyClient(
+        [
+            DummyMessage(tool_calls=[DummyToolCall("add", {"a": 1, "b": 2})]),
+            DummyMessage(content="summary"),
+            DummyMessage(content="done"),
+        ]
+    )
+
+    def make_engine(**kwargs):
+        return RLMEngine(client=client, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("rlm.acp.RLMEngine", make_engine)
+    agent = RLMACPAgent()
+    agent.on_connect(_Client())  # type: ignore[arg-type]
+    runtime_metadata = _runtime_metadata()
+    runtime_metadata[RUNTIME_METADATA_KEY]["policy"]["summarize_at_tokens"] = 1
+    created = await agent.new_session(str(tmp_path), **runtime_metadata)
+
+    try:
+        response = await agent.prompt(created.session_id, [text_block("compact")])
+        lineage = response.field_meta[SESSION_METADATA_KEY]["lineage"]
+        compaction_id = lineage["compactions"][0]["compaction_id"]
+
+        assert lineage["requests"][-1]["kind"] == "turn"
+        assert lineage["requests"][-1]["compaction_id"] == compaction_id
+    finally:
+        await agent.close_session(created.session_id)
+
+
 async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
     _Engine.instances.clear()
     monkeypatch.setenv("RLM_HOME", str(tmp_path / "rlm"))

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -667,6 +667,23 @@ async def test_engine_failed_start_cleans_kernel_before_retry(
     assert repls[1].stopped is True
 
 
+async def test_engine_failed_start_marks_lineage_failed(monkeypatch, session):
+    engine = RLMEngine(
+        client=DummyClient([]),  # type: ignore[arg-type]
+        session=session,
+    )
+
+    async def fail_start(prompt: str) -> None:
+        raise RuntimeError(f"cannot start: {prompt}")
+
+    monkeypatch.setattr(engine, "_start", fail_start)
+
+    with pytest.raises(RuntimeError, match="cannot start"):
+        await engine.run("first")
+
+    assert engine.execution_snapshot()["lineage"]["sessions"][0]["status"] == "failed"
+
+
 async def test_acp_failed_session_creation_closes_session(monkeypatch, tmp_path):
     session = Session(tmp_path / "session")
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -16,6 +16,7 @@ import pytest
 
 from conftest import DummyClient, DummyMessage, DummyToolCall
 from rlm.acp import (
+    ACP_LINEAGE_METADATA_KEY,
     CONTRACT_METADATA_KEY,
     RUNTIME_METADATA_KEY,
     SESSION_METADATA_KEY,
@@ -356,17 +357,22 @@ async def test_model_call_idempotency_survives_retry_and_compaction(
         len({header["Idempotency-Key"] for header in (turn, compaction, resumed)}) == 3
     )
     assert all(
-        header["Idempotency-Key"] == header["X-RLM-Request-ID"]
+        header["Idempotency-Key"] == header["X-ACP-Lineage-Request-ID"]
         for header in (turn, compaction, resumed)
     )
-    assert turn["X-RLM-Session-ID"] == engine._invocation_id
-    assert turn["X-RLM-Context-ID"] == compaction["X-RLM-Context-ID"]
-    assert turn["X-RLM-Transition"] == "root"
-    assert "X-RLM-Compaction-ID" not in turn
-    assert compaction["X-RLM-Compaction-ID"] == resumed["X-RLM-Compaction-ID"]
-    assert resumed["X-RLM-Previous-Context-ID"] == turn["X-RLM-Context-ID"]
-    assert resumed["X-RLM-Context-ID"] != turn["X-RLM-Context-ID"]
-    assert resumed["X-RLM-Transition"] == "compact"
+    assert turn["X-ACP-Lineage-Session-ID"] == engine._invocation_id
+    assert turn["X-ACP-Lineage-Context-ID"] == compaction["X-ACP-Lineage-Context-ID"]
+    assert turn["X-ACP-Lineage-Transition"] == "root"
+    assert "X-ACP-Lineage-Compaction-ID" not in turn
+    assert (
+        compaction["X-ACP-Lineage-Compaction-ID"]
+        == resumed["X-ACP-Lineage-Compaction-ID"]
+    )
+    assert (
+        resumed["X-ACP-Lineage-Previous-Context-ID"] == turn["X-ACP-Lineage-Context-ID"]
+    )
+    assert resumed["X-ACP-Lineage-Context-ID"] != turn["X-ACP-Lineage-Context-ID"]
+    assert resumed["X-ACP-Lineage-Transition"] == "compact"
 
 
 async def test_latest_cancelled_prompt_does_not_finalize_prior_result(session):
@@ -497,10 +503,10 @@ async def test_failed_prompt_restores_pre_compaction_context(session):
         call["extra_headers"] for call in client.calls
     ]
     assert result.answer == "continued"
-    assert summary["X-RLM-Context-ID"] == initial["X-RLM-Context-ID"]
-    assert compacted["X-RLM-Context-ID"] != initial["X-RLM-Context-ID"]
-    assert retried["X-RLM-Context-ID"] == initial["X-RLM-Context-ID"]
-    assert retried["X-RLM-Transition"] == "root"
+    assert summary["X-ACP-Lineage-Context-ID"] == initial["X-ACP-Lineage-Context-ID"]
+    assert compacted["X-ACP-Lineage-Context-ID"] != initial["X-ACP-Lineage-Context-ID"]
+    assert retried["X-ACP-Lineage-Context-ID"] == initial["X-ACP-Lineage-Context-ID"]
+    assert retried["X-ACP-Lineage-Transition"] == "root"
 
 
 async def test_engine_cancel_masks_tool_cleanup_error(monkeypatch, session):
@@ -748,7 +754,7 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert first.usage.total_tokens == 5
     assert second.stop_reason == "end_turn"
     assert created.field_meta is None
-    assert first.field_meta[SESSION_METADATA_KEY]["lineage"]["sessions"] == [
+    assert first.field_meta[ACP_LINEAGE_METADATA_KEY]["sessions"] == [
         {
             "session_id": "test-session",
             "depth": 0,
@@ -762,6 +768,10 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert closed_snapshot["session_id"] == "test-session"
     assert closed_snapshot["turns"] == 2
     assert closed_snapshot["last_stop_reason"] == "done"
+    assert "lineage" not in closed_snapshot
+    assert closed.field_meta[ACP_LINEAGE_METADATA_KEY]["sessions"][0]["status"] == (
+        "completed"
+    )
     assert "test-secret" not in closed.model_dump_json(by_alias=True)
     assert engine.closed is True
 
@@ -789,7 +799,7 @@ async def test_acp_prompt_snapshot_records_resumed_request_compaction(
 
     try:
         response = await agent.prompt(created.session_id, [text_block("compact")])
-        lineage = response.field_meta[SESSION_METADATA_KEY]["lineage"]
+        lineage = response.field_meta[ACP_LINEAGE_METADATA_KEY]
         compaction_id = lineage["compactions"][0]["compaction_id"]
 
         assert lineage["requests"][-1]["kind"] == "turn"
@@ -816,6 +826,7 @@ async def test_acp_cancel_keeps_session_reusable(monkeypatch, tmp_path):
     cancelled = await pending
     assert cancelled.stop_reason == "cancelled"
     assert SESSION_METADATA_KEY in cancelled.field_meta
+    assert ACP_LINEAGE_METADATA_KEY in cancelled.field_meta
     assert engine.closed is False
     resumed = await agent.prompt(created.session_id, [text_block("after")])
     assert resumed.stop_reason == "end_turn"

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -64,6 +64,7 @@ def test_completed_compaction_starts_linked_context_epoch():
     assert resumed_headers["X-RLM-Previous-Context-ID"] == source_context_id
     assert resumed_headers["X-RLM-Transition"] == "compact"
     assert resumed_headers["X-RLM-Compaction-ID"] == compaction.compaction_id
+    assert snapshot["requests"][-1]["compaction_id"] == compaction.compaction_id
     assert snapshot["compactions"] == [
         {
             "compaction_id": compaction.compaction_id,

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -149,8 +149,15 @@ def test_failed_compaction_does_not_activate_target_context():
     snapshot = lineage.snapshot()
 
     assert next_request.context_id == source_context_id
-    assert snapshot["compactions"][0]["status"] == "failed"
+    assert snapshot["compactions"] == [
+        {
+            "compaction_id": compaction.compaction_id,
+            "session_id": "trace-1",
+            "source_context_id": source_context_id,
+            "status": "failed",
+            "summary_request_id": snapshot["requests"][0]["request_id"],
+        }
+    ]
     assert [context["context_id"] for context in snapshot["contexts"]] == [
-        source_context_id,
-        compaction.target_context_id,
+        source_context_id
     ]

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -41,6 +41,17 @@ def test_root_and_child_requests_have_exact_parentage():
     assert snapshot["sessions"][1]["spawned_by_request_id"] == (root_request.request_id)
 
 
+def test_terminal_session_status_cannot_be_overwritten():
+    lineage = LineageTracker()
+    lineage.register_session("trace-1", parent_session_id=None, depth=0)
+
+    lineage.set_session_status("trace-1", "completed")
+    lineage.set_session_status("trace-1", "cancelled")
+    lineage.set_session_status("trace-1", "failed")
+
+    assert lineage.snapshot()["sessions"][0]["status"] == "completed"
+
+
 def test_completed_compaction_starts_linked_context_epoch():
     lineage = LineageTracker()
     source_context_id = lineage.register_session(

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -28,16 +28,16 @@ def test_root_and_child_requests_have_exact_parentage():
 
     assert root_headers == {
         "Idempotency-Key": root_request.request_id,
-        "X-RLM-Request-ID": root_request.request_id,
-        "X-RLM-Session-ID": "trace-1",
-        "X-RLM-Context-ID": root_context_id,
-        "X-RLM-Transition": "root",
-        "X-RLM-Depth": "0",
+        "X-ACP-Lineage-Request-ID": root_request.request_id,
+        "X-ACP-Lineage-Session-ID": "trace-1",
+        "X-ACP-Lineage-Context-ID": root_context_id,
+        "X-ACP-Lineage-Transition": "root",
+        "X-ACP-Lineage-Depth": "0",
     }
-    assert child_headers["X-RLM-Parent-Session-ID"] == "trace-1"
-    assert child_headers["X-RLM-Context-ID"] == child_context_id
-    assert child_headers["X-RLM-Transition"] == "spawn"
-    assert child_headers["X-RLM-Depth"] == "1"
+    assert child_headers["X-ACP-Lineage-Parent-Session-ID"] == "trace-1"
+    assert child_headers["X-ACP-Lineage-Context-ID"] == child_context_id
+    assert child_headers["X-ACP-Lineage-Transition"] == "spawn"
+    assert child_headers["X-ACP-Lineage-Depth"] == "1"
     assert snapshot["sessions"][1]["spawned_by_request_id"] == (root_request.request_id)
 
 
@@ -57,13 +57,13 @@ def test_completed_compaction_starts_linked_context_epoch():
     resumed_headers = model_call_headers(resumed_request)
     snapshot = lineage.snapshot()
 
-    assert summary_headers["X-RLM-Context-ID"] == source_context_id
-    assert summary_headers["X-RLM-Compaction-ID"] == compaction.compaction_id
-    assert "X-RLM-Previous-Context-ID" not in summary_headers
-    assert resumed_headers["X-RLM-Context-ID"] == compaction.target_context_id
-    assert resumed_headers["X-RLM-Previous-Context-ID"] == source_context_id
-    assert resumed_headers["X-RLM-Transition"] == "compact"
-    assert resumed_headers["X-RLM-Compaction-ID"] == compaction.compaction_id
+    assert summary_headers["X-ACP-Lineage-Context-ID"] == source_context_id
+    assert summary_headers["X-ACP-Lineage-Compaction-ID"] == compaction.compaction_id
+    assert "X-ACP-Lineage-Previous-Context-ID" not in summary_headers
+    assert resumed_headers["X-ACP-Lineage-Context-ID"] == compaction.target_context_id
+    assert resumed_headers["X-ACP-Lineage-Previous-Context-ID"] == source_context_id
+    assert resumed_headers["X-ACP-Lineage-Transition"] == "compact"
+    assert resumed_headers["X-ACP-Lineage-Compaction-ID"] == compaction.compaction_id
     assert snapshot["requests"][-1]["compaction_id"] == compaction.compaction_id
     assert snapshot["compactions"] == [
         {
@@ -87,10 +87,12 @@ async def test_concurrent_requests_receive_unique_stable_ids():
         return model_call_headers(provenance)
 
     headers = await asyncio.gather(*(start_request() for _ in range(64)))
-    request_ids = [item["X-RLM-Request-ID"] for item in headers]
+    request_ids = [item["X-ACP-Lineage-Request-ID"] for item in headers]
 
     assert len(set(request_ids)) == 64
-    assert all(item["Idempotency-Key"] == item["X-RLM-Request-ID"] for item in headers)
+    assert all(
+        item["Idempotency-Key"] == item["X-ACP-Lineage-Request-ID"] for item in headers
+    )
     assert [request["request_id"] for request in lineage.snapshot()["requests"]] == (
         request_ids
     )
@@ -119,11 +121,18 @@ def test_new_compaction_id_overrides_source_context_origin():
 
     ordinary_headers = model_call_headers(ordinary_request)
     summary_headers = model_call_headers(second_summary)
-    assert ordinary_headers["X-RLM-Compaction-ID"] == (first_compaction.compaction_id)
-    assert summary_headers["X-RLM-Context-ID"] == first_compaction.target_context_id
-    assert summary_headers["X-RLM-Previous-Context-ID"] == first_context_id
-    assert summary_headers["X-RLM-Transition"] == "compact"
-    assert summary_headers["X-RLM-Compaction-ID"] == (second_compaction.compaction_id)
+    assert ordinary_headers["X-ACP-Lineage-Compaction-ID"] == (
+        first_compaction.compaction_id
+    )
+    assert (
+        summary_headers["X-ACP-Lineage-Context-ID"]
+        == first_compaction.target_context_id
+    )
+    assert summary_headers["X-ACP-Lineage-Previous-Context-ID"] == first_context_id
+    assert summary_headers["X-ACP-Lineage-Transition"] == "compact"
+    assert summary_headers["X-ACP-Lineage-Compaction-ID"] == (
+        second_compaction.compaction_id
+    )
 
 
 def test_failed_compaction_does_not_activate_target_context():

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,146 @@
+"""Stable lineage for recursive sessions and compacted contexts."""
+
+from __future__ import annotations
+
+import asyncio
+
+from rlm.client import model_call_headers
+from rlm.lineage import LineageTracker
+
+
+def test_root_and_child_requests_have_exact_parentage():
+    lineage = LineageTracker()
+    root_context_id = lineage.register_session(
+        "trace-1", parent_session_id=None, depth=0
+    )
+    root_request = lineage.start_request("trace-1", kind="turn")
+    child_context_id = lineage.register_session(
+        "child-1",
+        parent_session_id="trace-1",
+        depth=1,
+        spawned_by_request_id=root_request.request_id,
+    )
+    child_request = lineage.start_request("child-1", kind="turn")
+
+    root_headers = model_call_headers(root_request)
+    child_headers = model_call_headers(child_request)
+    snapshot = lineage.snapshot()
+
+    assert root_headers == {
+        "Idempotency-Key": root_request.request_id,
+        "X-RLM-Request-ID": root_request.request_id,
+        "X-RLM-Session-ID": "trace-1",
+        "X-RLM-Context-ID": root_context_id,
+        "X-RLM-Transition": "root",
+        "X-RLM-Depth": "0",
+    }
+    assert child_headers["X-RLM-Parent-Session-ID"] == "trace-1"
+    assert child_headers["X-RLM-Context-ID"] == child_context_id
+    assert child_headers["X-RLM-Transition"] == "spawn"
+    assert child_headers["X-RLM-Depth"] == "1"
+    assert snapshot["sessions"][1]["spawned_by_request_id"] == (root_request.request_id)
+
+
+def test_completed_compaction_starts_linked_context_epoch():
+    lineage = LineageTracker()
+    source_context_id = lineage.register_session(
+        "trace-1", parent_session_id=None, depth=0
+    )
+    compaction = lineage.begin_compaction("trace-1")
+    summary_request = lineage.start_request(
+        "trace-1", kind="compaction", compaction_id=compaction.compaction_id
+    )
+    lineage.finish_compaction(compaction.compaction_id, "completed")
+    resumed_request = lineage.start_request("trace-1", kind="turn")
+
+    summary_headers = model_call_headers(summary_request)
+    resumed_headers = model_call_headers(resumed_request)
+    snapshot = lineage.snapshot()
+
+    assert summary_headers["X-RLM-Context-ID"] == source_context_id
+    assert summary_headers["X-RLM-Compaction-ID"] == compaction.compaction_id
+    assert "X-RLM-Previous-Context-ID" not in summary_headers
+    assert resumed_headers["X-RLM-Context-ID"] == compaction.target_context_id
+    assert resumed_headers["X-RLM-Previous-Context-ID"] == source_context_id
+    assert resumed_headers["X-RLM-Transition"] == "compact"
+    assert resumed_headers["X-RLM-Compaction-ID"] == compaction.compaction_id
+    assert snapshot["compactions"] == [
+        {
+            "compaction_id": compaction.compaction_id,
+            "session_id": "trace-1",
+            "source_context_id": source_context_id,
+            "target_context_id": compaction.target_context_id,
+            "status": "completed",
+            "summary_request_id": summary_request.request_id,
+        }
+    ]
+
+
+async def test_concurrent_requests_receive_unique_stable_ids():
+    lineage = LineageTracker()
+    lineage.register_session("trace-1", parent_session_id=None, depth=0)
+
+    async def start_request():
+        await asyncio.sleep(0)
+        provenance = lineage.start_request("trace-1", kind="turn")
+        return model_call_headers(provenance)
+
+    headers = await asyncio.gather(*(start_request() for _ in range(64)))
+    request_ids = [item["X-RLM-Request-ID"] for item in headers]
+
+    assert len(set(request_ids)) == 64
+    assert all(item["Idempotency-Key"] == item["X-RLM-Request-ID"] for item in headers)
+    assert [request["request_id"] for request in lineage.snapshot()["requests"]] == (
+        request_ids
+    )
+
+
+def test_new_compaction_id_overrides_source_context_origin():
+    lineage = LineageTracker()
+    first_context_id = lineage.register_session(
+        "trace-1", parent_session_id=None, depth=0
+    )
+    first_compaction = lineage.begin_compaction("trace-1")
+    lineage.start_request(
+        "trace-1",
+        kind="compaction",
+        compaction_id=first_compaction.compaction_id,
+    )
+    lineage.finish_compaction(first_compaction.compaction_id, "completed")
+
+    ordinary_request = lineage.start_request("trace-1", kind="turn")
+    second_compaction = lineage.begin_compaction("trace-1")
+    second_summary = lineage.start_request(
+        "trace-1",
+        kind="compaction",
+        compaction_id=second_compaction.compaction_id,
+    )
+
+    ordinary_headers = model_call_headers(ordinary_request)
+    summary_headers = model_call_headers(second_summary)
+    assert ordinary_headers["X-RLM-Compaction-ID"] == (first_compaction.compaction_id)
+    assert summary_headers["X-RLM-Context-ID"] == first_compaction.target_context_id
+    assert summary_headers["X-RLM-Previous-Context-ID"] == first_context_id
+    assert summary_headers["X-RLM-Transition"] == "compact"
+    assert summary_headers["X-RLM-Compaction-ID"] == (second_compaction.compaction_id)
+
+
+def test_failed_compaction_does_not_activate_target_context():
+    lineage = LineageTracker()
+    source_context_id = lineage.register_session(
+        "trace-1", parent_session_id=None, depth=0
+    )
+    compaction = lineage.begin_compaction("trace-1")
+    lineage.start_request(
+        "trace-1", kind="compaction", compaction_id=compaction.compaction_id
+    )
+    lineage.finish_compaction(compaction.compaction_id, "failed")
+    next_request = lineage.start_request("trace-1", kind="turn")
+    snapshot = lineage.snapshot()
+
+    assert next_request.context_id == source_context_id
+    assert snapshot["compactions"][0]["status"] == "failed"
+    assert [context["context_id"] for context in snapshot["contexts"]] == [
+        source_context_id,
+        compaction.target_context_id,
+    ]

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -215,6 +215,34 @@ async def test_cancel_while_awaiting_registry_lock_closes_child_session(
     assert created[0]._msg_file.closed
     assert supervisor._invocations == {}
     assert supervisor._capabilities == {}
+    assert supervisor.lineage.snapshot()["sessions"][1]["status"] == "cancelled"
+
+
+async def test_child_factory_failure_marks_lineage_failed(tmp_path):
+    class FailingEngine:
+        def __init__(self, **kwargs):
+            raise RuntimeError("engine init failed")
+
+    session = Session(tmp_path / "root")
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=_config(max_depth=1),
+        cwd=str(tmp_path),
+        engine_factory=FailingEngine,
+    )
+    await supervisor.start()
+    scope = await supervisor.open_scope(supervisor.root_id)
+    endpoint = supervisor.endpoint_for(supervisor.root_id)
+    try:
+        task = await supervisor._start_child(endpoint.capability, scope, "x")
+        with pytest.raises(RuntimeError, match="engine init failed"):
+            await task
+    finally:
+        await supervisor.close_scope(scope)
+        await supervisor.aclose()
+        session.close()
+
+    assert supervisor.lineage.snapshot()["sessions"][1]["status"] == "failed"
 
 
 async def test_saturated_nested_calls_do_not_deadlock(tmp_path):


### PR DESCRIPTION
## Summary
- emit complete recursive session/context provenance on every model request using the generic private `X-ACP-Lineage-*` envelope
- publish the versioned `ai.prime.acp/lineage-v1` manifest independently of nano-RLM's own ACP session metrics
- preserve exact lineage across retries, concurrent child sessions, completed compactions, failed/cancelled compaction attempts, prompt rollback, and resumed contexts
- materialize a replacement context only after compaction completes; failed/cancelled attempts retain their source, request, and status without publishing a target context
- classify startup exceptions as failed and keep the first terminal session outcome stable through later cleanup cancellation
- remain a provenance producer only: interception, validation, persistence, training graph construction, and downstream policy views stay in verifiers

## Validation
- `uv run pytest tests/`: 144 passed after merging `origin/main`
- focused lineage/ACP/supervisor suite: 33 passed
- ruff check and format: passed
- five live Prime/SWE-bench rollouts through verifiers PR #2449 with `deepseek/deepseek-v4-flash` covered root-only execution, concurrent children, repeated compaction, combined behavior, provider retry, and cutoff
- final current-schema smoke: 2 sessions, 4 materialized contexts, 3 compaction attempts (2 completed and 1 failed with no target), 7 logical requests, 6 model calls, and complete call attribution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all model-call transport headers, compaction/rollback paths, and ACP metadata contracts—behavior changes are observable to interceptors and clients, though scoped to provenance emission rather than execution policy.
> 
> **Overview**
> Adds **end-to-end provenance** for every LLM call: a shared `LineageTracker` records sessions (including recursive children), context epochs (`root` / `spawn` / `compact`), compaction attempts, and per-request IDs. Each chat completion now sends **`X-ACP-Lineage-*` headers** (aligned with `Idempotency-Key`) via `model_call_headers(RequestProvenance)`; custom provider headers cannot override those names.
> 
> The engine wires lineage into turns, compaction summary calls, prompt rollback (restores pre-compaction context), and session terminal status. The supervisor passes the parent turn’s request ID when spawning subagents. **ACP** exposes lineage under `ai.prime.acp/lineage-v1` separately from session metrics and attaches session + lineage snapshots to **cancelled** `PromptResponse`s; successful prompts still carry lineage in metadata as before.
> 
> Failed or cancelled compactions do not materialize a new context; only completed compactions advance the active context and link subsequent turns to the compaction ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e2a761d4d5b525d90783e006cc76fd24bd11b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


