### PR TITLE
feat: skills preset as the RLM_TOOLING default

### DIFF
--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -1,9 +1,9 @@
 """Builtin tool registry.
 
-rlm's default tool set is native ``bash`` and ``edit`` tools plus the persistent
-IPython REPL. Shell and edits are ALSO available as REPL skills (``await bash(...)``,
-``await edit(...)``) for mixing with Python in one cell. ``RLM_BUILTIN_TOOLS``
-(comma-separated) overrides the set, e.g. ``ipython`` for a REPL-only agent.
+rlm's default is the ``skills`` preset: the persistent IPython REPL as the sole
+tool, with shell and edits as pre-imported REPL skills (``await bash(...)``,
+``await edit(...)``). ``RLM_TOOLING`` selects ``tools`` or ``dual`` presets;
+``RLM_BUILTIN_TOOLS`` (comma-separated) overrides the tool set directly.
 """
 
 from __future__ import annotations
@@ -33,8 +33,8 @@ _TOOLING_PRESETS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
 
 
 def tooling_preset() -> str:
-    """The RLM_TOOLING preset name: dual (default), tools, or skills."""
-    preset = os.environ.get("RLM_TOOLING", "dual").strip() or "dual"
+    """The RLM_TOOLING preset name: skills (default), tools, or dual."""
+    preset = os.environ.get("RLM_TOOLING", "skills").strip() or "skills"
     if preset not in _TOOLING_PRESETS:
         raise ValueError(
             f"RLM_TOOLING must be one of {sorted(_TOOLING_PRESETS)}, got {preset!r}"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -97,6 +97,10 @@ def test_tooling_presets(monkeypatch):
     from rlm.tools.registry import preset_skills, preset_tools
 
     monkeypatch.delenv("RLM_TOOLING", raising=False)
+    assert preset_tools() == ("ipython",)
+    assert preset_skills() == ("bash", "edit")
+
+    monkeypatch.setenv("RLM_TOOLING", "dual")
     assert preset_tools() == ("bash", "edit", "ipython")
     assert preset_skills() == ("bash", "edit")
 


### PR DESCRIPTION
## Summary

Flips the default `RLM_TOOLING` preset from `dual` to **`skills`**: the default agent is REPL-only — `ipython` as the sole tool, `bash`/`edit` as pre-imported skills, with the validated triple-quote shell guidance auto-rendered in the prompt.

`RLM_TOOLING=dual` / `tools` restore the other configurations (one env var).

## Evidence (128 tasks, kimi-k3, same seeded set)

| preset | solve | turns | reason/turn | error turns |
|---|---|---|---|---|
| tools | 0.711 | 36.1 | 216 | 0.8% |
| **skills** | 0.704 | **33.5** | 256 | 2.5% |
| dual | 0.695 | 35.4 | 239 | 2.1% |

Converged on solve and total reasoning. Skills mode has the fewest turns (REPL cells batch several actions per turn — fewer round-trips, less prompt-token re-reading) at a modest error cost (2.5% vs 0.8%; was 5.0% before the triple-quote guidance, 53.5 turns before the `bash -c` parity fix).

## Why skills as default

- It is the rlm-native shape: one interface, one persistent namespace; skills, state, and `await rlm(...)` sub-agents compose in the same cell.
- The two historical blockers are fixed and regression-guarded (shell parity via the shared guarded runner; quoting via the auto-rendered prompt line).
- Cross-model note: GLM-5.3 pays more in skills mode (2.4x reasoning tokens vs tools) — models with REPL-sensitivity may prefer `dual`/`tools`, which remain one env var away. Defaults encode the primary target (k3-class agents), not a universal optimum.

Tests: 138 passed (6 pre-existing `test_acp.py` env failures, same as clean main); default-preset assertions updated; ruff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default preset alters which capabilities are exposed as native tools vs REPL skills for every deployment that does not set `RLM_TOOLING`, though prior behavior remains one env var away.
> 
> **Overview**
> **Default tooling is now the `skills` preset** when `RLM_TOOLING` is unset: only the persistent IPython REPL is registered as a builtin tool, with `bash` and `edit` supplied as pre-imported REPL skills instead of separate tools. The module docs and `tooling_preset()` docstring/env fallback were updated from **`dual`** to **`skills`**.
> 
> The **`dual`**, **`tools`**, and **`skills`** preset definitions are unchanged; setting `RLM_TOOLING=dual` or `tools` still restores the previous default-like setups. **`test_tooling_presets`** now asserts the unset-env case maps to `("ipython",)` tools and `("bash", "edit")` skills, and explicitly covers `RLM_TOOLING=dual` before the other presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 702c703bce7420f5e84c0f70d9fd937d0d204ef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->