### PR TITLE
feat: default compaction (256k) and max_depth=1

### DIFF
--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -36,8 +36,13 @@ def _positive_int(value: str | int, name: str) -> int:
 
 
 def _summarize_at_tokens(value: str | int | None) -> int | None:
+    """Unset -> the 256k default; "" or "0" -> disabled; else a positive threshold."""
+    if value is None:
+        return 256_000
+    if value in ("", "0", 0):
+        return None
     parsed = _optional_positive_int(value, "summarize_at_tokens")
-    if value not in (None, "") and parsed is None:
+    if parsed is None:
         raise ValueError(f"summarize_at_tokens must be positive (got {value})")
     return parsed
 
@@ -124,10 +129,10 @@ class InvocationContext(_ConfigModel):
 class ExecutionPolicy(_ConfigModel):
     """Resource and context-management policy for one RLM engine."""
 
-    max_depth: int = Field(default=0, ge=0)
+    max_depth: int = Field(default=1, ge=0)
     exec_timeout: int = Field(default=300, gt=0)
     max_tokens: int | None = Field(default=None, gt=0)
-    summarize_at_tokens: int | None = Field(default=None, gt=0)
+    summarize_at_tokens: int | None = Field(default=256_000, gt=0)
     max_compactions: int | None = Field(default=None, gt=0)
     max_concurrent_subagents: int = Field(default=4, gt=0)
     max_subagent_calls: int = Field(default=64, gt=0)
@@ -161,7 +166,7 @@ class RuntimeConfig(_ConfigModel):
     ) -> RuntimeConfig:
         env = os.environ if environ is None else environ
         raw_skills = env.get("RLM_SKILLS")
