### PR TITLE
feat: preserve compaction attempt provenance

### DIFF
--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -55,6 +55,7 @@ CONTRACT_METADATA_KEY = "ai.prime.rlm/contract-v1"
 SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
 RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
 ACP_SEMANTIC_EDGES_METADATA_KEY = "ai.prime.acp/semantic-edges-v1"
+ACP_TRAINING_EXCLUSIONS_METADATA_KEY = "ai.prime.acp/training-exclusions-v1"
 
 
 class _ContractModel(BaseModel):
@@ -117,6 +118,10 @@ class _SemanticEdgeSet(_ContractModel):
     edges: list[_SemanticEdge]
 
 
+class _TrainingExclusions(_ContractModel):
+    request_ids: list[str]
+
+
 class _SessionSnapshot(_ContractModel):
     session_id: str = Field(pattern=r"^[A-Za-z0-9._:-]{1,128}$")
     last_stop_reason: str | None
@@ -161,10 +166,16 @@ def _session_metadata(state: _SessionState) -> dict[str, Any]:
         **state.engine.execution_snapshot(),
     }
     semantic_edges = _SemanticEdgeSet.model_validate(snapshot.pop("semantic_edges"))
+    training_exclusions = _TrainingExclusions.model_validate(
+        snapshot.pop("training_exclusions")
+    )
     validated = _SessionSnapshot.model_validate(snapshot)
     return {
         SESSION_METADATA_KEY: validated.model_dump(mode="json", exclude_none=True),
         ACP_SEMANTIC_EDGES_METADATA_KEY: semantic_edges.model_dump(
+            mode="json", exclude_none=True
+        ),
+        ACP_TRAINING_EXCLUSIONS_METADATA_KEY: training_exclusions.model_dump(
             mode="json", exclude_none=True
         ),
     }

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -55,7 +55,6 @@ CONTRACT_METADATA_KEY = "ai.prime.rlm/contract-v1"
 SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
 RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
 ACP_SEMANTIC_EDGES_METADATA_KEY = "ai.prime.acp/semantic-edges-v1"
-ACP_TRAINING_EXCLUSIONS_METADATA_KEY = "ai.prime.acp/training-exclusions-v1"
 
 
 class _ContractModel(BaseModel):
@@ -118,10 +117,6 @@ class _SemanticEdgeSet(_ContractModel):
     edges: list[_SemanticEdge]
 
 
-class _TrainingExclusions(_ContractModel):
-    request_ids: list[str]
-
-
 class _SessionSnapshot(_ContractModel):
     session_id: str = Field(pattern=r"^[A-Za-z0-9._:-]{1,128}$")
     last_stop_reason: str | None
@@ -166,16 +161,10 @@ def _session_metadata(state: _SessionState) -> dict[str, Any]:
         **state.engine.execution_snapshot(),
     }
     semantic_edges = _SemanticEdgeSet.model_validate(snapshot.pop("semantic_edges"))
