### PR TITLE
feat!: move builtin tool selection into the runtime contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A minimal CLI coding agent with a persistent IPython execution environment and optional recursive sub-agents. For a full-fledged coding agent built on the same RLM principles, see [prime-agent](https://github.com/PrimeIntellect-ai/prime-agent).
 
-The model gets a single built-in tool, `ipython`: a persistent IPython kernel for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash`. The tool set is not configurable. File edits, shell work, and orchestration all go through it.
+By default the model gets a single built-in tool, `ipython`: a persistent IPython kernel for Python, shell commands via `!command`, and multi-line shell scripts via `%%bash`. File edits, shell work, and orchestration all go through it. The runtime contract's `builtin_tools` list can select a different tool set (`bash`, `edit`, `fetch`, `ipython`) for native tool-calling runs.
 
-For convenience, rlm ships built-in *skills* that can be enabled per session via the runtime contract's `skills` list (off by default): `edit` (single-occurrence string replacement), `search` (web search via Serper, needs `SERPER_API_KEY`), and `fetch` (retrieve a URL as cleaned text). Enabled skills are pre-imported into the IPython kernel like any other skill (see [Skills](#skills)), so the agent calls `await edit(path=..., old_str=..., new_str=...)`, `await search(query=...)`, or `await fetch(url=...)`. `fetch` also exists as a native builtin tool with the same semantics, for tool-calling runs (opt-in via `RLM_BUILTIN_TOOLS`).
+For convenience, rlm ships built-in *skills* that can be enabled per session via the runtime contract's `skills` list (off by default): `edit` (single-occurrence string replacement), `search` (web search via Serper, needs `SERPER_API_KEY`), and `fetch` (retrieve a URL as cleaned text). Enabled skills are pre-imported into the IPython kernel like any other skill (see [Skills](#skills)), so the agent calls `await edit(path=..., old_str=..., new_str=...)`, `await search(query=...)`, or `await fetch(url=...)`. `fetch` also exists as a native builtin tool with the same semantics, for tool-calling runs (opt-in via the contract's `builtin_tools`).
 
 Context compaction is on by default: the engine compacts when 16k tokens remain below an advertised model context window. Termination comes from the default tree-wide budget of 1M new tokens (`max_total_tokens`). The policy can set an explicit `summarize_at_tokens` threshold. The IPython kernel keeps running across compaction, so REPL state survives (see [Compaction](#compaction)).
 
@@ -48,6 +48,7 @@ RLM's ACP surface is a versioned training contract. `initialize` advertises the 
 it, then provide one complete `ai.prime.rlm/runtime-v1` object in
 `session/new._meta`. The runtime object contains the ACP session ID, model,
 provider, execution policy, prompt configuration, enabled built-in skills,
+optional builtin tool selection,
 explicit kernel environment, and optional search credential. Nullable and
 disabled values are sent explicitly as `null` or empty collections. Missing,
 partial, unknown, or unsupported contracts are rejected; ACP sessions never
@@ -81,7 +82,7 @@ no standalone entry point: outside a session the call raises.
 ## Configuration
 
 All runtime configuration enters through the `ai.prime.rlm/runtime-v1` contract object
-(model, provider credentials, execution policy, prompt configuration, skills, kernel
+(model, provider credentials, execution policy, prompt configuration, skills, builtin tools, kernel
 environment, search credential). Prompt configuration is role-aware: optional
 `subagent_append_to_system_prompt` (nodes that can still recurse) and
 `leaf_append_to_system_prompt` (depth == max_depth) override `append_to_system_prompt`

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -73,6 +73,7 @@ class _RuntimeMetadata(_ContractModel):
     subagent_append_to_system_prompt: str | None = None
     leaf_append_to_system_prompt: str | None = None
     skills: list[Annotated[str, Field(min_length=1)]]
+    builtin_tools: list[Annotated[str, Field(min_length=1)]] | None = None
     kernel_env: dict[str, str]
     search_api_key: str | None
 
@@ -207,6 +208,11 @@ def _runtime_config(meta_kwargs: Any) -> tuple[RuntimeConfig, str]:
             subagent_append_to_system_prompt=payload.subagent_append_to_system_prompt,
             leaf_append_to_system_prompt=payload.leaf_append_to_system_prompt,
             skills=tuple(payload.skills),
+            builtin_tools=(
+                tuple(payload.builtin_tools)
+                if payload.builtin_tools is not None
+                else None
+            ),
             kernel_env=tuple(payload.kernel_env.items()),
             search_api_key=payload.search_api_key,
         ),

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -106,6 +106,9 @@ class RuntimeConfig(_ConfigModel):
     subagent_append_to_system_prompt: str | None = None
     leaf_append_to_system_prompt: str | None = None
     skills: tuple[str, ...] = ()
+    builtin_tools: tuple[str, ...] | None = None
+    """Builtin tool set for every engine in the tree; None = the registry default
+    (`ipython` alone). Validated against the registry when the engine starts."""
     kernel_env: tuple[tuple[str, str], ...] = Field(default=(), repr=False)
     search_api_key: str | None = Field(default=None, repr=False)
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -322,6 +322,11 @@ class RLMEngine:
     async def _start(self, prompt: str) -> None:
         """Initialize the session, tools, conversation, and persistent kernel."""
 
+        self._active_tools = get_active_builtin_tools(
+            self.exec_timeout, self.builtin_tools
+        )
+        self._active_tool_schemas = [tool.schema() for tool in self._active_tools]
+
         if self.compaction and self.summarize_at_tokens is None:
             self.summarize_at_tokens = await discover_threshold(self.client, self.model)
 
@@ -384,10 +389,6 @@ class RLMEngine:
         try:
             self._repl.start()
 
-            self._active_tools = get_active_builtin_tools(
-                self.exec_timeout, self.builtin_tools
-            )
-            self._active_tool_schemas = [tool.schema() for tool in self._active_tools]
             system_prompt = self._load_system_prompt(self._active_tools)
 
             self._messages = [

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -148,12 +148,12 @@ class RLMEngine:
         self.depth = config.invocation.depth
         self.allow_git = config.policy.allow_git
 
-        # Task MCP tool servers to expose as IPython skills; kwarg wins, otherwise
-        # parse RLM_MCP_CONFIG (a standard mcpServers config).
+        # Task MCP tool servers to expose as IPython skills.
         self.mcp_servers = validate_mcp_servers(mcp_servers or {})
 
-        # Built-in skills (rlm.skills) to enable for this run, from RLM_SKILLS (comma-separated).
+        # Built-in skills and tool set for this run, from the runtime contract.
         self.skills = list(config.skills)
+        self.builtin_tools = config.builtin_tools
         self.kernel_env = dict(config.kernel_env)
         self.max_tokens = config.policy.max_tokens
 
@@ -384,7 +384,9 @@ class RLMEngine:
         try:
             self._repl.start()
 
-            self._active_tools = get_active_builtin_tools(self.exec_timeout)
+            self._active_tools = get_active_builtin_tools(
+                self.exec_timeout, self.builtin_tools
+            )
             self._active_tool_schemas = [tool.schema() for tool in self._active_tools]
             system_prompt = self._load_system_prompt(self._active_tools)
 
@@ -511,7 +513,7 @@ class RLMEngine:
             tool_name = tc.function.name
             tool_args = parsed_args[0]
             t0 = time.time()
-            tool = get_builtin_tool(tool_name)
+            tool = get_builtin_tool(tool_name, self.builtin_tools)
             if tool is None:
                 tool_result = ToolOutcome(content=f"Error: unknown tool '{tool_name}'")
             else:

--- a/src/rlm/tools/bash.py
+++ b/src/rlm/tools/bash.py
@@ -1,7 +1,8 @@
 """Native ``bash`` builtin tool.
 
 Runs one shell command per call in a fresh subshell, like a plain bash agent.
-Enabled by default alongside ipython; override the tool set with ``RLM_BUILTIN_TOOLS``.
+Selected via the runtime contract's ``builtin_tools`` (the default tool set is
+ipython alone).
 """
 
 from __future__ import annotations

--- a/src/rlm/tools/fetch.py
+++ b/src/rlm/tools/fetch.py
@@ -2,8 +2,9 @@
 
 Tool twin of the ``fetch`` skill (``rlm.skills.fetch``): same cleaning, truncation,
 and error semantics, exposed as a native tool call instead of a REPL function.
-Opt-in: registered but in no tooling preset, so it runs only when named in
-``RLM_BUILTIN_TOOLS`` — a network-capable tool stays off by default.
+Opt-in: outside the default tool set, so it runs only when the runtime
+contract's ``builtin_tools`` names it — a network-capable tool stays off by
+default.
 """
 
 from __future__ import annotations

--- a/src/rlm/tools/registry.py
+++ b/src/rlm/tools/registry.py
@@ -1,14 +1,15 @@
 """Builtin tool registry.
 
-rlm's default is the ``skills`` preset: the persistent IPython REPL as the sole
-tool, with shell and edits as pre-imported REPL skills (``await bash(...)``,
-``await edit(...)``). ``RLM_TOOLING`` selects ``tools`` or ``dual`` presets;
-``RLM_BUILTIN_TOOLS`` (comma-separated) overrides the tool set directly.
+rlm's default tool set is the persistent IPython REPL as the sole tool, with
+shell and edits available as pre-imported REPL skills (``await bash(...)``,
+``await edit(...)``). The runtime contract's ``builtin_tools`` list overrides
+the tool set directly (e.g. ``["bash", "edit", "ipython"]`` for a native tool
+agent).
 """
 
 from __future__ import annotations
 
-import os
+from collections.abc import Sequence
 
 from rlm.tools.base import BuiltinTool
 from rlm.tools.bash import BashTool, EditTool
@@ -16,82 +17,57 @@ from rlm.tools.fetch import FetchTool
 from rlm.tools.ipython import IpythonTool
 
 # All registered tools by name. Tests (and extensions) may add entries; names
-# listed in RLM_BUILTIN_TOOLS or the active preset become active.
+# listed in the contract's `builtin_tools` or the default set become active.
 _TOOLS_BY_NAME: dict[str, BuiltinTool] = {
     "bash": BashTool(),
     "edit": EditTool(),
     "fetch": FetchTool(),
     "ipython": IpythonTool(),
 }
-# NOT an activation list — activation comes from the RLM_TOOLING preset or
-# RLM_BUILTIN_TOOLS. _STOCK only marks the shipped tools so they are excluded from
-# the extras rule below, which auto-activates entries registered at runtime (test
-# fixtures/extensions). A stock tool outside every preset (`fetch` — network-capable)
-# therefore runs only when RLM_BUILTIN_TOOLS names it.
+# NOT an activation list — activation comes from the contract's `builtin_tools`
+# (None = DEFAULT_TOOLS). _STOCK only marks the shipped tools so they are excluded
+# from the extras rule below, which auto-activates entries registered at runtime
+# (test fixtures/extensions). A stock tool outside the default set (`fetch` —
+# network-capable) therefore runs only when `builtin_tools` names it.
 _STOCK = ("bash", "edit", "fetch", "ipython")
+DEFAULT_TOOLS = ("ipython",)
 
 
-_TOOLING_PRESETS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
-    # preset -> (builtin tools, builtin skills)
-    "dual": (("bash", "edit", "ipython"), ("bash", "edit")),
-    "tools": (("bash", "edit", "ipython"), ()),
-    "skills": (("ipython",), ("bash", "edit")),
-}
-
-
-def tooling_preset() -> str:
-    """The RLM_TOOLING preset name: skills (default), tools, or dual."""
-    preset = os.environ.get("RLM_TOOLING", "skills").strip() or "skills"
-    if preset not in _TOOLING_PRESETS:
-        raise ValueError(
-            f"RLM_TOOLING must be one of {sorted(_TOOLING_PRESETS)}, got {preset!r}"
-        )
-    return preset
-
-
-def preset_tools() -> tuple[str, ...]:
-    return _TOOLING_PRESETS[tooling_preset()][0]
-
-
-def preset_skills() -> tuple[str, ...]:
-    return _TOOLING_PRESETS[tooling_preset()][1]
-
-
-def _selected() -> tuple[BuiltinTool, ...]:
-    spec = os.environ.get("RLM_BUILTIN_TOOLS", "").strip()
-    if spec:
-        names = [n.strip() for n in spec.split(",") if n.strip()]
+def _selected(names: Sequence[str] | None) -> tuple[BuiltinTool, ...]:
+    if names is not None:
         unknown = [n for n in names if n not in _TOOLS_BY_NAME]
         if unknown:
             raise ValueError(
-                f"RLM_BUILTIN_TOOLS: unknown tool(s) {unknown}; "
+                f"builtin_tools: unknown tool(s) {unknown}; "
                 f"available: {sorted(_TOOLS_BY_NAME)}"
             )
         return tuple(_TOOLS_BY_NAME[n] for n in names)
-    # default: the RLM_TOOLING preset's tools plus any extra registered tools
-    # (fixtures/extensions).
-    preset = preset_tools()
+    # default: ipython plus any extra registered tools (fixtures/extensions).
     extras = [n for n in _TOOLS_BY_NAME if n not in _STOCK]
-    return tuple(_TOOLS_BY_NAME[n] for n in [*preset, *extras])
+    return tuple(_TOOLS_BY_NAME[n] for n in [*DEFAULT_TOOLS, *extras])
 
 
-def get_active_builtin_tools(exec_timeout: int = 300) -> list[BuiltinTool]:
-    """Return the active tools (per RLM_TOOLING/RLM_BUILTIN_TOOLS), with an
-    engine-specific IPython schema."""
+def get_active_builtin_tools(
+    exec_timeout: int = 300, names: Sequence[str] | None = None
+) -> list[BuiltinTool]:
+    """Return the active tools (the contract's `builtin_tools`, else the
+    default set), with an engine-specific IPython schema."""
     return [
         IpythonTool(exec_timeout) if tool.name == "ipython" else tool
-        for tool in _selected()
+        for tool in _selected(names)
     ]
 
 
-def get_active_tools() -> list[dict]:
+def get_active_tools(names: Sequence[str] | None = None) -> list[dict]:
     """Return OpenAI tool schemas for the active builtins."""
-    return [tool.schema() for tool in _selected()]
+    return [tool.schema() for tool in _selected(names)]
 
 
-def get_builtin_tool(name: str) -> BuiltinTool | None:
-    """Look up a builtin tool handler by name (None if unknown)."""
-    for tool in _selected():
+def get_builtin_tool(
+    name: str, names: Sequence[str] | None = None
+) -> BuiltinTool | None:
+    """Look up an active builtin tool handler by name (None if unknown or inactive)."""
+    for tool in _selected(names):
         if tool.name == name:
             return tool
     return None

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -549,7 +549,9 @@ async def test_engine_cancel_masks_tool_cleanup_error(monkeypatch, session):
         def shutdown(self):
             self.stopped = True
 
-    monkeypatch.setattr("rlm.engine.get_builtin_tool", lambda name: FailingTool())
+    monkeypatch.setattr(
+        "rlm.engine.get_builtin_tool", lambda name, names=None: FailingTool()
+    )
     client = DummyClient(
         [
             DummyMessage(tool_calls=[DummyToolCall("failing", {})]),

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -157,6 +157,24 @@ class _Engine:
         }
 
 
+async def test_engine_rejects_unknown_tools_before_kernel_start(monkeypatch, session):
+    def unexpected_start(self):
+        pytest.fail("invalid tool selection must not start a kernel")
+
+    monkeypatch.setattr("rlm.engine.IPythonREPL.start", unexpected_start)
+    engine = RLMEngine(
+        client=DummyClient([]),
+        session=session,
+        runtime_config=make_runtime_config(builtin_tools=("unknown-tool",)),
+    )
+    try:
+        with pytest.raises(ValueError, match="unknown tool"):
+            await engine.prompt("hello")
+        assert engine._repl is None
+    finally:
+        await engine.aclose()
+
+
 async def test_engine_prompt_preserves_conversation(session):
     client = DummyClient(
         [DummyMessage(content="first"), DummyMessage(content="second")]
@@ -835,12 +853,23 @@ async def test_acp_prompt_snapshot_records_compaction_edge(monkeypatch, tmp_path
     agent = RLMACPAgent()
     agent.on_connect(_Client())  # type: ignore[arg-type]
     runtime_metadata = _runtime_metadata()
+    runtime_metadata[RUNTIME_METADATA_KEY]["builtin_tools"] = ["add"]
     runtime_metadata[RUNTIME_METADATA_KEY]["policy"]["compaction"] = True
     runtime_metadata[RUNTIME_METADATA_KEY]["policy"]["summarize_at_tokens"] = 1
     created = await agent.new_session(str(tmp_path), **runtime_metadata)
 
     try:
         response = await agent.prompt(created.session_id, [text_block("compact")])
+        assert all(
+            [tool["function"]["name"] for tool in call["tools"]] == ["add"]
+            for call in client.calls
+        )
+        outputs = [
+            message["content"]
+            for message in client.calls[1]["messages"]
+            if message["role"] == "tool"
+        ]
+        assert outputs == ["3"]
         semantic_edges = response.field_meta[ACP_SEMANTIC_EDGES_METADATA_KEY]
         request_ids = [
             call["extra_headers"]["X-ACP-Model-Request-ID"] for call in client.calls

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -100,28 +100,20 @@ def test_ipython_kernel_does_not_inherit_parent_stdio(session, capfd):
     assert result.strip() == "4 14"
 
 
-def test_tooling_presets(monkeypatch):
-    from rlm.tools.registry import preset_skills, preset_tools
-
-    monkeypatch.delenv("RLM_TOOLING", raising=False)
-    assert preset_tools() == ("ipython",)
-    assert preset_skills() == ("bash", "edit")
-
-    monkeypatch.setenv("RLM_TOOLING", "dual")
-    assert preset_tools() == ("bash", "edit", "ipython")
-    assert preset_skills() == ("bash", "edit")
-
-    monkeypatch.setenv("RLM_TOOLING", "tools")
-    assert preset_skills() == ()
-
-    monkeypatch.setenv("RLM_TOOLING", "skills")
-    assert preset_tools() == ("ipython",)
-
-    monkeypatch.setenv("RLM_TOOLING", "bogus")
+def test_builtin_tools_selection():
     import pytest
 
-    with pytest.raises(ValueError):
-        preset_tools()
+    from rlm.tools.registry import get_active_builtin_tools
+
+    active = [tool.name for tool in get_active_builtin_tools(names=None)]
+    assert "ipython" in active
+    assert "bash" not in active  # stock tools activate only when named
+
+    names = ["bash", "edit", "ipython"]
+    assert [t.name for t in get_active_builtin_tools(names=names)] == names
+
+    with pytest.raises(ValueError, match="unknown tool"):
+        get_active_builtin_tools(names=["bogus"])
 
 
 def test_real_kernel_and_subprocess_receive_only_explicit_environment(
@@ -239,16 +231,13 @@ def test_truncate_tool_output_caps_and_reports():
     assert "Total output lines: 10001" in out
 
 
-def test_fetch_tool_is_opt_in(monkeypatch):
+def test_fetch_tool_is_opt_in():
     """fetch is registered but joins the active set only when named explicitly."""
     from rlm.tools.registry import get_active_builtin_tools
 
-    monkeypatch.delenv("RLM_BUILTIN_TOOLS", raising=False)
-    monkeypatch.delenv("RLM_TOOLING", raising=False)
     assert "fetch" not in [tool.name for tool in get_active_builtin_tools()]
-
-    monkeypatch.setenv("RLM_BUILTIN_TOOLS", "ipython,fetch")
-    assert [tool.name for tool in get_active_builtin_tools()] == ["ipython", "fetch"]
+    active = [t.name for t in get_active_builtin_tools(names=["ipython", "fetch"])]
+    assert active == ["ipython", "fetch"]
 
 
 def test_fetch_tool_validates_args():


### PR DESCRIPTION
Native tool selection belongs to the session's runtime contract. This change adds `builtin_tools` to `ai.prime.rlm/runtime-v1` and removes tool-selection environment variables and presets.

- Omitted or `null`: use the default tool set (`ipython` for the shipped registry).
- Explicit list: advertise and dispatch only the selected tools; `[]` selects none.
- Children inherit the selection. Unknown names fail before kernel startup.

The shipped tools are `bash`, `edit`, `fetch`, and `ipython`. Tool selection controls the model-facing interface; it is not a sandbox. Deployments using `RLM_TOOLING` or `RLM_BUILTIN_TOOLS` must supply the selection through the contract.

Companion: [Verifiers #2487](https://github.com/PrimeIntellect-ai/verifiers/pull/2487) exposes tool selection and execution controls and pins this PR's tested commit, `9685ad2d09e9d1a08d9aa9ac9a57a3403385c90b`. Merge this PR before adopting that adapter pin.

## Validation

- **165 tests passed**; Ruff lint/format and diff checks passed. Coverage includes ACP tool selection, dispatch, and rejection before kernel startup.
- Verifiers-generated payloads validate against the runtime parser, including default/empty tool sets and execution-policy overrides.
- Three one-task GSM8K evaluations through Prime Inference (`deepseek/deepseek-v4-flash`) and Docker passed with reward 1.0 and zero rollout errors: native Bash, IPython with child delegation, and one forced compaction. The compaction trace retains semantic links and the configured timeout in the tool schema.

These are integration checks, not model-quality evidence. A separate one-token-threshold stress case with unlimited compactions repeatedly re-executed completed work and was stopped after 29 calls; it is not counted as a pass. Remote runtimes, search/fetch networking, and actual timeout/call-cap exhaustion were not exercised live.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for deployments that relied on env vars for tool sets; misconfigured `builtin_tools` alters model-visible capabilities but is validated at engine start.
> 
> **Overview**
> **Breaking:** Native builtin tool selection moves from process env (`RLM_TOOLING`, `RLM_BUILTIN_TOOLS`) into `ai.prime.rlm/runtime-v1` as an optional `builtin_tools` list. Absent/`null` keeps the **`ipython`-only** default so existing clients stay compatible; sub-agents inherit the list via `model_copy` like other runtime fields.
> 
> The tool registry drops preset tables and reads the contract list directly (`bash`, `edit`, `fetch`, `ipython`), validating names when the engine starts—before the IPython kernel spins up on invalid input. The engine resolves active tool schemas up front and passes `builtin_tools` into lookups so only contracted tools are advertised and executable.
> 
> Docs and tests are updated accordingly (including ACP wire tests that assert a custom tool set is sent on model calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9685ad2d09e9d1a08d9aa9ac9a57a3403385c90b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