-        max_depth = int(env.get("RLM_MAX_DEPTH", "0"))
+        max_depth = int(env.get("RLM_MAX_DEPTH", "1"))
         default_concurrency = max(4, max_depth)
         max_concurrent_subagents = _positive_int(
             env.get("RLM_MAX_CONCURRENT_SUBAGENTS", str(default_concurrency)),

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -308,7 +308,7 @@ async def test_model_call_idempotency_survives_retry_and_compaction(
         model="test-model",
         provider=ProviderConfig(base_url=None, api_key="test-key"),
         invocation=InvocationContext(),
-        policy=ExecutionPolicy(summarize_at_tokens=1),
+        policy=ExecutionPolicy(summarize_at_tokens=1, max_depth=0),
     )
     engine = RLMEngine(
         client=client,  # type: ignore[arg-type]

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -176,7 +176,7 @@ async def test_engine_prompt_preserves_conversation(session):
         first = await engine.prompt("one")
         second = await engine.prompt("two")
     finally:
-        engine.close()
+        await engine.aclose()
 
     assert first.answer == "first"
     assert second.answer == "second"
@@ -262,7 +262,7 @@ async def test_engine_prompt_preserves_ipython_kernel(session):
         await engine.prompt("remember a value")
         result = await engine.prompt("use that value")
     finally:
-        engine.close()
+        await engine.aclose()
 
     tool_messages = [
         message for message in client.calls[-1]["messages"] if message["role"] == "tool"
@@ -295,7 +295,7 @@ async def test_engine_cancelled_prompt_can_be_retried(session):
     try:
         result = await engine.prompt("continue")
     finally:
-        engine.close()
+        await engine.aclose()
 
     assert result.answer == "continued"
     assert result.turns == 1
@@ -341,7 +341,7 @@ async def test_model_call_idempotency_survives_retry_and_compaction(
     try:
         result = await engine.prompt("compact")
     finally:
-        engine.close()
+        await engine.aclose()
 
     assert result.answer == "done"
     assert (
@@ -391,7 +391,7 @@ async def test_latest_cancelled_prompt_does_not_finalize_prior_result(session):
     pending.cancel()
     with pytest.raises(asyncio.CancelledError):
         await pending
-    engine.close()
+    await engine.aclose()
 
     meta = json.loads((Path(session.dir) / "meta.json").read_text())
     assert meta["status"] == "running"
@@ -424,7 +424,7 @@ async def test_compaction_counts_seed_prompt(session):
     try:
         await engine._compact_branch(messages, turn=0, active_tools=[])
     finally:
-        engine.close()
+        await engine.aclose()
 
     assert engine._metrics.num_compactions == 1
     assert engine._metrics.compaction_chars_dropped_mean == len("original promptwork")
@@ -445,7 +445,7 @@ async def test_engine_failed_prompt_can_be_retried(session):
     try:
         result = await engine.prompt("continue")
     finally:
-        engine.close()
+        await engine.aclose()
 
     assert result.answer == "continued"
     assert result.turns == 1
@@ -496,7 +496,7 @@ async def test_failed_prompt_restores_pre_compaction_context(session):
     try:
         result = await engine.prompt("continue")
     finally:
-        engine.close()
+        await engine.aclose()
 
     request_ids = [
         call["extra_headers"]["X-ACP-Lineage-Request-ID"] for call in client.calls
@@ -563,7 +563,7 @@ async def test_engine_cancel_masks_tool_cleanup_error(monkeypatch, session):
     try:
         result = await engine.prompt("continue")
     finally:
-        engine.close()
+        await engine.aclose()
 
     assert result.answer == "continued"
     assert repl.finished is True
@@ -614,7 +614,7 @@ async def test_engine_cancelled_tool_recovers_kernel(session, tmp_path):
     try:
         result = await engine.prompt("continue")
     finally:
-        engine.close()
+        await engine.aclose()
 
     tool_messages = [
         message for message in client.calls[-1]["messages"] if message["role"] == "tool"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,3 +64,15 @@ def test_runtime_config_rejects_unsafe_recursive_and_environment_values():
     provider.headers["Idempotency-Key"] = "forged-after-construction"
     with pytest.raises(ValueError, match="reserved names"):
         make_client(provider)
+
+
+def test_default_policy_enables_compaction_and_recursion():
+    config = RuntimeConfig.from_env(environ={})
+    assert config.policy.summarize_at_tokens == 256_000
+    assert config.policy.max_depth == 1
+
+
+def test_summarize_at_tokens_disabled_by_zero_or_empty():
+    for raw in ("", "0"):
+        config = RuntimeConfig.from_env(environ={"RLM_SUMMARIZE_AT_TOKENS": raw})
+        assert config.policy.summarize_at_tokens is None


### PR DESCRIPTION
## Summary

Two default changes:

| setting | before | after | disable/override |
|---|---|---|---|
| `summarize_at_tokens` | `None` (compaction off) | **256,000** | `RLM_SUMMARIZE_AT_TOKENS=""` or `"0"` |
| `max_depth` | 0 (no sub-agents) | **1** | `RLM_MAX_DEPTH=0` |

## Why

- **Compaction on by default**: without it, long trajectories die at the model context limit. 256k is a safety-net threshold — typical rollouts never touch it (SWE medians are ~10-30k), but the rare monster trajectory compacts and survives instead of failing. Compaction behavior (handoff quality, post-compaction recovery via the surviving kernel + conversation log) has been validated in the ablations backing #142; at-threshold rollouts solved at 0.75-0.88 with the improved handoff prompt.
- **`max_depth=1` by default**: one level of `await rlm('sub-task')` is available out of the box, matching how the harness is deployed in practice.

## Notes

- Empty/`0` env values for `RLM_SUMMARIZE_AT_TOKENS` now mean "disabled" (previously "" meant unset->off; unset now means the 256k default).
- With `max_depth>=1` the engine owns a `SessionTreeSupervisor`; embedders using the sync `close()` inside an event loop must switch to `await engine.aclose()` (the idempotency test now pins `max_depth=0` for that reason — it tests retries, not recursion).
- Tests: 130 passed; the 6 `test_acp.py` failures are pre-existing on clean main in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for all deployments that relied on implicit defaults (compaction off, no sub-agents); long runs may compact unexpectedly and recursive `rlm()` is enabled unless env overrides are set.
> 
> **Overview**
> **Default execution policy** now turns on context compaction at **256,000** tokens and allows **one level** of sub-agent recursion (`max_depth=1`), including matching env defaults for `RLM_MAX_DEPTH`.
> 
> **`RLM_SUMMARIZE_AT_TOKENS` parsing** changes semantics: omitting the variable applies the 256k threshold; **`""` or `"0"`** explicitly disables compaction (replacing the old “unset/empty means off” behavior). `_summarize_at_tokens` encodes that logic and invalid positives still raise.
> 
> **Tests** assert the new defaults, cover disable-via-empty/zero, switch async engine teardown from **`close()`** to **`await aclose()`** (needed when recursion/supervisor is on), and pin **`max_depth=0`** on the compaction/idempotency test so it stays focused on retries rather than sub-agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37848a3599f516be7e8703877f611c97f2d0e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->