-    training_exclusions = _TrainingExclusions.model_validate(
-        snapshot.pop("training_exclusions")
-    )
     validated = _SessionSnapshot.model_validate(snapshot)
     return {
         SESSION_METADATA_KEY: validated.model_dump(mode="json", exclude_none=True),
         ACP_SEMANTIC_EDGES_METADATA_KEY: semantic_edges.model_dump(
-            mode="json", exclude_none=True
-        ),
-        ACP_TRAINING_EXCLUSIONS_METADATA_KEY: training_exclusions.model_dump(
             mode="json", exclude_none=True
         ),
     }

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -841,9 +841,10 @@ class RLMEngine:
         """Ask the model for a handoff summary and rebuild ``messages``.
 
         Called in-place: mutates ``messages`` to ``[system, user(framing +
-        summary)]`` while preserving the IPython kernel. The LLM call for the
-        summary is housekeeping, not a work turn, but its tokens land in
-        ``_total_usage`` for cost accounting.
+        summary)]`` while preserving the IPython kernel. A summary attempt does
+        not count toward the policy turn limit, but all attempts remain in the
+        trace: accepted summary tokens are trainable, while rejected attempts
+        are explicitly excluded from training.
 
         Active tools are forwarded with ``tool_choice="none"`` so the system prompt matches
         regular turns (vLLM's chat-completions layer injects the tools
@@ -891,9 +892,7 @@ class RLMEngine:
                 if not message.tool_calls and text:
                     summary_text = text
                     break
-                # An unusable reply finished its request without failing it, so the
-                # compaction still holds the claim - release it for the resample.
-                self._semantic_edges.release_summary_request(compaction.compaction_id)
+                self._semantic_edges.reject_summary_request(compaction.compaction_id)
             if not summary_text:
                 raise CompactionFailed(
                     f"no usable summary after {self.max_compaction_attempts} attempts"
@@ -991,6 +990,7 @@ class RLMEngine:
                 "allow_git": self.runtime_config.policy.allow_git,
             },
             "semantic_edges": self._semantic_edges.snapshot(),
+            "training_exclusions": self._semantic_edges.exclusions_snapshot(),
         }
         return snapshot
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -842,9 +842,8 @@ class RLMEngine:
 
         Called in-place: mutates ``messages`` to ``[system, user(framing +
         summary)]`` while preserving the IPython kernel. A summary attempt does
-        not count toward the policy turn limit, but all attempts remain in the
-        trace: accepted summary tokens are trainable, while rejected attempts
-        are explicitly excluded from training.
+        not count toward the policy turn limit, but every committed attempt remains
+        represented in the semantic graph.
 
         Active tools are forwarded with ``tool_choice="none"`` so the system prompt matches
         regular turns (vLLM's chat-completions layer injects the tools
@@ -892,7 +891,7 @@ class RLMEngine:
                 if not message.tool_calls and text:
                     summary_text = text
                     break
-                self._semantic_edges.reject_summary_request(compaction.compaction_id)
+                self._semantic_edges.release_summary_request(compaction.compaction_id)
             if not summary_text:
                 raise CompactionFailed(
                     f"no usable summary after {self.max_compaction_attempts} attempts"
@@ -990,7 +989,6 @@ class RLMEngine:
                 "allow_git": self.runtime_config.policy.allow_git,
             },
             "semantic_edges": self._semantic_edges.snapshot(),
-            "training_exclusions": self._semantic_edges.exclusions_snapshot(),
         }
         return snapshot
 

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -841,9 +841,11 @@ class RLMEngine:
         """Ask the model for a handoff summary and rebuild ``messages``.
 
         Called in-place: mutates ``messages`` to ``[system, user(framing +
-        summary)]`` while preserving the IPython kernel. A summary attempt does
-        not count toward the policy turn limit, but every committed attempt remains
-        represented in the semantic graph.
+        summary)]`` while preserving the IPython kernel. A summary attempt is
+        housekeeping, not a work turn: it does not count toward ``max_total_turns``.
+        Its tokens still land in ``_total_usage`` for cost accounting and count
+        toward token budgets. Every committed attempt remains represented in the
+        semantic graph.
 
         Active tools are forwarded with ``tool_choice="none"`` so the system prompt matches
         regular turns (vLLM's chat-completions layer injects the tools

--- a/src/rlm/semantic.py
+++ b/src/rlm/semantic.py
@@ -64,7 +64,6 @@ class SemanticEdgeTracker:
         self._requests: dict[str, _Request] = {}
         self._compactions: dict[str, _Compaction] = {}
         self._edges: list[dict[str, str]] = []
-        self._excluded_request_ids: list[str] = []
 
     def register_session(
         self,
@@ -94,9 +93,6 @@ class SemanticEdgeTracker:
     def restore(self, session_id: str, checkpoint: _Checkpoint) -> None:
         """Restore the semantic continuation point after a rolled-back prompt."""
         session = self._sessions[session_id]
-        for edge in session.pending_edges:
-            if edge.type == "compaction":
-                self._exclude_request(edge.source_request_id)
         session.pending_edges = list(checkpoint.pending_edges)
         session.last_request_id = checkpoint.last_request_id
         session.spawn_claimed = checkpoint.spawn_claimed
@@ -161,18 +157,12 @@ class SemanticEdgeTracker:
             return
         session.pending_edges = request.inbound_edges + session.pending_edges
 
-    def reject_summary_request(self, compaction_id: str) -> None:
-        """Exclude a committed summary attempt and release the next attempt slot."""
+    def release_summary_request(self, compaction_id: str) -> None:
+        """Release a committed summary attempt so another attempt can start."""
         compaction = self._compactions[compaction_id]
-        request_id = compaction.summary_request_id
-        if request_id is None:
+        if compaction.summary_request_id is None:
             raise ValueError("compaction has no summary request to reject")
-        self._exclude_request(request_id)
         compaction.summary_request_id = None
-
-    def _exclude_request(self, request_id: str) -> None:
-        if request_id not in self._excluded_request_ids:
-            self._excluded_request_ids.append(request_id)
 
     def begin_compaction(self, session_id: str) -> Compaction:
         session = self._sessions[session_id]
@@ -213,6 +203,3 @@ class SemanticEdgeTracker:
 
     def snapshot(self) -> dict[str, list[dict[str, str]]]:
         return {"edges": [edge.copy() for edge in self._edges]}
-
-    def exclusions_snapshot(self) -> dict[str, list[str]]:
-        return {"request_ids": list(self._excluded_request_ids)}

--- a/src/rlm/semantic.py
+++ b/src/rlm/semantic.py
@@ -53,6 +53,7 @@ class _Request:
 class _Compaction:
     session_id: str
     source_request_id: str | None
+    pending_edges: tuple[_PendingEdge, ...]
     summary_request_id: str | None = None
 
 
@@ -110,10 +111,15 @@ class SemanticEdgeTracker:
                 raise ValueError("compaction does not belong to session")
             if compaction.summary_request_id is not None:
                 raise ValueError("compaction already has a summary request")
-            inbound = (
-                [_PendingEdge(compaction.source_request_id, "compaction_attempt")]
-                if compaction.source_request_id is not None
-                else []
+            inbound = []
+            if compaction.source_request_id is not None:
+                inbound.append(
+                    _PendingEdge(compaction.source_request_id, "compaction_attempt")
+                )
+            inbound.extend(
+                edge
+                for edge in compaction.pending_edges
+                if edge.source_request_id != compaction.source_request_id
             )
         else:
             inbound = session.pending_edges
@@ -170,6 +176,7 @@ class SemanticEdgeTracker:
         self._compactions[compaction_id] = _Compaction(
             session_id=session_id,
             source_request_id=session.last_request_id,
+            pending_edges=tuple(session.pending_edges),
         )
         return Compaction(compaction_id=compaction_id, session_id=session_id)
 
@@ -183,6 +190,10 @@ class SemanticEdgeTracker:
             raise ValueError(
                 "completed compaction requires a successful summary request"
             )
+        captured_edges = list(compaction.pending_edges)
+        if session.pending_edges[: len(captured_edges)] != captured_edges:
+            raise ValueError("session pending edges changed during compaction")
+        del session.pending_edges[: len(captured_edges)]
         session.last_request_id = summary_request_id
         session.pending_edges.append(_PendingEdge(summary_request_id, "compaction"))
 

--- a/src/rlm/semantic.py
+++ b/src/rlm/semantic.py
@@ -52,6 +52,7 @@ class _Request:
 @dataclass
 class _Compaction:
     session_id: str
+    source_request_id: str | None
     summary_request_id: str | None = None
 
 
@@ -63,6 +64,7 @@ class SemanticEdgeTracker:
         self._requests: dict[str, _Request] = {}
         self._compactions: dict[str, _Compaction] = {}
         self._edges: list[dict[str, str]] = []
+        self._excluded_request_ids: list[str] = []
 
     def register_session(
         self,
@@ -92,6 +94,9 @@ class SemanticEdgeTracker:
     def restore(self, session_id: str, checkpoint: _Checkpoint) -> None:
         """Restore the semantic continuation point after a rolled-back prompt."""
         session = self._sessions[session_id]
+        for edge in session.pending_edges:
+            if edge.type == "compaction":
+                self._exclude_request(edge.source_request_id)
         session.pending_edges = list(checkpoint.pending_edges)
         session.last_request_id = checkpoint.last_request_id
         session.spawn_claimed = checkpoint.spawn_claimed
@@ -103,24 +108,33 @@ class SemanticEdgeTracker:
         compaction_id: str | None = None,
     ) -> str:
         session = self._sessions[session_id]
-        inbound = session.pending_edges
-        session.pending_edges = []
-        if not session.spawn_claimed and session.spawned_by_request_id is not None:
-            inbound.append(_PendingEdge(session.spawned_by_request_id, "subagent_call"))
-            session.spawn_claimed = True
-        if session.last_request_id is not None and not any(
-            edge.source_request_id == session.last_request_id for edge in inbound
-        ):
-            inbound.append(_PendingEdge(session.last_request_id, "continuation"))
-
-        request_id = uuid.uuid4().hex
-        self._requests[request_id] = _Request(session_id, inbound, compaction_id)
         if compaction_id is not None:
             compaction = self._compactions[compaction_id]
             if compaction.session_id != session_id:
                 raise ValueError("compaction does not belong to session")
             if compaction.summary_request_id is not None:
                 raise ValueError("compaction already has a summary request")
+            inbound = (
+                [_PendingEdge(compaction.source_request_id, "compaction_attempt")]
+                if compaction.source_request_id is not None
+                else []
+            )
+        else:
+            inbound = session.pending_edges
+            session.pending_edges = []
+            if not session.spawn_claimed and session.spawned_by_request_id is not None:
+                inbound.append(
+                    _PendingEdge(session.spawned_by_request_id, "subagent_call")
+                )
+                session.spawn_claimed = True
+            if session.last_request_id is not None and not any(
+                edge.source_request_id == session.last_request_id for edge in inbound
+            ):
+                inbound.append(_PendingEdge(session.last_request_id, "continuation"))
+
+        request_id = uuid.uuid4().hex
+        self._requests[request_id] = _Request(session_id, inbound, compaction_id)
+        if compaction_id is not None:
             compaction.summary_request_id = request_id
         return request_id
 
@@ -134,27 +148,39 @@ class SemanticEdgeTracker:
                     "type": inbound.type,
                 }
             )
-        self._sessions[request.session_id].last_request_id = request_id
+        if request.compaction_id is None:
+            self._sessions[request.session_id].last_request_id = request_id
 
     def fail_request(self, request_id: str) -> None:
         request = self._requests.pop(request_id)
         session = self._sessions[request.session_id]
-        session.pending_edges = request.inbound_edges + session.pending_edges
-        # A failed summary attempt releases its compaction, so a retry can claim it.
         if request.compaction_id is not None:
             compaction = self._compactions.get(request.compaction_id)
             if compaction is not None and compaction.summary_request_id == request_id:
                 compaction.summary_request_id = None
+            return
+        session.pending_edges = request.inbound_edges + session.pending_edges
 
-    def release_summary_request(self, compaction_id: str) -> None:
-        """Unbind a compaction's summary request so a resampled attempt can claim it."""
-        compaction = self._compactions.get(compaction_id)
-        if compaction is not None:
-            compaction.summary_request_id = None
+    def reject_summary_request(self, compaction_id: str) -> None:
+        """Exclude a committed summary attempt and release the next attempt slot."""
+        compaction = self._compactions[compaction_id]
+        request_id = compaction.summary_request_id
+        if request_id is None:
+            raise ValueError("compaction has no summary request to reject")
+        self._exclude_request(request_id)
+        compaction.summary_request_id = None
+
+    def _exclude_request(self, request_id: str) -> None:
+        if request_id not in self._excluded_request_ids:
+            self._excluded_request_ids.append(request_id)
 
     def begin_compaction(self, session_id: str) -> Compaction:
+        session = self._sessions[session_id]
         compaction_id = uuid.uuid4().hex
-        self._compactions[compaction_id] = _Compaction(session_id=session_id)
+        self._compactions[compaction_id] = _Compaction(
+            session_id=session_id,
+            source_request_id=session.last_request_id,
+        )
         return Compaction(compaction_id=compaction_id, session_id=session_id)
 
     def finish_compaction(self, compaction_id: str, status: CompactionStatus) -> None:
@@ -163,10 +189,11 @@ class SemanticEdgeTracker:
             return
         summary_request_id = compaction.summary_request_id
         session = self._sessions[compaction.session_id]
-        if summary_request_id is None or session.last_request_id != summary_request_id:
+        if summary_request_id is None:
             raise ValueError(
                 "completed compaction requires a successful summary request"
             )
+        session.last_request_id = summary_request_id
         session.pending_edges.append(_PendingEdge(summary_request_id, "compaction"))
 
     def finish_subagent(self, session_id: str) -> None:
@@ -186,3 +213,6 @@ class SemanticEdgeTracker:
 
     def snapshot(self) -> dict[str, list[dict[str, str]]]:
         return {"edges": [edge.copy() for edge in self._edges]}
+
+    def exclusions_snapshot(self) -> dict[str, list[str]]:
+        return {"request_ids": list(self._excluded_request_ids)}

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -16,7 +16,6 @@ import pytest
 
 from conftest import DummyClient, DummyMessage, DummyToolCall, make_runtime_config
 from rlm.acp import (
-    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     ACP_SEMANTIC_EDGES_METADATA_KEY,
     CONTRACT_METADATA_KEY,
     RUNTIME_METADATA_KEY,
@@ -155,7 +154,6 @@ class _Engine:
                 "allow_git": False,
             },
             "semantic_edges": {"edges": []},
-            "training_exclusions": {"request_ids": []},
         }
 
 
