### PR TITLE
fix: recognize vLLM's context-length 400 as request-too-large

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -117,9 +117,15 @@ POST_COMPACTION_FRAMING = (
 
 
 def _is_request_too_large(e: BadRequestError) -> bool:
-    """True if a 400 matches the proxy's "Request Entity Too Large" body."""
+    """True if a 400 says the request outgrew the serving limit, so the session can end
+    with its graceful hard-ceiling stop instead of erroring. Matches the proxy's
+    "Request Entity Too Large" body and vLLM's context-length phrasing
+    ("This model's maximum context length is ..." / "Prompt length ... exceeds the
+    maximum context length")."""
     haystack = f"{e} {getattr(e, 'body', '') or ''}".lower()
-    return "request entity too large" in haystack
+    return (
+        "request entity too large" in haystack or "maximum context length" in haystack
+    )
 
 
 def _parse_tool_call_args(raw: str) -> tuple[dict | None, dict | None]:


### PR DESCRIPTION
The graceful hard-ceiling stop (`stop_reason=request_too_large`, session ends with its final answer) only matched the proxy's "request entity too large" phrasing. vLLM reports context overflow as "This model's maximum context length is …" / "Prompt length … exceeds the maximum context length" — so against a vLLM endpoint an overflowing session raised instead of ending cleanly, and its rollout surfaced as an error rather than a scoreable result. Broaden the matcher to vLLM's phrasing.

Observed in the wild: 20–35% of long-horizon eval rollouts on a 131k-context endpoint died as `ProviderError: upstream 400` where the intended behavior was the clean hard-ceiling ending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to 400 error classification only; other BadRequestErrors still propagate unchanged.
> 
> **Overview**
> When a session hits the model’s context limit, the engine is supposed to **stop cleanly** with `stop_reason=request_too_large` and a final answer—not surface a provider error. That path only recognized the proxy’s **“Request Entity Too Large”** wording, so **vLLM** overflows (messages like **“maximum context length”** / prompt length exceeded) still raised **`BadRequestError`** and failed long-horizon eval rollouts.
> 
> **`_is_request_too_large`** now also matches **`maximum context length`** in the error text/body, so the same graceful hard-ceiling behavior applies on vLLM-backed endpoints during normal turns and during compaction LLM calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c54ab4d9da850daf25bf6fded795fa1d50b6dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->