### PR TITLE
feat: role-aware sub-agent prompting (built-in contract + per-tier appends)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ no standalone entry point: outside a session the call raises.
 
 All runtime configuration enters through the `ai.prime.rlm/runtime-v1` contract object
 (model, provider credentials, execution policy, prompt configuration, skills, kernel
-environment, search credential). Recursive children inherit the parent's configuration
+environment, search credential). Prompt configuration is role-aware: optional
+`subagent_append_to_system_prompt` (nodes that can still recurse) and
+`leaf_append_to_system_prompt` (depth == max_depth) override `append_to_system_prompt`
+for sub-agents, each falling back to the next-more-general tier. Recursive children inherit the parent's configuration
 in-memory (`model_copy`); nothing is re-read from the process environment.
 
 The process environment configures only process infrastructure:

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -70,6 +70,8 @@ class _RuntimeMetadata(_ContractModel):
     policy: ExecutionPolicy
     system_prompt_path: str | None
     append_to_system_prompt: str | None
+    subagent_append_to_system_prompt: str | None = None
+    leaf_append_to_system_prompt: str | None = None
     skills: list[Annotated[str, Field(min_length=1)]]
     kernel_env: dict[str, str]
     search_api_key: str | None
@@ -201,6 +203,8 @@ def _runtime_config(meta_kwargs: Any) -> tuple[RuntimeConfig, str]:
             policy=payload.policy,
             system_prompt_path=payload.system_prompt_path,
             append_to_system_prompt=payload.append_to_system_prompt,
+            subagent_append_to_system_prompt=payload.subagent_append_to_system_prompt,
+            leaf_append_to_system_prompt=payload.leaf_append_to_system_prompt,
             skills=tuple(payload.skills),
             kernel_env=tuple(payload.kernel_env.items()),
             search_api_key=payload.search_api_key,

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -91,6 +91,31 @@ class RuntimeConfig(_ConfigModel):
     policy: ExecutionPolicy
     system_prompt_path: str | None = None
     append_to_system_prompt: str | None = None
+    subagent_append_to_system_prompt: str | None = None
+    leaf_append_to_system_prompt: str | None = None
     skills: tuple[str, ...] = ()
     kernel_env: tuple[tuple[str, str], ...] = Field(default=(), repr=False)
     search_api_key: str | None = Field(default=None, repr=False)
+
+    @property
+    def resolved_append_to_system_prompt(self) -> str | None:
+        """The append for this engine's role in the session tree.
+
+        root (depth 0)                            -> append_to_system_prompt
+        node (depth >= 1, can still recurse)      -> subagent_append_to_system_prompt
+        leaf (depth == max_depth, cannot recurse) -> leaf_append_to_system_prompt
+
+        Each tier falls back to the next-more-general one (leaf -> subagent -> root),
+        so any unset append preserves the prior single-append behavior. Mirrors the
+        allow_recursion gating that build_system_prompt uses for the built-in rlm hint.
+        """
+        if self.invocation.depth == 0:
+            return self.append_to_system_prompt
+        if (
+            self.invocation.depth >= self.policy.max_depth
+            and self.leaf_append_to_system_prompt is not None
+        ):
+            return self.leaf_append_to_system_prompt
+        if self.subagent_append_to_system_prompt is not None:
+            return self.subagent_append_to_system_prompt
+        return self.append_to_system_prompt

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -1001,6 +1001,7 @@ class RLMEngine:
             self.cwd,
             str(SKILLS_DIR) if SKILLS_DIR is not None else None,
             discover_skills(self.session.dir),
+            depth=self.depth,
             allow_recursion=self.depth < self.max_depth,
             allow_git=self.allow_git,
             active_tools=active_tools,

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -143,7 +143,7 @@ class RLMEngine:
         self.summarize_at_tokens = config.policy.summarize_at_tokens
         self.max_compactions = config.policy.max_compactions
         self.system_prompt_path = config.system_prompt_path