@@ -805,7 +803,6 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert second_snapshot["usage"]["total_tokens"] == 10
     assert second_snapshot["last_stop_reason"] == "done"
     assert first.field_meta[ACP_SEMANTIC_EDGES_METADATA_KEY] == {"edges": []}
-    assert first.field_meta[ACP_TRAINING_EXCLUSIONS_METADATA_KEY] == {"request_ids": []}
 
     closed = await agent.close_session(created.session_id)
     closed_snapshot = closed.field_meta[SESSION_METADATA_KEY]
@@ -814,9 +811,6 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert closed_snapshot["last_stop_reason"] == "done"
     assert "semantic_edges" not in closed_snapshot
     assert closed.field_meta[ACP_SEMANTIC_EDGES_METADATA_KEY] == {"edges": []}
-    assert closed.field_meta[ACP_TRAINING_EXCLUSIONS_METADATA_KEY] == {
-        "request_ids": []
-    }
     assert "test-secret" not in closed.model_dump_json(by_alias=True)
     assert engine.closed is True
 
@@ -872,9 +866,6 @@ async def test_acp_prompt_snapshot_records_compaction_edge(monkeypatch, tmp_path
                 "type": "compaction",
             },
         ]
-        assert response.field_meta[ACP_TRAINING_EXCLUSIONS_METADATA_KEY] == {
-            "request_ids": [rejected_tool, rejected_empty]
-        }
     finally:
         await agent.close_session(created.session_id)
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -16,6 +16,7 @@ import pytest
 
 from conftest import DummyClient, DummyMessage, DummyToolCall, make_runtime_config
 from rlm.acp import (
+    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     ACP_SEMANTIC_EDGES_METADATA_KEY,
     CONTRACT_METADATA_KEY,
     RUNTIME_METADATA_KEY,
@@ -154,6 +155,7 @@ class _Engine:
                 "allow_git": False,
             },
             "semantic_edges": {"edges": []},
