### PR TITLE
feat: 10KB hard cap on tool output entering context

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -48,6 +48,31 @@ from rlm.types import (
 
 logger = logging.getLogger(__name__)
 
+# Hard cap for a single tool result entering the conversation (the session log
+# keeps the full output). Head+tail with a warning naming the original size —
+# Codex's output policy, matching verifiers' bash-harness truncation.
+TOOL_OUTPUT_MAX_BYTES = 10_000
+
+
+def estimated_tokens(chars: str) -> int:
+    """Rough token count at four characters per token."""
+    return (len(chars) + 3) // 4
+
+
+def truncate_tool_output(text: str) -> str:
+    """Keep the head and tail of an oversized tool result and say what was cut."""
+    data = text.encode("utf-8")
+    if len(data) <= TOOL_OUTPUT_MAX_BYTES:
+        return text
+    keep = TOOL_OUTPUT_MAX_BYTES // 2
+    head = data[:keep].decode("utf-8", errors="ignore")
+    tail = data[-keep:].decode("utf-8", errors="ignore")
+    return (
+        f"Warning: truncated output (original token count: {estimated_tokens(text)})\n"
+        f"Total output lines: {text.count(chr(10)) + 1}\n\n"
+        f"{head}\n[... {len(data) - 2 * keep} bytes truncated ...]\n{tail}"
+    )
+
 
 # Injected as a user message when the branch's context size reaches the
 # compaction threshold. The model's next reply is expected to be a
@@ -569,7 +594,7 @@ class RLMEngine:
                 {
                     "role": "tool",
                     "tool_call_id": tc.id,
-                    "content": result,
+                    "content": truncate_tool_output(result),
                 }
             )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -216,3 +216,17 @@ def test_kernel_receives_policy_env(session):
     finally:
         repl.shutdown()
     assert out.strip() == "42 1"
+
+
+def test_truncate_tool_output_caps_and_reports():
+    from rlm.engine import TOOL_OUTPUT_MAX_BYTES, truncate_tool_output
+
+    small = "x" * 100
+    assert truncate_tool_output(small) == small
+
+    big = "line\n" * 10_000
+    out = truncate_tool_output(big)
+    assert len(out.encode()) < TOOL_OUTPUT_MAX_BYTES + 500
+    assert out.startswith("Warning: truncated output")
+    assert "bytes truncated" in out
+    assert "Total output lines: 10001" in out


### PR DESCRIPTION
## Summary

Hard-caps any single tool result entering the conversation at **10KB**, middle-out (keep head+tail), with a warning header naming the original size and line count:

```
Warning: truncated output (original token count: 12500)
Total output lines: 10001

<first 5KB>
[... 40000 bytes truncated ...]
<last 5KB>
```

Applies at the engine tool-result boundary — so it covers **all tools** (`bash`, `edit`, and `ipython` cell output) uniformly.

## Scope: context only — tools yes, skills no

- The **session log keeps the full output** (audit trail unchanged).
- **Skill return values inside the kernel stay uncapped**: `out = await bash(...)` holds the complete string for in-cell filtering; only what the cell *prints* (the tool result) is subject to the cap. Capture-then-filter workflows keep full fidelity — the cap only protects the context window.

## Compatibility

The function is byte-compatible with the truncation in [verifiers#2454](https://github.com/PrimeIntellect-ai/verifiers/pull/2454) (bash harness) and the copy bundled inside [#147](https://github.com/PrimeIntellect-ai/nano-rlm/pull/147) (auto-compaction) — extracted standalone here so the cap can ship independently; #147 can relocate/dedupe it when it lands.

Motivation from eval traces: unclipped tool results produced single-turn context blowups (observed up to ~690k tokens from one `cat` on a large file), which no compaction threshold can save you from after the fact.

Tests: truncation unit test added; 139 passed (6 pre-existing `test_acp.py` env failures, same as clean main); ruff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what every tool returns to the model mid-run; large outputs lose middle content in context (by design), though logs retain full fidelity.
> 
> **Overview**
> Adds a **10KB UTF-8 hard cap** on each tool result before it is appended to the conversation. Oversized output is **head+tail truncated** with a warning that includes estimated original token count and line count.
> 
> Truncation runs in **`RLMEngine`** when building the `tool` message (`truncate_tool_output`); **`session.log_tool_result` still records the full string**, so audit trails and in-kernel skill return values are unchanged—only what the model sees in context is limited.
> 
> A unit test in **`test_tools.py`** checks passthrough for small output and warning/size behavior for large output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32bb7290115c03b7edfcc39ffd4393642529c59c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->