-        self.append_to_system_prompt = config.append_to_system_prompt
+        self.append_to_system_prompt = config.resolved_append_to_system_prompt
         self.max_depth = config.policy.max_depth
         self.depth = config.invocation.depth
         self.allow_git = config.policy.allow_git

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -1002,6 +1002,7 @@ class RLMEngine:
             str(SKILLS_DIR) if SKILLS_DIR is not None else None,
             discover_skills(self.session.dir),
             depth=self.depth,
+            session_dir=str(self.session.dir),
             allow_recursion=self.depth < self.max_depth,
             allow_git=self.allow_git,
             active_tools=active_tools,

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -43,6 +43,11 @@ IPYTHON_CONTROL_PROMPT = (
     "Run shell commands with `%%bash` as the very first line of a code cell "
     "(no comments, imports, or statements before it). " + PROJECT_ENV_PROMPT
 )
+KERNEL_PACKAGES_PROMPT = (
+    "Pre-installed in the kernel venv: " + ", ".join(BASE_TOOLKIT) + ". "
+    "Install extra packages with `!uv pip install <pkg>` in a code cell — that "
+    "targets the kernel venv (a uv-managed venv with no pip module)."
+)
 BASH_SKILL_PROMPT = (
     "Run shell with `out = await bash('''command here''')` — always "
     "triple-quote the command so shell quotes and multi-line scripts never "
@@ -86,6 +91,7 @@ def build_system_prompt(
     installed_skills: list[str],
     *,
     depth: int = 0,
+    session_dir: str | None = None,
     allow_recursion: bool,
     allow_git: bool,
     active_tools: list[BuiltinTool],
@@ -93,9 +99,9 @@ def build_system_prompt(
 ) -> str:
     """Build the system prompt.
 
-    Layout: role → environment (cwd, log path, skills) → capabilities
-    (recursion) → tool API. Keep it tight: the model also receives the
-    per-tool schemas, so redundant tool guidance here just inflates
+    Layout: role → environment (cwd, log path, skills, kernel venv) →
+    capabilities (recursion) → guards. Keep it tight: the model also receives
+    the per-tool schemas, so redundant tool guidance here just inflates
     every request.
     """
     has_bash = _has_tool(active_tools, "bash")
@@ -130,14 +136,13 @@ def build_system_prompt(
         )
     else:
         done_line = "When you are done, stop calling tools and state your final answer."
+    log_dir = session_dir or "$RLM_SESSION_DIR"
     parts: list[str] = [
         role,
         done_line,
         "",
         f"Working directory: {cwd}",
-        "Conversation log: $RLM_SESSION_DIR/messages.jsonl",
-        f"Pre-installed Python packages: {', '.join(BASE_TOOLKIT)}.",
-        "Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
+        f"Conversation log: {log_dir}/messages.jsonl",
     ]
 
     skill_lines: list[str] = []
@@ -149,8 +154,8 @@ def build_system_prompt(
         installed = ", ".join(f"`{skill}`" for skill in installed_skills)
         skill_lines.append(f"Installed skills (pre-imported): {installed}.")
         skill_lines.append(
-            "Each skill is an async function by the same name. "
-            "Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`."
+            "Each skill is an async function by the same name; "
+            "inspect one with `help(<skill>)`."
         )
         shell_skill_set = set(shell_skills or [])
         if shell_skill_set:
@@ -167,6 +172,11 @@ def build_system_prompt(
     if skill_lines:
         parts.extend(["", *skill_lines])
 
+    if has_ipython and not has_bash and "bash" not in (installed_skills or []):
+        parts.extend(["", IPYTHON_CONTROL_PROMPT, KERNEL_PACKAGES_PROMPT])
+    elif has_ipython:
+        parts.extend(["", PROJECT_ENV_PROMPT, KERNEL_PACKAGES_PROMPT])
+
     if allow_recursion:
         parts.extend(
             [
@@ -175,11 +185,6 @@ def build_system_prompt(
                 "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
             ]
         )
-
-    if has_ipython and not has_bash and "bash" not in (installed_skills or []):
-        parts.extend(["", IPYTHON_CONTROL_PROMPT])
-    elif has_ipython:
-        parts.extend(["", PROJECT_ENV_PROMPT])
 
     if _should_include_git_history_guard(active_tools, allow_git):
         parts.extend(["", GIT_HISTORY_GUARD_PROMPT])

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -85,6 +85,7 @@ def build_system_prompt(
     skills_dir: str | None,
     installed_skills: list[str],
     *,
+    depth: int = 0,
     allow_recursion: bool,
     allow_git: bool,
     active_tools: list[BuiltinTool],
@@ -100,7 +101,14 @@ def build_system_prompt(
     has_bash = _has_tool(active_tools, "bash")
     has_edit = _has_tool(active_tools, "edit")
     has_ipython = _has_tool(active_tools, "ipython")
-    role = "You are a coding agent."
+    if depth > 0:
+        role = (
+            "You are a coding agent, spawned as a sub-agent: your caller "
+            "delegated a single task to you and sees none of your work. Do "
+            "exactly that task; don't widen the scope."
+        )
+    else:
+        role = "You are a coding agent."
     if has_bash:
         role += " You have access to a bash tool for running shell commands."
     if has_edit:
@@ -113,9 +121,18 @@ def build_system_prompt(
             " You also have an ipython tool: a persistent Python REPL "
             "(variables, imports, and function definitions persist across calls)."
         )
+    if depth > 0:
+        done_line = (
+            "When the task is done, stop calling tools and state your final "
+            "answer. It is the only thing your caller receives, so make it a "
+            "complete, self-contained result — the answer plus the evidence "
+            "needed to trust it (sources, file paths, values)."
+        )
+    else:
+        done_line = "When you are done, stop calling tools and state your final answer."
     parts: list[str] = [
         role,
-        "When you are done, stop calling tools and state your final answer.",
+        done_line,
         "",
         f"Working directory: {cwd}",
         "Conversation log: $RLM_SESSION_DIR/messages.jsonl",

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -253,7 +253,7 @@ class IPythonREPL:
         skill_names = discover_skills(self.session.dir if self.session else None)
 
         setup_code = f"""\
-import os, sys, types, json, time, functools, inspect
+import os, sys, asyncio, types, json, time, functools, inspect
 os.chdir({self.cwd!r})
 if {bool(session_dir)!r}:
     sys.path.append({session_dir!r})


### PR DESCRIPTION
Recursive sessions currently prompt every engine identically: a depth-3 leaf gets the same system prompt as the root, and a single `append_to_system_prompt` applies at every depth. This PR makes prompting role-aware, in two layers.

## What this adds

**1. A built-in sub-agent framing, gated on depth (zero config).** `build_system_prompt` now takes `depth`; any `depth>0` engine gets its sub-agent identity woven into the prompt's two opening lines instead of the root's plain ones:

> You are a coding agent, spawned as a sub-agent: your caller delegated a single task to you and sees none of your work. Do exactly that task; don't widen the scope. [+ tool sentences]
>
> When the task is done, stop calling tools and state your final answer. It is the only thing your caller receives, so make it a complete, self-contained result — the answer plus the evidence needed to trust it (sources, file paths, values).

**2. Per-tier append fields (config).** The ACP `runtime-v1` contract and `RuntimeConfig` gain `subagent_append_to_system_prompt` and `leaf_append_to_system_prompt` alongside the existing `append_to_system_prompt`. `RuntimeConfig.resolved_append_to_system_prompt` picks by role, with fallback **leaf → subagent → root**, so unset fields preserve today's single-append behavior. Children inherit config via `model_copy`, so every descendant resolves its own tier.

The resulting tiers:

| tier | condition | sub-agent framing | `rlm` hint | append field |
|------|-----------|-------------------|------------|--------------|
| root | `depth == 0` | – | ✓ (if `max_depth > 0`) | `append_to_system_prompt` |
| node | `1 ≤ depth < max_depth` | ✓ | ✓ | `subagent_append_to_system_prompt` |
| leaf | `depth == max_depth` | ✓ | – | `leaf_append_to_system_prompt` |

## Rationale

The design splits sub-agent prompting into three concerns, each handled where it belongs:

- **Contract — built-in, shared by node and leaf.** "Your caller sees only your final message; make it self-contained; stay on the delegated task" is true identically for every sub-agent, so it ships as the default rather than something every host must remember to configure. It lives in the role and final-answer lines (not a separate mid-prompt block) so there's exactly one "You are …" statement and the framing is the first thing the model reads — weaker models overweight the prompt opening.
- **Capability — built-in, differs by tier.** Nodes get the `rlm` recursion hint; leaves get no mention of `rlm` at all. Deliberately *no* "you cannot spawn sub-agents" line: advertising a missing capability is what caused depth-thrash before this PR — leaves calling `rlm()`, hitting `[depth limit … reached]`, and burning turns retrying.
- **Strategy — config, per tier.** How aggressively a node should decompose vs. a leaf should execute-and-report is model- and taskset-dependent, so it stays out of the harness and goes in the appends. That's also the fix for the motivating bug: a delegation-oriented root append used to be injected verbatim into leaves that couldn't act on it. In a search-taskset eval, tiered appends took depth-thrash from 13–27 occurrences to 0 while keeping heavy, load-bearing delegation.


## Before/after on SWE-bench Pro

32 stratified tasks (3 per repo across all 11 repos; identical task list in every arm), k=1, three models via Prime Inference, stock harness settings except `max_depth=1` and a 1h rollout wall clock. **before** = main (`7eaff71`), **after** = #151 + #166 stacked (`c886994`). Zero harness errors across ~190 rollouts.

| model | arm | n | mean reward | solved | turns/rollout | tokens/rollout |
|---|---|---|---|---|---|---|
| z-ai/glm-5.3 | before | 32 | 0.562 | 18/32 | 82.8 | 143k |
| z-ai/glm-5.3 | after | 32 | **0.656** | **21/32** | 78.2 | 141k |
| deepseek-v4-flash | before | 32 | 0.438 | 14/32 | 74.3 | 123k |
| deepseek-v4-flash | after | 32 | 0.438 | 14/32 | 72.5 | 111k |
| kimi-k3 | before | 31 | 0.581 | 18/31 | 59.3 | 165k |
| kimi-k3 | after | 32 | 0.594 | 19/32 | 57.5 | 157k |

Paired on shared tasks: glm-5.3 **3W/0L/29T** (sign p=0.25), deepseek 2W/2L/28T, kimi-k3 2W/1L/28T. The after arm is never worse on reward and slightly cheaper on every model (fewer turns and tokens). Individual deltas are within noise at n=32/k=1; the uniform direction across three models is the signal.

One honest caveat for THIS PR: on SWE tasks no model delegates unprompted — exactly one `rlm()` call occurred across all ~190 rollouts — so the built-in sub-agent contract almost never rendered and this eval is primarily a no-regression check for it. The contract's behavioral evidence is the append-driven redsearcher experiment above (depth-thrash 13–27 → 0).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every agent’s system prompt and runtime contract fields; misconfigured tier appends could alter delegation behavior, though fallbacks preserve prior single-append semantics when new fields are unset.
> 
> **Overview**
> This PR makes **system prompts depend on where an engine sits in the recursion tree**, instead of treating every depth the same.
> 
> **Built-in sub-agent framing (no config):** `build_system_prompt` now takes `depth` and `session_dir`. Engines with `depth > 0` get a sub-agent role and a stricter “final answer” line (caller-only, self-contained result with evidence). The conversation log path uses the real session directory when available. Kernel guidance is consolidated into **`KERNEL_PACKAGES_PROMPT`** (`!uv pip install` in cells); skill help text is slightly tightened.
> 
> **Per-tier config appends:** The ACP `runtime-v1` contract and `RuntimeConfig` add **`subagent_append_to_system_prompt`** and **`leaf_append_to_system_prompt`**. **`resolved_append_to_system_prompt`** selects root vs node vs leaf append with fallback **leaf → subagent → root**, so unset tiers keep today’s single-`append_to_system_prompt` behavior. **`RLMEngine`** applies the resolved append when loading the system prompt.
> 
> **Kernel bootstrap:** IPython startup pre-imports **`asyncio`** so parallel `rlm` examples in the prompt work without extra setup.
> 
> README documents the new append fields and tier semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc4d2d3f882f583f37cefef7ddd88a85ffb683a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