+            "training_exclusions": {"request_ids": []},
         }
 
 
@@ -359,7 +361,7 @@ async def test_model_call_idempotency_survives_retry_and_compaction(
         {
             "source_request_id": turn["X-ACP-Model-Request-ID"],
             "target_request_id": compaction["X-ACP-Model-Request-ID"],
-            "type": "continuation",
+            "type": "compaction_attempt",
         },
         {
             "source_request_id": compaction["X-ACP-Model-Request-ID"],
@@ -515,7 +517,7 @@ async def test_failed_prompt_restores_pre_compaction_context(session):
         {
             "source_request_id": initial,
             "target_request_id": summary,
-            "type": "continuation",
+            "type": "compaction_attempt",
         },
         {
             "source_request_id": summary,
@@ -803,6 +805,7 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert second_snapshot["usage"]["total_tokens"] == 10
     assert second_snapshot["last_stop_reason"] == "done"
     assert first.field_meta[ACP_SEMANTIC_EDGES_METADATA_KEY] == {"edges": []}
+    assert first.field_meta[ACP_TRAINING_EXCLUSIONS_METADATA_KEY] == {"request_ids": []}
 
     closed = await agent.close_session(created.session_id)
     closed_snapshot = closed.field_meta[SESSION_METADATA_KEY]
@@ -811,6 +814,9 @@ async def test_acp_session_reuses_engine(monkeypatch, tmp_path):
     assert closed_snapshot["last_stop_reason"] == "done"
     assert "semantic_edges" not in closed_snapshot
     assert closed.field_meta[ACP_SEMANTIC_EDGES_METADATA_KEY] == {"edges": []}
+    assert closed.field_meta[ACP_TRAINING_EXCLUSIONS_METADATA_KEY] == {
+        "request_ids": []
+    }
     assert "test-secret" not in closed.model_dump_json(by_alias=True)
     assert engine.closed is True
 
@@ -819,6 +825,8 @@ async def test_acp_prompt_snapshot_records_compaction_edge(monkeypatch, tmp_path
     client = DummyClient(
         [
             DummyMessage(tool_calls=[DummyToolCall("add", {"a": 1, "b": 2})]),
+            DummyMessage(tool_calls=[DummyToolCall("add", {"a": 3, "b": 4})]),
+            DummyMessage(content="  "),
             DummyMessage(content="summary"),
             DummyMessage(content="done"),
         ]
@@ -838,26 +846,35 @@ async def test_acp_prompt_snapshot_records_compaction_edge(monkeypatch, tmp_path
     try:
         response = await agent.prompt(created.session_id, [text_block("compact")])
         semantic_edges = response.field_meta[ACP_SEMANTIC_EDGES_METADATA_KEY]
+        request_ids = [
+            call["extra_headers"]["X-ACP-Model-Request-ID"] for call in client.calls
+        ]
+        turn, rejected_tool, rejected_empty, accepted, resumed = request_ids
         assert semantic_edges["edges"] == [
             {
-                "source_request_id": client.calls[0]["extra_headers"][
-                    "X-ACP-Model-Request-ID"
-                ],
-                "target_request_id": client.calls[1]["extra_headers"][
-                    "X-ACP-Model-Request-ID"
-                ],
-                "type": "continuation",
+                "source_request_id": turn,
+                "target_request_id": rejected_tool,
+                "type": "compaction_attempt",
             },
             {
-                "source_request_id": client.calls[1]["extra_headers"][
-                    "X-ACP-Model-Request-ID"
-                ],
-                "target_request_id": client.calls[2]["extra_headers"][
-                    "X-ACP-Model-Request-ID"
-                ],
+                "source_request_id": turn,
+                "target_request_id": rejected_empty,
+                "type": "compaction_attempt",
+            },
+            {
+                "source_request_id": turn,
+                "target_request_id": accepted,
+                "type": "compaction_attempt",
+            },
+            {
+                "source_request_id": accepted,
+                "target_request_id": resumed,
                 "type": "compaction",
             },
         ]
+        assert response.field_meta[ACP_TRAINING_EXCLUSIONS_METADATA_KEY] == {
+            "request_ids": [rejected_tool, rejected_empty]
+        }
     finally:
         await agent.close_session(created.session_id)
 

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -102,6 +102,88 @@ def test_completed_compaction_links_summary_to_resumed_request():
     ]
 
 
+def test_compaction_consumes_restored_edges_but_preserves_late_returns():
+    lineage = SemanticEdgeTracker()
+    lineage.register_session("root", parent_session_id=None)
+    preceding_request = _finish(lineage, "root")
+
+    lineage.register_session(
+        "early-child",
+        parent_session_id="root",
+        spawned_by_request_id=preceding_request,
+    )
+    early_child_request = _finish(lineage, "early-child")
+    lineage.finish_subagent("early-child")
+
+    failed_request = lineage.start_request("root")
+    lineage.fail_request(failed_request)
+    compaction = lineage.begin_compaction("root")
+
+    rejected_summary = lineage.start_request(
+        "root", compaction_id=compaction.compaction_id
+    )
+    lineage.finish_request(rejected_summary)
+    lineage.release_summary_request(compaction.compaction_id)
+
+    lineage.register_session(
+        "late-child",
+        parent_session_id="root",
+        spawned_by_request_id=preceding_request,
+    )
+    late_child_request = _finish(lineage, "late-child")
+    lineage.finish_subagent("late-child")
+
+    accepted_summary = lineage.start_request(
+        "root", compaction_id=compaction.compaction_id
+    )
+    lineage.finish_request(accepted_summary)
+    lineage.finish_compaction(compaction.compaction_id, "completed")
+    resumed_request = _finish(lineage, "root")
+
+    assert lineage.snapshot()["edges"] == [
+        {
+            "source_request_id": preceding_request,
+            "target_request_id": early_child_request,
+            "type": "subagent_call",
+        },
+        {
+            "source_request_id": preceding_request,
+            "target_request_id": rejected_summary,
+            "type": "compaction_attempt",
+        },
+        {
+            "source_request_id": early_child_request,
+            "target_request_id": rejected_summary,
+            "type": "subagent_return",
+        },
+        {
+            "source_request_id": preceding_request,
+            "target_request_id": late_child_request,
+            "type": "subagent_call",
+        },
+        {
+            "source_request_id": preceding_request,
+            "target_request_id": accepted_summary,
+            "type": "compaction_attempt",
+        },
+        {
+            "source_request_id": early_child_request,
+            "target_request_id": accepted_summary,
+            "type": "subagent_return",
+        },
+        {
+            "source_request_id": late_child_request,
+            "target_request_id": resumed_request,
+            "type": "subagent_return",
+        },
+        {
+            "source_request_id": accepted_summary,
+            "target_request_id": resumed_request,
+            "type": "compaction",
+        },
+    ]
+
+
 def test_failed_compaction_publishes_no_transition():
     lineage = SemanticEdgeTracker()
     lineage.register_session("root", parent_session_id=None)

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -92,7 +92,7 @@ def test_completed_compaction_links_summary_to_resumed_request():
         {
             "source_request_id": preceding_request,
             "target_request_id": summary_request,
-            "type": "continuation",
+            "type": "compaction_attempt",
         },
         {
             "source_request_id": summary_request,
@@ -116,9 +116,10 @@ def test_failed_compaction_publishes_no_transition():
     assert lineage.snapshot() == {"edges": []}
 
 
-def test_prompt_rollback_discards_unconsumed_compaction_transition():
+def test_prompt_rollback_keeps_and_excludes_unconsumed_compaction_attempt():
     lineage = SemanticEdgeTracker()
     lineage.register_session("root", parent_session_id=None)
+    preceding_request = _finish(lineage, "root")
     before = lineage.checkpoint("root")
     compaction = lineage.begin_compaction("root")
     summary_request = lineage.start_request(
@@ -129,9 +130,23 @@ def test_prompt_rollback_discards_unconsumed_compaction_transition():
     failed_target = lineage.start_request("root")
     lineage.fail_request(failed_target)
     lineage.restore("root", before)
-    _finish(lineage, "root")
+    retried_request = _finish(lineage, "root")
 
-    assert lineage.snapshot() == {"edges": []}
+    assert lineage.snapshot() == {
+        "edges": [
+            {
+                "source_request_id": preceding_request,
+                "target_request_id": summary_request,
+                "type": "compaction_attempt",
+            },
+            {
+                "source_request_id": preceding_request,
+                "target_request_id": retried_request,
+                "type": "continuation",
+            },
+        ]
+    }
+    assert lineage.exclusions_snapshot() == {"request_ids": [summary_request]}
 
 
 def test_prompt_rollback_restores_previous_continuation_point():

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -116,7 +116,7 @@ def test_failed_compaction_publishes_no_transition():
     assert lineage.snapshot() == {"edges": []}
 
 
-def test_prompt_rollback_keeps_and_excludes_unconsumed_compaction_attempt():
+def test_prompt_rollback_keeps_unconsumed_compaction_attempt():
     lineage = SemanticEdgeTracker()
     lineage.register_session("root", parent_session_id=None)
     preceding_request = _finish(lineage, "root")
@@ -146,7 +146,6 @@ def test_prompt_rollback_keeps_and_excludes_unconsumed_compaction_attempt():
             },
         ]
     }
-    assert lineage.exclusions_snapshot() == {"request_ids": [summary_request]}
 
 
 def test_prompt_rollback_restores_previous_continuation_point():


### PR DESCRIPTION
## Summary

- publish every committed summary retry as a sibling `compaction_attempt` semantic edge
- continue only the accepted summary through the existing `compaction` edge
- keep ACP metadata limited to execution semantics; nano-RLM does not prescribe downstream training policy
- use the configurable per-cycle attempt limit now available on `main` (default: five)

Every attempt therefore remains visible as a real sampled model call. A rejected attempt is a dangling semantic leaf; an accepted attempt is distinguished solely by its outgoing `compaction` edge.

Verifiers can derive branch trainability from those facts without a second exclusion manifest or mutated token masks.

## Testing

- `uv run --no-sync pytest tests/` (163 passed)
- `uv run --no-sync pre-commit run --all-files`
- PR CI: Python 3.10–3.13, Ruff, and CodeQL passed
- existing Docker Redsearcher smoke on DeepSeek v4 Flash: 12 model calls and three rejected summary attempts published as sibling leaves before `compaction_failed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compaction semantic lineage and rollback behavior, which downstream RL/verifier tooling may rely on, but scope is limited to the compaction path with expanded test coverage.
> 
> **Overview**
> Compaction handoff now records **every committed summary model call** in the semantic graph as a **`compaction_attempt`** edge from the pre-compaction request (plus any pending subagent-return edges captured at `begin_compaction`), instead of treating retries as ordinary **`continuation`** edges. Only the **accepted** summary keeps the existing outgoing **`compaction`** link to post-compaction work; rejected retries stay as leaves until `release_summary_request` allows another attempt.
> 
> **`SemanticEdgeTracker`** snapshots `source_request_id` and `pending_edges` when compaction starts, wires summary requests with that provenance, skips updating `last_request_id` until compaction completes, and on success validates and consumes the frozen pending-edge prefix. Failed or released summary attempts no longer roll inbound edges back onto the session. Engine docs clarify that summary turns are housekeeping for turn limits but still count for tokens and graph edges.
> 
> ACP and lineage tests now expect **`compaction_attempt`** (including multiple sibling retries) and cover late subagent returns during an in-flight compaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb14252e7d4761acefe5396e0aa3c7df7852c1de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->