### PR TITLE
feat: execution guardrails (turn, context, tree-token, and output caps)

### DIFF
--- a/src/rlm/compaction.py
+++ b/src/rlm/compaction.py
@@ -131,12 +131,12 @@ async def discover_threshold(client: AsyncOpenAI, model: str) -> int | None:
     return default_threshold(window) if window is not None else None
 
 
-def truncate_tool_output(text: str) -> str:
+def truncate_tool_output(text: str, max_bytes: int = TOOL_OUTPUT_MAX_BYTES) -> str:
     """Keep the head and tail of an oversized tool result and say what was cut."""
     data = text.encode("utf-8")
-    if len(data) <= TOOL_OUTPUT_MAX_BYTES:
+    if len(data) <= max_bytes:
         return text
-    keep = TOOL_OUTPUT_MAX_BYTES // 2
+    keep = max_bytes // 2
     head = data[:keep].decode("utf-8", errors="ignore")
     tail = data[-keep:].decode("utf-8", errors="ignore")
     return (

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -52,6 +52,20 @@ class ExecutionPolicy(_ConfigModel):
     """Resource and context-management policy for one RLM engine."""
 
     max_depth: int = Field(default=1, ge=0)
+    max_total_turns: int | None = Field(default=None, gt=0)
+    """Tree-total turn budget (one turn = one work-loop model call, any engine; compaction
+    calls don't count). Once reached, every engine stops before its next model call
+    (stop_reason=max_total_turns). None = uncapped."""
+    max_total_tokens: int | None = Field(default=None, gt=0)
+    """Tree-total budget of NEW tokens across the whole recursive session tree, live: each
+    model call contributes its completion plus uncached prompt tokens (the cached context
+    prefix re-billed every call is not new work). Once reached, every engine stops before
+    its next model call (stop_reason=max_total_tokens) and no further sub-agents are
+    spawned. None = unbounded."""
+    max_tool_output_bytes: int | None = Field(default=None, gt=0)
+    """Byte budget for a single tool result entering the conversation (middle truncation,
+    head + tail, with a warning naming the original size). None = the built-in 20KB
+    default; an explicit value overrides it in either direction."""
     exec_timeout: int = Field(default=300, gt=0)
     max_tokens: int | None = Field(default=None, gt=0)
     compaction: bool = False

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -24,6 +24,7 @@ from rlm.client import (
 from rlm.compaction import (
     COMPACTION_ATTEMPTS,
     CHECKPOINT_PROMPT,
+    TOOL_OUTPUT_MAX_BYTES,
     CompactionFailed,
     REPL_NOTE,
     SUMMARY_FRAMING,
@@ -93,6 +94,23 @@ def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:
     return args, None
 
 
+def _new_tokens(response, usage: TokenUsage) -> int:
+    """One call's contribution to the tree budget: completion + uncached prompt tokens.
+    The cached context prefix re-billed on every call is not new work; a provider that
+    reports no cache detail counts the full prompt (conservative)."""
+    details = getattr(getattr(response, "usage", None), "prompt_tokens_details", None)
+    cached = getattr(details, "cached_tokens", 0) or 0
+    return max(usage.prompt_tokens - cached, 0) + usage.completion_tokens
+
+
+def _last_assistant_text(messages: list[dict]) -> str:
+    """The most recent non-empty assistant content, for a graceful capped stop."""
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant" and msg.get("content"):
+            return msg["content"]
+    return ""
+
+
 class RLMEngine:
     def __init__(
         self,
@@ -119,6 +137,8 @@ class RLMEngine:
         self.model = config.model
         self.cwd = cwd or os.getcwd()
         self.exec_timeout = config.policy.exec_timeout
+        self.max_total_turns = config.policy.max_total_turns
+        self.max_tool_output_bytes = config.policy.max_tool_output_bytes
         self.compaction = config.policy.compaction
         self.summarize_at_tokens = config.policy.summarize_at_tokens
         self.max_compactions = config.policy.max_compactions
@@ -156,6 +176,12 @@ class RLMEngine:
         )
         self._owns_supervisor = False
         self._total_usage = TokenUsage()
+        # Engine-local tree-cap accounting. No supervisor exists when nothing needs
+        # brokering (max_depth=0, no MCP, no search); that session is a one-engine
+        # tree, so its own counters are the tree totals.
+        self._own_turns = 0
+        self._own_new_tokens = 0
+        self._last_handoff_summary: str | None = None
         self._last_prompt_tokens = 0
         self._last_good = 0
         """Message count of the newest state that passed a threshold check - by
@@ -385,8 +411,28 @@ class RLMEngine:
             raise RuntimeError("RLM engine is not started")
 
         final_text = ""
+        # Cap-stop salvage looks only at messages produced by THIS prompt, so a later
+        # prompt on an already-capped session can't replay a stale prior answer.
+        salvage_from = len(messages)
+        self._last_handoff_summary = None
 
         for turn in itertools.count(self._turn):
+            # Cap checks run before the turn is counted, so a capped stop reports the
+            # true number of model calls; the final answer falls back to this prompt's
+            # last assistant text, then a compaction handoff summary, then a marker —
+            # a capped sub-agent still hands its parent something.
+            if capped := self._spent_tree_cap():
+                self._metrics.stop_reason = capped
+                final_text = (
+                    _last_assistant_text(messages[salvage_from:])
+                    or self._last_handoff_summary
+                    or (
+                        "[turn budget reached]"
+                        if capped == "max_total_turns"
+                        else "[token budget reached]"
+                    )
+                )
+                break
             self._turn = turn + 1
             try:
                 response, usage = await self._complete(messages, turn)
@@ -535,7 +581,9 @@ class RLMEngine:
             result = tool_result.content
 
             self.session.log_tool_result(turn, tool_name, result, duration)
-            content = truncate_tool_output(result)
+            content = truncate_tool_output(
+                result, self.max_tool_output_bytes or TOOL_OUTPUT_MAX_BYTES
+            )
             messages.append(
                 {
                     "role": "tool",
@@ -662,10 +710,31 @@ class RLMEngine:
             or self._metrics.num_compactions < self.max_compactions
         )
 
+    def _spent_tree_cap(self) -> str | None:
+        """The stop_reason of a spent tree budget, or None. Live supervisor totals
+        cover the whole tree; without a supervisor this engine is the whole tree."""
+        if self._supervisor is not None:
+            turns = self._supervisor.total_turns
+            tokens = self._supervisor.total_tokens
+        else:
+            turns = self._own_turns
+            tokens = self._own_new_tokens
+        if self.max_total_turns is not None and turns >= self.max_total_turns:
+            return "max_total_turns"
+        budget = self.runtime_config.policy.max_total_tokens
+        if budget is not None and tokens >= budget:
+            return "max_total_tokens"
+        return None
+
     def _should_compact(
         self, messages: list[dict], usage: TokenUsage, extra_text: str = ""
     ) -> bool:
         if self.summarize_at_tokens is None or not self._can_compact():
+            return False
+        # A spent tree cap stops the session next iteration: don't burn a model
+        # call summarizing a conversation that is about to end. (The reactive
+        # overflow path stays available - that call was already permitted.)
+        if self._spent_tree_cap() is not None:
             return False
         if not compactable(messages):
             return False
@@ -705,6 +774,15 @@ class RLMEngine:
         usage = extract_usage(response)
         self._total_usage.prompt_tokens += usage.prompt_tokens
         self._total_usage.completion_tokens += usage.completion_tokens
+        new_tokens = _new_tokens(response, usage)
+        self._own_new_tokens += new_tokens
+        if not checkpoint:
+            self._own_turns += 1
+        if self._supervisor is not None:
+            if checkpoint:
+                self._supervisor.record_usage(new_tokens)
+            else:
+                self._supervisor.record_call(new_tokens)
         if not checkpoint:
             self._last_prompt_tokens = usage.prompt_tokens
             self._last_call_id = request_id
@@ -829,6 +907,7 @@ class RLMEngine:
             raise
 
         system_msg = messages[0]
+        self._last_handoff_summary = summary_text
         compacted_user_content = SUMMARY_FRAMING + "\n\n" + summary_text
         messages[:] = [
             system_msg,

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -96,6 +96,10 @@ class SessionTreeSupervisor:
         self._close_task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
         self._total_calls = 0
+        # live tree totals, pushed by every engine per model call: work-loop turns,
+        # and NEW tokens (completion + uncached prompt)
+        self._total_turns = 0
+        self._total_tokens = 0
         self._tasks: set[asyncio.Task[Any]] = set()
         self._child_tasks: set[asyncio.Task[RLMResult]] = set()
         self._connection_tasks: set[asyncio.Task[None]] = set()
@@ -162,6 +166,25 @@ class SessionTreeSupervisor:
     @property
     def total_calls(self) -> int:
         return self._total_calls
+
+    @property
+    def total_turns(self) -> int:
+        """Live tree-total work-loop turns (every engine's model calls)."""
+        return self._total_turns
+
+    @property
+    def total_tokens(self) -> int:
+        """Live tree-total NEW tokens (completion + uncached prompt, every engine)."""
+        return self._total_tokens
+
+    def record_call(self, tokens: int) -> None:
+        """Count one work-loop model call: a tree turn plus its new tokens."""
+        self._total_turns += 1
+        self._total_tokens += tokens
+
+    def record_usage(self, tokens: int) -> None:
+        """Add new tokens without a turn (compaction/checkpoint calls)."""
+        self._total_tokens += tokens
 
     @property
     def active_calls(self) -> int:
@@ -267,6 +290,21 @@ class SessionTreeSupervisor:
             if self._total_calls >= parent.runtime_config.policy.max_subagent_calls:
                 return asyncio.create_task(
                     self._limit_result(parent, "recursive call limit reached")
+                )
+            policy = parent.runtime_config.policy
+            if (
+                policy.max_total_turns is not None
+                and self._total_turns >= policy.max_total_turns
+            ):
+                return asyncio.create_task(
+                    self._limit_result(parent, "turn budget reached")
+                )
+            if (
+                policy.max_total_tokens is not None
+                and self._total_tokens >= policy.max_total_tokens
+            ):
+                return asyncio.create_task(
+                    self._limit_result(parent, "token budget reached")
                 )
             self._total_calls += 1
             task = asyncio.create_task(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -258,3 +258,75 @@ def test_fetch_tool_validates_args():
     assert tool.schema()["function"]["name"] == "fetch"
     assert tool.execute({}, None).content == "Error: url is required"
     assert "max_chars" in tool.execute({"url": "x.org", "max_chars": 0}, None).content
+
+
+def test_truncate_tool_output_budget_override():
+    """The policy byte budget drives the same mechanism as the built-in default."""
+    from rlm.compaction import truncate_tool_output
+
+    big = "line\n" * 10_000
+    tight = truncate_tool_output(big, max_bytes=1_000)
+    assert len(tight.encode()) < 1_500
+    assert "bytes truncated" in tight
+
+
+def test_new_tokens_excludes_cached_prompt():
+    from types import SimpleNamespace
+
+    from rlm.engine import _new_tokens
+    from rlm.types import TokenUsage
+
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=50)
+    cached = SimpleNamespace(
+        usage=SimpleNamespace(prompt_tokens_details=SimpleNamespace(cached_tokens=900))
+    )
+    assert _new_tokens(cached, usage) == 150
+    assert _new_tokens(SimpleNamespace(usage=None), usage) == 1050
+
+
+async def test_tree_token_budget_stops_engine(session):
+    """Once the live tree total crosses max_total_tokens, the next turn stops gracefully."""
+    from rlm.config import ExecutionPolicy
+
+    messages = [
+        DummyMessage(tool_calls=[DummyToolCall("add", {"a": 1, "b": 2})]),
+        DummyMessage(content="never reached"),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,
+        session=session,
+        runtime_config=make_runtime_config(policy=ExecutionPolicy(max_total_tokens=1)),
+    )  # type: ignore
+
+    result = await engine.run("count things")
+
+    assert engine.stop_reason == "max_total_tokens"
+    assert len(client.calls) == 1
+    assert result.answer == "[token budget reached]"
+    assert result.turns == 1
+
+
+async def test_tree_turn_budget_stops_engine(session):
+    """Once the tree has spent max_total_turns work-loop calls, engines stop gracefully.
+    max_depth=0 means no supervisor exists: the engine-local counters must enforce it."""
+    from rlm.config import ExecutionPolicy
+
+    messages = [
+        DummyMessage(tool_calls=[DummyToolCall("add", {"a": 1, "b": 2})]),
+        DummyMessage(content="never reached"),
+    ]
+    client = DummyClient(messages)
+    engine = RLMEngine(
+        client=client,
+        session=session,
+        runtime_config=make_runtime_config(
+            policy=ExecutionPolicy(max_depth=0, max_total_turns=1)
+        ),
+    )  # type: ignore
+
+    result = await engine.run("count things")
+
+    assert engine.stop_reason == "max_total_turns"
+    assert len(client.calls) == 1
+    assert result.answer == "[turn budget reached]"


### PR DESCRIPTION
Three optional resource caps for recursive sessions, each an `ExecutionPolicy` field on the ACP `runtime-v1` contract (unset = prior behavior). The tree budgets are live stop signals: every engine halts gracefully once they're spent. Contract-only by design — rlm is consumed training-only through the versioned contract.

| `ExecutionPolicy` field | What it bounds |
|---|---|
| `max_total_turns` | **Tree-total** work-loop turn budget (one turn = one model call, any engine; compaction/checkpoint calls excluded), counted live by the supervisor. |
| `max_total_tokens` | **Tree-total** budget of NEW tokens: each call contributes its completion plus uncached prompt (`prompt_tokens_details.cached_tokens`) — the cached prefix re-billed every call is not new work. Compaction calls and failed children count. |
| `max_tool_output_bytes` | One tool result entering the conversation: overrides the built-in 20KB middle-out truncation budget (#147's mechanism, one pass, one warning header). Session logs keep the full output. |

**Enforcement.** Every engine pushes per-call usage to the session supervisor, so the totals are live across the whole tree. Each engine checks the budgets before its next model call and stops gracefully (`stop_reason=max_total_turns|max_total_tokens`, soft by one turn) with true turn counts and a salvaged final answer — this prompt's last assistant text, else the compaction handoff summary, else a bracketed marker — so a capped sub-agent still hands its parent something. The supervisor also refuses new sub-agent spawns on a spent budget ("turn/token budget reached"), and a spent cap suppresses proactive compaction (the reactive overflow path stays available — that call was already permitted). When nothing needs brokering (`max_depth=0`, no MCP, no search) no supervisor exists: the engine's own counters enforce the budgets — a one-engine session is its own whole tree.

**Validated on redsearcher** (deepseek-v4-flash, 8 tasks, sub-agents, 200k budget, 6KB tool cap): 8/8 episodes ended scored with non-empty answers (no wall-clock errors), budget stops fired gracefully, tool messages capped at 6113 bytes with single warning headers. The new-token accounting matters: under billed accounting the same 200k budget starved episodes at ~33 calls (mean reward 0.00); counting new tokens they ran ~170 calls, 3/8 hitting the budget and the rest finishing naturally (mean reward 0.25).

Original motivation (search-taskset eval runs with sub-agents): unbounded turns ate the whole tree budget — completion 5.6% → 90% with caps; raw page dumps flooded contexts.

Dropped along the way, deliberately: `max_output_tokens` (per-call completion cap — truncating a thinking model mid-generation produces degenerate finals), `subagent_summarize_at_tokens` (per-role compaction split — one `summarize_at_tokens` for every engine), and per-session `max_turns` (superseded by the tree-total form). Rebased onto auto-compaction (#147) and consolidated to a single commit. Formerly third of the 4-PR stack; #132/#160 are merged, #151 and #164 remain open behind this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent-loop stopping, token accounting, and sub-agent spawning; misconfigured budgets could cut runs early, but behavior is opt-in and covered by new tests.
> 
> **Overview**
> Adds optional **execution guardrails** on `ExecutionPolicy`: **`max_total_turns`** and **`max_total_tokens`** bound the whole recursive session tree live (supervisor totals when sub-agents exist; engine-local counters when `max_depth=0`). Engines check budgets **before each work-loop model call**, set `stop_reason` to `max_total_turns` or `max_total_tokens`, and return a graceful answer (this prompt’s last assistant text, compaction handoff summary, or a short marker). **New-token** accounting uses completion plus uncached prompt via `_new_tokens`; compaction/checkpoint calls add tokens without counting as turns. Spent caps **block new sub-agents** and **skip proactive compaction** (reactive overflow compaction unchanged).
> 
> **`max_tool_output_bytes`** overrides the default 20KB middle truncation for tool results in the conversation (session logs stay full); `truncate_tool_output` now accepts `max_bytes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 546b915ba2cfa0f52b132e7181a3b833b5ea2779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
