### PR TITLE
fix: bash tool survives binary output

### DIFF
--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -72,6 +72,7 @@ def run_bash(
             ["bash", "-c", command],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=timeout,
             cwd=cwd or None,
         )

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -194,3 +194,8 @@ def test_enable_bash_skill_writes_stub(tmp_path):
     assert enabled == ["bash"]
     stub = (tmp_path / "bash.py").read_text()
     assert "from rlm.skills.bash import run" in stub
+
+
+async def test_bash_survives_binary_output():
+    out = await bash("printf 'head\\xff\\xfetail'")
+    assert "head" in out and "tail" in out


### PR DESCRIPTION
subprocess.run(text=True) decodes strictly — a command emitting non-UTF-8 bytes (e.g. cat on a binary) raised UnicodeDecodeError inside the tool, crashing the rollout as an ACP Internal error (observed in production: byte 0xff at position 11195). Decode with errors="replace" so binary output degrades gracefully. Regression test added. Note: not created as draft — this is a production-breaking bug worth fast-tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line decoding behavior change in the bash executor; reduces failure modes without altering command blocking or timeout logic.
> 
> **Overview**
> Fixes production rollouts crashing when shell commands emit non-UTF-8 bytes (e.g. reading binary files). **`run_bash`** now passes **`errors="replace"`** to **`subprocess.run`** alongside **`text=True`**, so invalid sequences become replacement characters instead of raising **`UnicodeDecodeError`**.
> 
> A regression test runs **`printf`** with embedded **`0xff`** bytes and asserts the tool still returns readable **`head`** / **`tail`** text. The bash skill path is covered because it calls the same **`run_bash`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de92665da1cac834de1ac99ec91ccf8de712778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->