### PR TITLE
fix: prompt clarity for weaker models

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -1002,6 +1002,7 @@ class RLMEngine:
             str(SKILLS_DIR) if SKILLS_DIR is not None else None,
             discover_skills(self.session.dir),
             depth=self.depth,
+            session_dir=str(self.session.dir),
             allow_recursion=self.depth < self.max_depth,
             allow_git=self.allow_git,
             active_tools=active_tools,

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -43,6 +43,11 @@ IPYTHON_CONTROL_PROMPT = (
     "Run shell commands with `%%bash` as the very first line of a code cell "
     "(no comments, imports, or statements before it). " + PROJECT_ENV_PROMPT
 )
+KERNEL_PACKAGES_PROMPT = (
+    "Pre-installed in the kernel venv: " + ", ".join(BASE_TOOLKIT) + ". "
+    "Install extra packages with `!uv pip install <pkg>` in a code cell — that "
+    "targets the kernel venv (a uv-managed venv with no pip module)."
+)
 BASH_SKILL_PROMPT = (
     "Run shell with `out = await bash('''command here''')` — always "
     "triple-quote the command so shell quotes and multi-line scripts never "
@@ -86,6 +91,7 @@ def build_system_prompt(
     installed_skills: list[str],
     *,
     depth: int = 0,
+    session_dir: str | None = None,
     allow_recursion: bool,
     allow_git: bool,
     active_tools: list[BuiltinTool],
@@ -93,9 +99,9 @@ def build_system_prompt(
 ) -> str:
     """Build the system prompt.
 
-    Layout: role → environment (cwd, log path, skills) → capabilities
-    (recursion) → tool API. Keep it tight: the model also receives the
-    per-tool schemas, so redundant tool guidance here just inflates
+    Layout: role → environment (cwd, log path, skills, kernel venv) →
+    capabilities (recursion) → guards. Keep it tight: the model also receives
+    the per-tool schemas, so redundant tool guidance here just inflates
     every request.
     """
     has_bash = _has_tool(active_tools, "bash")
@@ -130,14 +136,13 @@ def build_system_prompt(
         )
     else:
         done_line = "When you are done, stop calling tools and state your final answer."
+    log_dir = session_dir or "$RLM_SESSION_DIR"
     parts: list[str] = [
         role,
         done_line,
         "",
         f"Working directory: {cwd}",
-        "Conversation log: $RLM_SESSION_DIR/messages.jsonl",
-        f"Pre-installed Python packages: {', '.join(BASE_TOOLKIT)}.",
-        "Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).",
+        f"Conversation log: {log_dir}/messages.jsonl",
     ]
 
     skill_lines: list[str] = []
@@ -149,8 +154,8 @@ def build_system_prompt(
         installed = ", ".join(f"`{skill}`" for skill in installed_skills)
         skill_lines.append(f"Installed skills (pre-imported): {installed}.")
         skill_lines.append(
-            "Each skill is an async function by the same name. "
-            "Inspect with `help(<skill>)` or `inspect.signature(<skill>.run)`."
+            "Each skill is an async function by the same name; "
+            "inspect one with `help(<skill>)`."
         )
         shell_skill_set = set(shell_skills or [])
         if shell_skill_set:
@@ -167,6 +172,11 @@ def build_system_prompt(
     if skill_lines:
         parts.extend(["", *skill_lines])
 
+    if has_ipython and not has_bash and "bash" not in (installed_skills or []):
+        parts.extend(["", IPYTHON_CONTROL_PROMPT, KERNEL_PACKAGES_PROMPT])
+    elif has_ipython:
+        parts.extend(["", PROJECT_ENV_PROMPT, KERNEL_PACKAGES_PROMPT])
+
     if allow_recursion:
         parts.extend(
             [
@@ -175,11 +185,6 @@ def build_system_prompt(
                 "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
             ]
         )
-
-    if has_ipython and not has_bash and "bash" not in (installed_skills or []):
-        parts.extend(["", IPYTHON_CONTROL_PROMPT])
-    elif has_ipython:
-        parts.extend(["", PROJECT_ENV_PROMPT])
 
     if _should_include_git_history_guard(active_tools, allow_git):
         parts.extend(["", GIT_HISTORY_GUARD_PROMPT])

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -253,7 +253,7 @@ class IPythonREPL:
         skill_names = discover_skills(self.session.dir if self.session else None)
 
         setup_code = f"""\
-import os, sys, types, json, time, functools, inspect
+import os, sys, asyncio, types, json, time, functools, inspect
 os.chdir({self.cwd!r})
 if {bool(session_dir)!r}:
     sys.path.append({session_dir!r})


### PR DESCRIPTION
Four clarity fixes to the generated system prompt, aimed at weaker models. No behavioral policy changes — every instruction still says the same thing, it just can no longer be misread.

## What changed

**1. The two-Python-environments story is now one block.** The kernel's package list and the `uv pip install` line lived at the top of the prompt, while the "kernel is an isolated venv / project code goes through bash" paragraph sat near the bottom — a weak model had to synthesize across the gap that there are *two* environments, and the install line never said which one it targets. The isolation note, package list, and install command are now a single block placed right after the skills section, and the install line states where packages land: `!uv pip install <pkg>` in a code cell targets the kernel venv (true — the kernel inherits `VIRTUAL_ENV`). The kernel lines also no longer render when ipython isn't an active tool.

**2. The conversation-log line names the real path.** `$RLM_SESSION_DIR/messages.jsonl` is shell syntax handed to a Python-first agent; `open("$RLM_SESSION_DIR/messages.jsonl")` is a guaranteed FileNotFoundError. The engine knows the session dir when it builds the prompt, so it now inlines the absolute path (the env-var form remains the fallback when no session dir is passed).

**3. Skill introspection is just `help(<skill>)` now.** The old line suggested `inspect.signature(<skill>.run)`, which contradicts "each skill is an async function by the same name" (functions don't have `.run`) — a confusing dual mental model of what a skill is. The wrapper already mirrors `__signature__`/`__doc__` onto the skill, so `help(<skill>)` shows the real API on its own.

**4. `asyncio` is pre-imported in the kernel.** The recursion hint (`await asyncio.gather(rlm(...), rlm(...))`) and the search skill's fan-out hint both NameError'd until the model imported asyncio itself; weaker models sometimes conclude parallelism "doesn't work" and serialize everything. One name added to the kernel bootstrap imports makes the prompt's own suggestions runnable as written.

## Validation

- `uv run pytest tests/` — 161 passed
- ruff check + format clean


## Before/after on SWE-bench Pro

32 stratified tasks (3 per repo across all 11 repos; identical task list in every arm), k=1, three models via Prime Inference, stock harness settings except `max_depth=1` and a 1h rollout wall clock. **before** = main (`7eaff71`), **after** = #151 + #166 stacked (`c886994`). Zero harness errors across ~190 rollouts.

| model | arm | n | mean reward | solved | turns/rollout | tokens/rollout |
|---|---|---|---|---|---|---|
| z-ai/glm-5.3 | before | 32 | 0.562 | 18/32 | 82.8 | 143k |
| z-ai/glm-5.3 | after | 32 | **0.656** | **21/32** | 78.2 | 141k |
| deepseek-v4-flash | before | 32 | 0.438 | 14/32 | 74.3 | 123k |
| deepseek-v4-flash | after | 32 | 0.438 | 14/32 | 72.5 | 111k |
| kimi-k3 | before | 31 | 0.581 | 18/31 | 59.3 | 165k |
| kimi-k3 | after | 32 | 0.594 | 19/32 | 57.5 | 157k |

Paired on shared tasks: glm-5.3 **3W/0L/29T** (sign p=0.25), deepseek 2W/2L/28T, kimi-k3 2W/1L/28T. The after arm is never worse on reward and slightly cheaper on every model (fewer turns and tokens). Individual deltas are within noise at n=32/k=1; the uniform direction across three models is the signal.

Since sub-agents were almost never spawned in these runs (one `rlm()` call across ~190 rollouts), the measured effect is attributable to this PR's root-prompt changes rather than #151's sub-agent contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt text and kernel startup imports only; no auth, persistence, or tool execution policy changes.
> 
> **Overview**
> **Tightens the generated system prompt** so weaker models are less likely to misread environment and tooling guidance—wording only, no policy change.
> 
> The **conversation log path** is now the real session directory when the engine builds the prompt (`{session_dir}/messages.jsonl`), instead of shell-style `$RLM_SESSION_DIR` that breaks in Python `open()`.
> 
> **Kernel venv guidance** is grouped in one block after skills (only when IPython is active): isolated kernel vs project code via bash, pre-installed `BASE_TOOLKIT` packages, and **`!uv pip install`** explicitly targeting the kernel venv. Those lines were removed from the top of the prompt where they were separated from the isolation note.
> 
> **Skill introspection** is simplified to `help(<skill>)` only, dropping the conflicting `inspect.signature(<skill>.run)` hint.
> 
> The **IPython kernel bootstrap** pre-imports **`asyncio`** so prompt examples like `asyncio.gather` for parallel `rlm`/`search` calls work without an extra import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8869947e2d0efb78d450102431782880f3e4ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
