### PR TITLE
fix: decouple broker waits from execution timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ results = await asyncio.gather(
 
 Recursive calls are created by a session-local supervisor rather than by the IPython kernel. The supervisor assigns depth and session ancestry, enforces the concurrency and total-call limits, and cancels descendants when their parent cell or session closes. When recursion is disabled by depth, the system prompt does not advertise these APIs and child runs beyond the depth limit fail immediately.
 
-The IPython execution timeout measures active cell execution. Time spent responsively awaiting a supervisor-owned sub-agent or skill does not consume that budget, nor does an `asyncio.gather` containing only those broker calls. Kernel CPU, ordinary waits, mixed gathers, background broker tasks, and periods without broker heartbeats still do. Recursive work remains bounded independently by the tree resource policy and the runtime hosting the rollout.
+The IPython execution timeout measures active cell execution. Time spent responsively awaiting a supervisor-owned sub-agent does not consume that budget, nor does an `asyncio.gather` containing only sub-agent calls. Kernel CPU, skills, ordinary waits, mixed gathers, background sub-agent tasks, and periods without broker heartbeats still do. Recursive work remains bounded independently by the tree resource policy and the runtime hosting the rollout.
 
 ## Compaction
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ results = await asyncio.gather(
 
 Recursive calls are created by a session-local supervisor rather than by the IPython kernel. The supervisor assigns depth and session ancestry, enforces the concurrency and total-call limits, and cancels descendants when their parent cell or session closes. When recursion is disabled by depth, the system prompt does not advertise these APIs and child runs beyond the depth limit fail immediately.
 
+The IPython execution timeout measures active cell execution. Time spent responsively awaiting supervisor-owned sub-agents or skills does not consume that budget, including concurrent calls made with `asyncio.gather`; kernel CPU and periods without broker heartbeats still do. Recursive work remains bounded independently by the tree resource policy and the runtime hosting the rollout.
+
 ## Compaction
 
 There is no model-driven compaction tool. Compaction is on by default and unlimited (the policy's `compaction` field turns it off, `max_compactions` caps it); the default 1M `max_total_tokens` tree budget keeps sessions bounded, since each compaction cycle itself spends new tokens. The engine reads the model context window from the provider's `/models` response and compacts when 16k tokens remain below it; small windows keep at least half. Set `summarize_at_tokens` to pin the threshold explicitly. Without a known window or explicit threshold, proactive compaction stays off, but a provider overflow still triggers it reactively. A tool result larger than 20KB is truncated to its head and tail before it enters the conversation, with a warning naming the original size.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ results = await asyncio.gather(
 
 Recursive calls are created by a session-local supervisor rather than by the IPython kernel. The supervisor assigns depth and session ancestry, enforces the concurrency and total-call limits, and cancels descendants when their parent cell or session closes. When recursion is disabled by depth, the system prompt does not advertise these APIs and child runs beyond the depth limit fail immediately.
 
-The IPython execution timeout measures active cell execution. Time spent responsively awaiting supervisor-owned sub-agents or skills does not consume that budget, including concurrent calls made with `asyncio.gather`; kernel CPU and periods without broker heartbeats still do. Recursive work remains bounded independently by the tree resource policy and the runtime hosting the rollout.
+The IPython execution timeout measures active cell execution. Time spent responsively awaiting a supervisor-owned sub-agent or skill does not consume that budget, nor does an `asyncio.gather` containing only those broker calls. Kernel CPU, ordinary waits, mixed gathers, background broker tasks, and periods without broker heartbeats still do. Recursive work remains bounded independently by the tree resource policy and the runtime hosting the rollout.
 
 ## Compaction
 

--- a/README.md
+++ b/README.md
@@ -102,20 +102,20 @@ Each agent runs inside a persistent IPython kernel with an already-running event
 result = await rlm("verify the fix")
 ```
 
-The result is an `RLMResult` with `.answer`, `.usage`, `.turns`, and `.session_dir`. For parallel sub-agents, use normal async Python:
+The result is an `RLMResult` with `.answer`, `.usage`, `.turns`, and `.session_dir`. For parallel sub-agents, use `rlm.gather`:
 
 ```python
-import asyncio
-
-results = await asyncio.gather(
+results = await rlm.gather(
     rlm("check auth.py"),
     rlm("check login.py"),
 )
 ```
 
+`rlm.gather` accepts only calls to `rlm(...)` or `rlm.run(...)`, starts them concurrently when awaited or scheduled, and returns results in input order. It is an async function: assigning `pending = rlm.gather(...)` does not start the calls. If a call raises, the exception propagates; remaining calls stay owned by the cell scope.
+
 Recursive calls are created by a session-local supervisor rather than by the IPython kernel. The supervisor assigns depth and session ancestry, enforces the concurrency and total-call limits, and cancels descendants when their parent cell or session closes. When recursion is disabled by depth, the system prompt does not advertise these APIs and child runs beyond the depth limit fail immediately.
 
-The IPython execution timeout measures active cell execution. Time spent responsively awaiting a supervisor-owned sub-agent does not consume that budget, nor does an `asyncio.gather` containing only sub-agent calls. Kernel CPU, skills, ordinary waits, mixed gathers, background sub-agent tasks, and periods without broker heartbeats still do. Recursive work remains bounded independently by the tree resource policy and the runtime hosting the rollout.
+The IPython execution timeout measures active cell execution. Direct `await rlm(...)` and `await rlm.gather(...)` exclude responsive inference waits from that budget. Kernel CPU, skills, ordinary waits, all `asyncio.gather(...)` calls, background sub-agent tasks, and periods without broker heartbeats still consume it. Recursive work remains bounded independently by the tree resource policy and the runtime hosting the rollout.
 
 ## Compaction
 

--- a/src/rlm/__init__.py
+++ b/src/rlm/__init__.py
@@ -1,12 +1,13 @@
 """rlm — A minimalistic CLI agent for true recursion."""
 
-from rlm.api import run
+from rlm.api import gather, run
 from rlm.config import ExecutionPolicy, InvocationContext, ProviderConfig, RuntimeConfig
 from rlm.engine import RLMEngine
 from rlm.types import RLMMetrics, RLMResult
 
 __all__ = [
     "run",
+    "gather",
     "ExecutionPolicy",
     "InvocationContext",
     "ProviderConfig",

--- a/src/rlm/api.py
+++ b/src/rlm/api.py
@@ -1,10 +1,13 @@
 """Public Python API for running rlm agents."""
 
+from collections.abc import Coroutine
+from typing import Any
+
 from rlm import broker
 from rlm.types import RLMResult
 
 
-async def run(prompt: str) -> RLMResult:
+def run(prompt: str) -> Coroutine[Any, Any, RLMResult]:
     """Run a recursive sub-agent through the session's broker."""
     if not broker.is_configured():
         raise RuntimeError(
@@ -12,4 +15,4 @@ async def run(prompt: str) -> RLMResult:
             "running rlm session). Standalone execution was removed: rlm is "
             "consumed via the ACP runtime contract."
         )
-    return await broker.run(prompt)
+    return broker.run(prompt)

--- a/src/rlm/api.py
+++ b/src/rlm/api.py
@@ -16,3 +16,10 @@ def run(prompt: str) -> Coroutine[Any, Any, RLMResult]:
             "consumed via the ACP runtime contract."
         )
     return broker.run(prompt)
+
+
+async def gather(*calls: Coroutine[Any, Any, RLMResult]) -> list[RLMResult]:
+    """Run sub-agent calls concurrently when awaited, excluding their inference wait
+    from the cell's execution timeout. Accepts only calls to rlm() or rlm.run().
+    """
+    return await broker.gather(*calls)

--- a/src/rlm/broker.py
+++ b/src/rlm/broker.py
@@ -93,8 +93,10 @@ class BrokerWaitTracker:
 _endpoint: BrokerEndpoint | None = None
 _scope_id: str | None = None
 _original_gather = asyncio.gather
-_broker_calls: weakref.WeakSet[Coroutine[Any, Any, Any]] = weakref.WeakSet()
-_collective_waits: weakref.WeakSet[Coroutine[Any, Any, Any]] = weakref.WeakSet()
+_subagent_calls: weakref.WeakSet[Coroutine[Any, Any, Any]] = weakref.WeakSet()
+_collective_subagent_waits: weakref.WeakSet[Coroutine[Any, Any, Any]] = (
+    weakref.WeakSet()
+)
 
 _JSON_TO_PY = {
     "string": str,
@@ -245,7 +247,7 @@ def run(prompt: str) -> Coroutine[Any, Any, RLMResult]:
     )
 
     async def invoke() -> RLMResult:
-        response = await _request(payload, _is_exclusive_wait(creator_task))
+        response = await _request(payload, _is_exclusive_subagent_wait(creator_task))
         result = response.get("result")
         if not isinstance(result, dict):
             raise RuntimeError("invalid response from RLM supervisor")
@@ -253,7 +255,7 @@ def run(prompt: str) -> Coroutine[Any, Any, RLMResult]:
 
     creator_task = asyncio.current_task()
     call = invoke()
-    _broker_calls.add(call)
+    _subagent_calls.add(call)
     return call
 
 
@@ -270,16 +272,13 @@ def call_skill(capability: str, arguments: dict[str, Any]) -> Coroutine[Any, Any
     )
 
     async def invoke() -> str:
-        response = await _request(payload, _is_exclusive_wait(creator_task))
+        response = await _request(payload, exclusive_wait=False)
         result = response.get("result")
         if not isinstance(result, str):
             raise RuntimeError("invalid skill response from RLM supervisor")
         return result
 
-    creator_task = asyncio.current_task()
-    call = invoke()
-    _broker_calls.add(call)
-    return call
+    return invoke()
 
 
 def make_skill(descriptor: dict[str, Any]):
@@ -353,33 +352,33 @@ async def _send_heartbeats(writer: asyncio.StreamWriter, exclusive_wait: bool) -
         await asyncio.sleep(BROKER_HEARTBEAT_INTERVAL_SECONDS)
 
 
-def _is_exclusive_wait(creator_task: asyncio.Task[Any] | None) -> bool:
+def _is_exclusive_subagent_wait(creator_task: asyncio.Task[Any] | None) -> bool:
     current_task = asyncio.current_task()
     if current_task is creator_task:
         return True
     if current_task is None:
         return False
     try:
-        return current_task.get_coro() in _collective_waits
+        return current_task.get_coro() in _collective_subagent_waits
     except TypeError:
         return False
 
 
-def _is_broker_call(value: Any) -> bool:
+def _is_subagent_call(value: Any) -> bool:
     try:
-        return value in _broker_calls
+        return value in _subagent_calls
     except TypeError:
         return False
 
 
 @functools.wraps(asyncio.gather)
-def _broker_aware_gather(*aws: Any, **kwargs: Any):
-    if aws and all(_is_broker_call(aw) for aw in aws):
-        _collective_waits.update(aws)
+def _subagent_aware_gather(*aws: Any, **kwargs: Any):
+    if aws and all(_is_subagent_call(aw) for aw in aws):
+        _collective_subagent_waits.update(aws)
     return _original_gather(*aws, **kwargs)
 
 
 def _install_asyncio_hooks() -> None:
-    if asyncio.gather is _broker_aware_gather:
+    if asyncio.gather is _subagent_aware_gather:
         return
-    asyncio.gather = _broker_aware_gather
+    asyncio.gather = _subagent_aware_gather

--- a/src/rlm/broker.py
+++ b/src/rlm/broker.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import json
 import keyword
 import struct
 import threading
 import time
+import weakref
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 
@@ -44,18 +47,20 @@ class BrokerWaitTracker:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._heartbeats: dict[str, float] = {}
+        self._heartbeats: dict[str, tuple[float, bool]] = {}
         self._process_time: float | None = None
 
     def start(self, operation_id: str) -> None:
         with self._lock:
-            self._heartbeats[operation_id] = time.monotonic()
+            self._heartbeats[operation_id] = (0.0, False)
 
-    def heartbeat(self, operation_id: str, process_time: float) -> None:
+    def heartbeat(
+        self, operation_id: str, process_time: float, exclusive_wait: bool
+    ) -> None:
         with self._lock:
             if operation_id not in self._heartbeats:
                 return
-            self._heartbeats[operation_id] = time.monotonic()
+            self._heartbeats[operation_id] = (time.monotonic(), exclusive_wait)
             if self._process_time is None or process_time > self._process_time:
                 self._process_time = process_time
 
@@ -66,12 +71,20 @@ class BrokerWaitTracker:
     def snapshot(self) -> BrokerWaitSnapshot:
         with self._lock:
             active = bool(self._heartbeats)
-            freshest = max(self._heartbeats.values(), default=0.0)
+            freshest_exclusive = max(
+                (
+                    heartbeat_at
+                    for heartbeat_at, exclusive in self._heartbeats.values()
+                    if exclusive
+                ),
+                default=0.0,
+            )
             return BrokerWaitSnapshot(
                 active=active,
                 responsive=(
-                    active
-                    and time.monotonic() - freshest <= BROKER_HEARTBEAT_GRACE_SECONDS
+                    freshest_exclusive > 0
+                    and time.monotonic() - freshest_exclusive
+                    <= BROKER_HEARTBEAT_GRACE_SECONDS
                 ),
                 process_time=self._process_time,
             )
@@ -79,6 +92,9 @@ class BrokerWaitTracker:
 
 _endpoint: BrokerEndpoint | None = None
 _scope_id: str | None = None
+_original_gather = asyncio.gather
+_broker_calls: weakref.WeakSet[Coroutine[Any, Any, Any]] = weakref.WeakSet()
+_collective_waits: weakref.WeakSet[Coroutine[Any, Any, Any]] = weakref.WeakSet()
 
 _JSON_TO_PY = {
     "string": str,
@@ -118,6 +134,7 @@ class BrokerHeartbeat(TypedDict):
     __pydantic_config__ = ConfigDict(extra="forbid")
     op: Literal["wait.heartbeat"]
     process_time: Annotated[float, Field(ge=0)]
+    exclusive_wait: bool
 
 
 _HEARTBEAT_ADAPTER = TypeAdapter(BrokerHeartbeat)
@@ -175,6 +192,8 @@ def result_from_payload(value: dict[str, Any]) -> RLMResult:
 def configure(endpoint: BrokerEndpoint | None) -> None:
     global _endpoint
     _endpoint = endpoint
+    if endpoint is not None:
+        _install_asyncio_hooks()
 
 
 def is_configured() -> bool:
@@ -212,43 +231,55 @@ async def write_frame(
     await writer.drain()
 
 
-async def run(prompt: str) -> RLMResult:
+def run(prompt: str) -> Coroutine[Any, Any, RLMResult]:
     """Run a recursive RLM through the trusted session supervisor."""
     if _endpoint is None or _scope_id is None:
         raise RuntimeError("recursive RLM calls are unavailable outside an active cell")
     if not isinstance(prompt, str):
         raise TypeError("prompt must be a string")
-    response = await _request(
-        {
-            "op": "rlm.run",
-            "capability": _endpoint.capability,
-            "scope_id": _scope_id,
-            "prompt": prompt,
-        }
+    payload = BrokerRunRequest(
+        op="rlm.run",
+        capability=_endpoint.capability,
+        scope_id=_scope_id,
+        prompt=prompt,
     )
-    result = response.get("result")
-    if not isinstance(result, dict):
-        raise RuntimeError("invalid response from RLM supervisor")
-    return result_from_payload(result)
+
+    async def invoke() -> RLMResult:
+        response = await _request(payload, _is_exclusive_wait(creator_task))
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise RuntimeError("invalid response from RLM supervisor")
+        return result_from_payload(result)
+
+    creator_task = asyncio.current_task()
+    call = invoke()
+    _broker_calls.add(call)
+    return call
 
 
-async def call_skill(capability: str, arguments: dict[str, Any]) -> str:
+def call_skill(capability: str, arguments: dict[str, Any]) -> Coroutine[Any, Any, str]:
     """Invoke a supervisor-owned skill through its opaque capability."""
     if _endpoint is None or _scope_id is None:
         raise RuntimeError("brokered calls are unavailable outside an active cell")
-    response = await _request(
-        {
-            "op": "skill.call",
-            "capability": _endpoint.capability,
-            "scope_id": _scope_id,
-            "skill_capability": capability,
-            "arguments": arguments,
-        }
+    payload = BrokerSkillRequest(
+        op="skill.call",
+        capability=_endpoint.capability,
+        scope_id=_scope_id,
+        skill_capability=capability,
+        arguments=arguments,
     )
-    result = response.get("result")
-    if not isinstance(result, str):
-        raise RuntimeError("invalid skill response from RLM supervisor")
-    return result
+
+    async def invoke() -> str:
+        response = await _request(payload, _is_exclusive_wait(creator_task))
+        result = response.get("result")
+        if not isinstance(result, str):
+            raise RuntimeError("invalid skill response from RLM supervisor")
+        return result
+
+    creator_task = asyncio.current_task()
+    call = invoke()
+    _broker_calls.add(call)
+    return call
 
 
 def make_skill(descriptor: dict[str, Any]):
@@ -257,8 +288,8 @@ def make_skill(descriptor: dict[str, Any]):
     description = descriptor["description"]
     schema = descriptor["input_schema"]
 
-    async def run(**kwargs: Any) -> str:
-        return await call_skill(capability, kwargs)
+    def run(**kwargs: Any) -> Coroutine[Any, Any, str]:
+        return call_skill(capability, kwargs)
 
     properties = schema.get("properties", {})
     required = set(schema.get("required", []))
@@ -280,7 +311,7 @@ def make_skill(descriptor: dict[str, Any]):
     return run
 
 
-async def _request(payload: BrokerRequest) -> BrokerResponse:
+async def _request(payload: BrokerRequest, exclusive_wait: bool) -> BrokerResponse:
     if _endpoint is None:
         raise RuntimeError("brokered calls are unavailable outside an active cell")
     reader, writer = await asyncio.open_unix_connection(_endpoint.socket_path)
@@ -291,7 +322,7 @@ async def _request(payload: BrokerRequest) -> BrokerResponse:
             payload,
             MAX_REQUEST_BYTES,
         )
-        heartbeat_task = asyncio.create_task(_send_heartbeats(writer))
+        heartbeat_task = asyncio.create_task(_send_heartbeats(writer, exclusive_wait))
         raw_response = await read_frame(reader, MAX_RESPONSE_BYTES)
     finally:
         if heartbeat_task is not None:
@@ -308,14 +339,47 @@ async def _request(payload: BrokerRequest) -> BrokerResponse:
     return response
 
 
-async def _send_heartbeats(writer: asyncio.StreamWriter) -> None:
+async def _send_heartbeats(writer: asyncio.StreamWriter, exclusive_wait: bool) -> None:
     while True:
         await write_frame(
             writer,
             {
                 "op": "wait.heartbeat",
                 "process_time": time.process_time(),
+                "exclusive_wait": exclusive_wait,
             },
             MAX_REQUEST_BYTES,
         )
         await asyncio.sleep(BROKER_HEARTBEAT_INTERVAL_SECONDS)
+
+
+def _is_exclusive_wait(creator_task: asyncio.Task[Any] | None) -> bool:
+    current_task = asyncio.current_task()
+    if current_task is creator_task:
+        return True
+    if current_task is None:
+        return False
+    try:
+        return current_task.get_coro() in _collective_waits
+    except TypeError:
+        return False
+
+
+def _is_broker_call(value: Any) -> bool:
+    try:
+        return value in _broker_calls
+    except TypeError:
+        return False
+
+
+@functools.wraps(asyncio.gather)
+def _broker_aware_gather(*aws: Any, **kwargs: Any):
+    if aws and all(_is_broker_call(aw) for aw in aws):
+        _collective_waits.update(aws)
+    return _original_gather(*aws, **kwargs)
+
+
+def _install_asyncio_hooks() -> None:
+    if asyncio.gather is _broker_aware_gather:
+        return
+    asyncio.gather = _broker_aware_gather

--- a/src/rlm/broker.py
+++ b/src/rlm/broker.py
@@ -7,6 +7,8 @@ import inspect
 import json
 import keyword
 import struct
+import threading
+import time
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 
@@ -18,12 +20,61 @@ from rlm.types import RLMResult
 
 MAX_REQUEST_BYTES = 1024 * 1024
 MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+BROKER_HEARTBEAT_INTERVAL_SECONDS = 0.25
+BROKER_HEARTBEAT_GRACE_SECONDS = 1.0
 
 
 @dataclass(frozen=True)
 class BrokerEndpoint:
     socket_path: str
     capability: str
+
+
+@dataclass(frozen=True)
+class BrokerWaitSnapshot:
+    """Thread-safe view of broker work awaited by one IPython cell."""
+
+    active: bool
+    responsive: bool
+    process_time: float | None
+
+
+class BrokerWaitTracker:
+    """Track live broker operations and kernel liveness for one cell."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._heartbeats: dict[str, float] = {}
+        self._process_time: float | None = None
+
+    def start(self, operation_id: str) -> None:
+        with self._lock:
+            self._heartbeats[operation_id] = time.monotonic()
+
+    def heartbeat(self, operation_id: str, process_time: float) -> None:
+        with self._lock:
+            if operation_id not in self._heartbeats:
+                return
+            self._heartbeats[operation_id] = time.monotonic()
+            if self._process_time is None or process_time > self._process_time:
+                self._process_time = process_time
+
+    def finish(self, operation_id: str) -> None:
+        with self._lock:
+            self._heartbeats.pop(operation_id, None)
+
+    def snapshot(self) -> BrokerWaitSnapshot:
+        with self._lock:
+            active = bool(self._heartbeats)
+            freshest = max(self._heartbeats.values(), default=0.0)
+            return BrokerWaitSnapshot(
+                active=active,
+                responsive=(
+                    active
+                    and time.monotonic() - freshest <= BROKER_HEARTBEAT_GRACE_SECONDS
+                ),
+                process_time=self._process_time,
+            )
 
 
 _endpoint: BrokerEndpoint | None = None
@@ -63,6 +114,15 @@ BrokerRequest = Annotated[
 _REQUEST_ADAPTER = TypeAdapter(BrokerRequest)
 
 
+class BrokerHeartbeat(TypedDict):
+    __pydantic_config__ = ConfigDict(extra="forbid")
+    op: Literal["wait.heartbeat"]
+    process_time: Annotated[float, Field(ge=0)]
+
+
+_HEARTBEAT_ADAPTER = TypeAdapter(BrokerHeartbeat)
+
+
 class _BrokerSuccess(TypedDict):
     __pydantic_config__ = ConfigDict(extra="forbid")
     result: dict[str, Any] | str
@@ -87,6 +147,13 @@ def parse_request(value: dict[str, Any]) -> BrokerRequest:
         return _REQUEST_ADAPTER.validate_python(value)
     except ValidationError:
         raise ValueError("invalid broker request") from None
+
+
+def parse_heartbeat(value: dict[str, Any]) -> BrokerHeartbeat:
+    try:
+        return _HEARTBEAT_ADAPTER.validate_python(value)
+    except ValidationError:
+        raise ValueError("invalid broker heartbeat") from None
 
 
 def result_to_payload(result: RLMResult) -> dict[str, Any]:
@@ -217,14 +284,19 @@ async def _request(payload: BrokerRequest) -> BrokerResponse:
     if _endpoint is None:
         raise RuntimeError("brokered calls are unavailable outside an active cell")
     reader, writer = await asyncio.open_unix_connection(_endpoint.socket_path)
+    heartbeat_task: asyncio.Task[None] | None = None
     try:
         await write_frame(
             writer,
             payload,
             MAX_REQUEST_BYTES,
         )
+        heartbeat_task = asyncio.create_task(_send_heartbeats(writer))
         raw_response = await read_frame(reader, MAX_RESPONSE_BYTES)
     finally:
+        if heartbeat_task is not None:
+            heartbeat_task.cancel()
+            await asyncio.gather(heartbeat_task, return_exceptions=True)
         writer.close()
         await writer.wait_closed()
     try:
@@ -234,3 +306,16 @@ async def _request(payload: BrokerRequest) -> BrokerResponse:
     if "error" in response:
         raise RuntimeError(response["error"])
     return response
+
+
+async def _send_heartbeats(writer: asyncio.StreamWriter) -> None:
+    while True:
+        await write_frame(
+            writer,
+            {
+                "op": "wait.heartbeat",
+                "process_time": time.process_time(),
+            },
+            MAX_REQUEST_BYTES,
+        )
+        await asyncio.sleep(BROKER_HEARTBEAT_INTERVAL_SECONDS)

--- a/src/rlm/broker.py
+++ b/src/rlm/broker.py
@@ -11,8 +11,9 @@ import struct
 import threading
 import time
 import weakref
-from collections.abc import Coroutine
-from dataclasses import dataclass
+from collections.abc import Coroutine, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal
 
 from pydantic import ConfigDict, Field, TypeAdapter, ValidationError
@@ -92,11 +93,55 @@ class BrokerWaitTracker:
 
 _endpoint: BrokerEndpoint | None = None
 _scope_id: str | None = None
+_cell_task: asyncio.Task[Any] | None = None
 _original_gather = asyncio.gather
-_subagent_calls: weakref.WeakSet[Coroutine[Any, Any, Any]] = weakref.WeakSet()
-_collective_subagent_waits: weakref.WeakSet[Coroutine[Any, Any, Any]] = (
-    weakref.WeakSet()
+
+
+@dataclass
+class _SubagentWait:
+    scope_id: str
+    leases: int = 0
+    changed: asyncio.Event = field(default_factory=asyncio.Event)
+
+    @property
+    def exclusive(self) -> bool:
+        return self.scope_id == _scope_id and self.leases > 0
+
+
+_subagent_calls: weakref.WeakKeyDictionary[Coroutine[Any, Any, Any], _SubagentWait] = (
+    weakref.WeakKeyDictionary()
 )
+
+
+@contextmanager
+def cell_execution() -> Iterator[None]:
+    """Bind timeout leases to the task actually executing IPython user code."""
+    global _cell_task
+    previous_task = _cell_task
+    _cell_task = asyncio.current_task()
+    try:
+        yield
+    finally:
+        _cell_task = previous_task
+
+
+@contextmanager
+def _exclusive_wait(*waits: _SubagentWait) -> Iterator[None]:
+    eligible = (
+        [wait for wait in waits if wait.scope_id == _scope_id]
+        if _cell_task is not None and asyncio.current_task() is _cell_task
+        else []
+    )
+    for wait in eligible:
+        wait.leases += 1
+        wait.changed.set()
+    try:
+        yield
+    finally:
+        for wait in eligible:
+            wait.leases -= 1
+            wait.changed.set()
+
 
 _JSON_TO_PY = {
     "string": str,
@@ -246,16 +291,18 @@ def run(prompt: str) -> Coroutine[Any, Any, RLMResult]:
         prompt=prompt,
     )
 
+    wait = _SubagentWait(_scope_id)
+
     async def invoke() -> RLMResult:
-        response = await _request(payload, _is_exclusive_subagent_wait(creator_task))
+        with _exclusive_wait(wait):
+            response = await _request(payload, wait)
         result = response.get("result")
         if not isinstance(result, dict):
             raise RuntimeError("invalid response from RLM supervisor")
         return result_from_payload(result)
 
-    creator_task = asyncio.current_task()
     call = invoke()
-    _subagent_calls.add(call)
+    _subagent_calls[call] = wait
     return call
 
 
@@ -272,7 +319,7 @@ def call_skill(capability: str, arguments: dict[str, Any]) -> Coroutine[Any, Any
     )
 
     async def invoke() -> str:
-        response = await _request(payload, exclusive_wait=False)
+        response = await _request(payload)
         result = response.get("result")
         if not isinstance(result, str):
             raise RuntimeError("invalid skill response from RLM supervisor")
@@ -310,7 +357,9 @@ def make_skill(descriptor: dict[str, Any]):
     return run
 
 
-async def _request(payload: BrokerRequest, exclusive_wait: bool) -> BrokerResponse:
+async def _request(
+    payload: BrokerRequest, wait: _SubagentWait | None = None
+) -> BrokerResponse:
     if _endpoint is None:
         raise RuntimeError("brokered calls are unavailable outside an active cell")
     reader, writer = await asyncio.open_unix_connection(_endpoint.socket_path)
@@ -321,7 +370,7 @@ async def _request(payload: BrokerRequest, exclusive_wait: bool) -> BrokerRespon
             payload,
             MAX_REQUEST_BYTES,
         )
-        heartbeat_task = asyncio.create_task(_send_heartbeats(writer, exclusive_wait))
+        heartbeat_task = asyncio.create_task(_send_heartbeats(writer, wait))
         raw_response = await read_frame(reader, MAX_RESPONSE_BYTES)
     finally:
         if heartbeat_task is not None:
@@ -338,30 +387,57 @@ async def _request(payload: BrokerRequest, exclusive_wait: bool) -> BrokerRespon
     return response
 
 
-async def _send_heartbeats(writer: asyncio.StreamWriter, exclusive_wait: bool) -> None:
+async def _send_heartbeats(
+    writer: asyncio.StreamWriter, wait: _SubagentWait | None
+) -> None:
     while True:
+        if wait is not None:
+            wait.changed.clear()
         await write_frame(
             writer,
             {
                 "op": "wait.heartbeat",
                 "process_time": time.process_time(),
-                "exclusive_wait": exclusive_wait,
+                "exclusive_wait": wait is not None and wait.exclusive,
             },
             MAX_REQUEST_BYTES,
         )
-        await asyncio.sleep(BROKER_HEARTBEAT_INTERVAL_SECONDS)
+        if wait is None:
+            await asyncio.sleep(BROKER_HEARTBEAT_INTERVAL_SECONDS)
+        else:
+            try:
+                await asyncio.wait_for(
+                    wait.changed.wait(), BROKER_HEARTBEAT_INTERVAL_SECONDS
+                )
+            except asyncio.TimeoutError:
+                pass
 
 
-def _is_exclusive_subagent_wait(creator_task: asyncio.Task[Any] | None) -> bool:
-    current_task = asyncio.current_task()
-    if current_task is creator_task:
-        return True
-    if current_task is None:
-        return False
-    try:
-        return current_task.get_coro() in _collective_subagent_waits
-    except TypeError:
-        return False
+class _SubagentGather(asyncio.Future):
+    """An eager gather whose lease lasts only for a cell-task await."""
+
+    def __init__(self, gather: asyncio.Future, waits: list[_SubagentWait]) -> None:
+        super().__init__(loop=gather.get_loop())
+        self._gather = gather
+        self._waits = waits
+        gather.add_done_callback(self._complete)
+
+    def _complete(self, gather: asyncio.Future) -> None:
+        if gather.cancelled():
+            super().cancel()
+        elif (error := gather.exception()) is not None:
+            self.set_exception(error)
+        else:
+            self.set_result(gather.result())
+
+    def cancel(self, msg: str | None = None) -> bool:
+        return self._gather.cancel(msg=msg)
+
+    def __await__(self):
+        with _exclusive_wait(*self._waits):
+            return (yield from super().__await__())
+
+    __iter__ = __await__
 
 
 def _is_subagent_call(value: Any) -> bool:
@@ -374,7 +450,9 @@ def _is_subagent_call(value: Any) -> bool:
 @functools.wraps(asyncio.gather)
 def _subagent_aware_gather(*aws: Any, **kwargs: Any):
     if aws and all(_is_subagent_call(aw) for aw in aws):
-        _collective_subagent_waits.update(aws)
+        return _SubagentGather(
+            _original_gather(*aws, **kwargs), [_subagent_calls[aw] for aw in aws]
+        )
     return _original_gather(*aws, **kwargs)
 
 

--- a/src/rlm/broker.py
+++ b/src/rlm/broker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import functools
 import inspect
 import json
 import keyword
@@ -38,7 +37,6 @@ class BrokerEndpoint:
 class BrokerWaitSnapshot:
     """Thread-safe view of broker work awaited by one IPython cell."""
 
-    active: bool
     responsive: bool
     process_time: float | None
 
@@ -71,7 +69,6 @@ class BrokerWaitTracker:
 
     def snapshot(self) -> BrokerWaitSnapshot:
         with self._lock:
-            active = bool(self._heartbeats)
             freshest_exclusive = max(
                 (
                     heartbeat_at
@@ -81,7 +78,6 @@ class BrokerWaitTracker:
                 default=0.0,
             )
             return BrokerWaitSnapshot(
-                active=active,
                 responsive=(
                     freshest_exclusive > 0
                     and time.monotonic() - freshest_exclusive
@@ -94,7 +90,6 @@ class BrokerWaitTracker:
 _endpoint: BrokerEndpoint | None = None
 _scope_id: str | None = None
 _cell_task: asyncio.Task[Any] | None = None
-_original_gather = asyncio.gather
 
 
 @dataclass
@@ -239,8 +234,6 @@ def result_from_payload(value: dict[str, Any]) -> RLMResult:
 def configure(endpoint: BrokerEndpoint | None) -> None:
     global _endpoint
     _endpoint = endpoint
-    if endpoint is not None:
-        _install_asyncio_hooks()
 
 
 def is_configured() -> bool:
@@ -306,26 +299,33 @@ def run(prompt: str) -> Coroutine[Any, Any, RLMResult]:
     return call
 
 
-def call_skill(capability: str, arguments: dict[str, Any]) -> Coroutine[Any, Any, str]:
+async def gather(*calls: Coroutine[Any, Any, RLMResult]) -> list[RLMResult]:
+    """Run sub-agent calls concurrently while the cell awaits their results."""
+    if not all(inspect.iscoroutine(call) and call in _subagent_calls for call in calls):
+        raise TypeError(
+            "rlm.gather() accepts only calls returned by rlm() or rlm.run()"
+        )
+    with _exclusive_wait(*(_subagent_calls[call] for call in calls)):
+        return await asyncio.gather(*calls)
+
+
+async def call_skill(capability: str, arguments: dict[str, Any]) -> str:
     """Invoke a supervisor-owned skill through its opaque capability."""
     if _endpoint is None or _scope_id is None:
         raise RuntimeError("brokered calls are unavailable outside an active cell")
-    payload = BrokerSkillRequest(
-        op="skill.call",
-        capability=_endpoint.capability,
-        scope_id=_scope_id,
-        skill_capability=capability,
-        arguments=arguments,
+    response = await _request(
+        {
+            "op": "skill.call",
+            "capability": _endpoint.capability,
+            "scope_id": _scope_id,
+            "skill_capability": capability,
+            "arguments": arguments,
+        }
     )
-
-    async def invoke() -> str:
-        response = await _request(payload)
-        result = response.get("result")
-        if not isinstance(result, str):
-            raise RuntimeError("invalid skill response from RLM supervisor")
-        return result
-
-    return invoke()
+    result = response.get("result")
+    if not isinstance(result, str):
+        raise RuntimeError("invalid skill response from RLM supervisor")
+    return result
 
 
 def make_skill(descriptor: dict[str, Any]):
@@ -334,8 +334,8 @@ def make_skill(descriptor: dict[str, Any]):
     description = descriptor["description"]
     schema = descriptor["input_schema"]
 
-    def run(**kwargs: Any) -> Coroutine[Any, Any, str]:
-        return call_skill(capability, kwargs)
+    async def run(**kwargs: Any) -> str:
+        return await call_skill(capability, kwargs)
 
     properties = schema.get("properties", {})
     required = set(schema.get("required", []))
@@ -370,7 +370,8 @@ async def _request(
             payload,
             MAX_REQUEST_BYTES,
         )
-        heartbeat_task = asyncio.create_task(_send_heartbeats(writer, wait))
+        if wait is not None:
+            heartbeat_task = asyncio.create_task(_send_heartbeats(writer, wait))
         raw_response = await read_frame(reader, MAX_RESPONSE_BYTES)
     finally:
         if heartbeat_task is not None:
@@ -387,76 +388,21 @@ async def _request(
     return response
 
 
-async def _send_heartbeats(
-    writer: asyncio.StreamWriter, wait: _SubagentWait | None
-) -> None:
+async def _send_heartbeats(writer: asyncio.StreamWriter, wait: _SubagentWait) -> None:
     while True:
-        if wait is not None:
-            wait.changed.clear()
+        wait.changed.clear()
         await write_frame(
             writer,
             {
                 "op": "wait.heartbeat",
                 "process_time": time.process_time(),
-                "exclusive_wait": wait is not None and wait.exclusive,
+                "exclusive_wait": wait.exclusive,
             },
             MAX_REQUEST_BYTES,
         )
-        if wait is None:
-            await asyncio.sleep(BROKER_HEARTBEAT_INTERVAL_SECONDS)
-        else:
-            try:
-                await asyncio.wait_for(
-                    wait.changed.wait(), BROKER_HEARTBEAT_INTERVAL_SECONDS
-                )
-            except asyncio.TimeoutError:
-                pass
-
-
-class _SubagentGather(asyncio.Future):
-    """An eager gather whose lease lasts only for a cell-task await."""
-
-    def __init__(self, gather: asyncio.Future, waits: list[_SubagentWait]) -> None:
-        super().__init__(loop=gather.get_loop())
-        self._gather = gather
-        self._waits = waits
-        gather.add_done_callback(self._complete)
-
-    def _complete(self, gather: asyncio.Future) -> None:
-        if gather.cancelled():
-            super().cancel()
-        elif (error := gather.exception()) is not None:
-            self.set_exception(error)
-        else:
-            self.set_result(gather.result())
-
-    def cancel(self, msg: str | None = None) -> bool:
-        return self._gather.cancel(msg=msg)
-
-    def __await__(self):
-        with _exclusive_wait(*self._waits):
-            return (yield from super().__await__())
-
-    __iter__ = __await__
-
-
-def _is_subagent_call(value: Any) -> bool:
-    try:
-        return value in _subagent_calls
-    except TypeError:
-        return False
-
-
-@functools.wraps(asyncio.gather)
-def _subagent_aware_gather(*aws: Any, **kwargs: Any):
-    if aws and all(_is_subagent_call(aw) for aw in aws):
-        return _SubagentGather(
-            _original_gather(*aws, **kwargs), [_subagent_calls[aw] for aw in aws]
-        )
-    return _original_gather(*aws, **kwargs)
-
-
-def _install_asyncio_hooks() -> None:
-    if asyncio.gather is _subagent_aware_gather:
-        return
-    asyncio.gather = _subagent_aware_gather
+        try:
+            await asyncio.wait_for(
+                wait.changed.wait(), BROKER_HEARTBEAT_INTERVAL_SECONDS
+            )
+        except asyncio.TimeoutError:
+            pass

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -68,8 +68,8 @@ class ExecutionPolicy(_ConfigModel):
     head + tail, with a warning naming the original size). None = the built-in 20KB
     default; an explicit value overrides it in either direction."""
     exec_timeout: int = Field(default=300, gt=0)
-    """Active execution budget for one IPython cell. Responsive waits on supervisor-owned
-    sub-agents and skills do not consume it; kernel CPU and unresponsive time do."""
+    """Active execution budget for one IPython cell. Direct broker waits and gathers made
+    only of broker calls do not consume it; CPU, ordinary waits, and mixed work do."""
     max_tokens: int | None = Field(default=None, gt=0)
     compaction: bool = True
     """Compact the context once it outgrows ``summarize_at_tokens`` (and recover from

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -68,6 +68,8 @@ class ExecutionPolicy(_ConfigModel):
     head + tail, with a warning naming the original size). None = the built-in 20KB
     default; an explicit value overrides it in either direction."""
     exec_timeout: int = Field(default=300, gt=0)
+    """Active execution budget for one IPython cell. Responsive waits on supervisor-owned
+    sub-agents and skills do not consume it; kernel CPU and unresponsive time do."""
     max_tokens: int | None = Field(default=None, gt=0)
     compaction: bool = True
     """Compact the context once it outgrows ``summarize_at_tokens`` (and recover from

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -68,8 +68,8 @@ class ExecutionPolicy(_ConfigModel):
     head + tail, with a warning naming the original size). None = the built-in 20KB
     default; an explicit value overrides it in either direction."""
     exec_timeout: int = Field(default=300, gt=0)
-    """Active execution budget for one IPython cell. Direct broker waits and gathers made
-    only of broker calls do not consume it; CPU, ordinary waits, and mixed work do."""
+    """Active execution budget for one IPython cell. Direct sub-agent waits and gathers
+    made only of sub-agent calls do not consume it; skills and other work do."""
     max_tokens: int | None = Field(default=None, gt=0)
     compaction: bool = True
     """Compact the context once it outgrows ``summarize_at_tokens`` (and recover from

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -68,8 +68,8 @@ class ExecutionPolicy(_ConfigModel):
     head + tail, with a warning naming the original size). None = the built-in 20KB
     default; an explicit value overrides it in either direction."""
     exec_timeout: int = Field(default=300, gt=0)
-    """Active execution budget for one IPython cell. Direct sub-agent waits and gathers
-    made only of sub-agent calls do not consume it; skills and other work do."""
+    """Active execution budget for one IPython cell. Direct sub-agent waits and
+    rlm.gather waits do not consume it; skills and other work do."""
     max_tokens: int | None = Field(default=None, gt=0)
     compaction: bool = True
     """Compact the context once it outgrows ``summarize_at_tokens`` (and recover from

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -528,7 +528,10 @@ class RLMEngine:
                     )
                 try:
                     if scope_id is not None:
-                        repl.set_broker_scope(scope_id)
+                        repl.set_broker_scope(
+                            scope_id,
+                            self._supervisor.broker_waits(scope_id),
+                        )
                     tool_task = asyncio.create_task(
                         asyncio.to_thread(
                             tool.execute, tool_args, self._tool_context(messages)

--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -182,7 +182,10 @@ def build_system_prompt(
             [
                 "",
                 "A callable `rlm` is already in your global namespace — call it directly with `await rlm('sub-task')` to spawn a recursive sub-agent. Returns an `RLMResult` with `.answer` (string), `.usage`, `.turns`, and `.session_dir`.",
-                "For parallel sub-agents, use normal Python async patterns such as `await asyncio.gather(rlm('task1'), rlm('task2'))`.",
+                "For parallel sub-agents, use `await rlm.gather(rlm('task1'), rlm('task2'))`. "
+                "It accepts only sub-agent calls and starts them when awaited. "
+                "Direct `await rlm(...)` and `await rlm.gather(...)` exclude inference waits from the cell timeout; "
+                "ordinary `asyncio.gather(...)` and background tasks still consume that budget.",
             ]
         )
 

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -510,7 +510,11 @@ class SessionTreeSupervisor:
     ) -> None:
         while True:
             heartbeat = parse_heartbeat(await read_frame(reader))
-            wait_tracker.heartbeat(operation_id, heartbeat["process_time"])
+            wait_tracker.heartbeat(
+                operation_id,
+                heartbeat["process_time"],
+                heartbeat["exclusive_wait"],
+            )
 
     async def aclose(self) -> None:
         if self._closed and self._close_task is None:

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -9,13 +9,15 @@ import shutil
 import tempfile
 import uuid
 from collections.abc import Awaitable, Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rlm.broker import (
     BrokerEndpoint,
+    BrokerWaitTracker,
+    parse_heartbeat,
     parse_request,
     read_frame,
     result_to_payload,
@@ -58,6 +60,7 @@ class _Scope:
     invocation_id: str
     tasks: set[asyncio.Task[Any]]
     request_id: str | None = None
+    broker_waits: BrokerWaitTracker = field(default_factory=BrokerWaitTracker)
 
 
 def depth_capacities(max_depth: int, limit: int, root_depth: int = 0) -> dict[int, int]:
@@ -264,6 +267,12 @@ class SessionTreeSupervisor:
             self._scopes[scope_id] = _Scope(invocation_id, set(), request_id)
             return scope_id
 
+    def broker_waits(self, scope_id: str) -> BrokerWaitTracker:
+        scope = self._scopes.get(scope_id)
+        if scope is None:
+            raise RuntimeError("broker scope is no longer active")
+        return scope.broker_waits
+
     async def close_scope(self, scope_id: str) -> None:
         async with self._lock:
             scope = self._scopes.pop(scope_id, None)
@@ -432,7 +441,9 @@ class SessionTreeSupervisor:
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         operation_task: asyncio.Task[Any] | None = None
-        disconnect_task: asyncio.Task[bytes] | None = None
+        heartbeat_task: asyncio.Task[None] | None = None
+        wait_tracker: BrokerWaitTracker | None = None
+        operation_id: str | None = None
         try:
             try:
                 request = await asyncio.wait_for(
@@ -454,12 +465,17 @@ class SessionTreeSupervisor:
                     request["skill_capability"],
                     request["arguments"],
                 )
-            disconnect_task = asyncio.create_task(reader.read(1))
+            wait_tracker = self.broker_waits(request["scope_id"])
+            operation_id = uuid.uuid4().hex
+            wait_tracker.start(operation_id)
+            heartbeat_task = asyncio.create_task(
+                self._receive_heartbeats(reader, wait_tracker, operation_id)
+            )
             done, _ = await asyncio.wait(
-                {operation_task, disconnect_task},
+                {operation_task, heartbeat_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            if disconnect_task in done and operation_task not in done:
+            if heartbeat_task in done and operation_task not in done:
                 operation_task.cancel()
                 await asyncio.gather(operation_task, return_exceptions=True)
                 return
@@ -474,15 +490,27 @@ class SessionTreeSupervisor:
                 except (ConnectionError, OSError, asyncio.IncompleteReadError):
                     pass
         finally:
-            if disconnect_task is not None:
-                disconnect_task.cancel()
-                await asyncio.gather(disconnect_task, return_exceptions=True)
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+                await asyncio.gather(heartbeat_task, return_exceptions=True)
+            if wait_tracker is not None and operation_id is not None:
+                wait_tracker.finish(operation_id)
             writer.close()
             try:
                 await writer.wait_closed()
             except (ConnectionError, OSError):
                 pass
             self._connection_writers.discard(writer)
+
+    async def _receive_heartbeats(
+        self,
+        reader: asyncio.StreamReader,
+        wait_tracker: BrokerWaitTracker,
+        operation_id: str,
+    ) -> None:
+        while True:
+            heartbeat = parse_heartbeat(await read_frame(reader))
+            wait_tracker.heartbeat(operation_id, heartbeat["process_time"])
 
     async def aclose(self) -> None:
         if self._closed and self._close_task is None:

--- a/src/rlm/supervisor.py
+++ b/src/rlm/supervisor.py
@@ -441,7 +441,7 @@ class SessionTreeSupervisor:
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         operation_task: asyncio.Task[Any] | None = None
-        heartbeat_task: asyncio.Task[None] | None = None
+        connection_task: asyncio.Task[Any] | None = None
         wait_tracker: BrokerWaitTracker | None = None
         operation_id: str | None = None
         try:
@@ -458,6 +458,12 @@ class SessionTreeSupervisor:
                     request["scope_id"],
                     request["prompt"],
                 )
+                wait_tracker = self.broker_waits(request["scope_id"])
+                operation_id = uuid.uuid4().hex
+                wait_tracker.start(operation_id)
+                connection_task = asyncio.create_task(
+                    self._receive_heartbeats(reader, wait_tracker, operation_id)
+                )
             else:
                 operation_task = await self._start_skill_call(
                     request["capability"],
@@ -465,17 +471,12 @@ class SessionTreeSupervisor:
                     request["skill_capability"],
                     request["arguments"],
                 )
-            wait_tracker = self.broker_waits(request["scope_id"])
-            operation_id = uuid.uuid4().hex
-            wait_tracker.start(operation_id)
-            heartbeat_task = asyncio.create_task(
-                self._receive_heartbeats(reader, wait_tracker, operation_id)
-            )
+                connection_task = asyncio.create_task(reader.read(1))
             done, _ = await asyncio.wait(
-                {operation_task, heartbeat_task},
+                {operation_task, connection_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            if heartbeat_task in done and operation_task not in done:
+            if connection_task in done and operation_task not in done:
                 operation_task.cancel()
                 await asyncio.gather(operation_task, return_exceptions=True)
                 return
@@ -490,9 +491,9 @@ class SessionTreeSupervisor:
                 except (ConnectionError, OSError, asyncio.IncompleteReadError):
                     pass
         finally:
-            if heartbeat_task is not None:
-                heartbeat_task.cancel()
-                await asyncio.gather(heartbeat_task, return_exceptions=True)
+            if connection_task is not None:
+                connection_task.cancel()
+                await asyncio.gather(connection_task, return_exceptions=True)
             if wait_tracker is not None and operation_id is not None:
                 wait_tracker.finish(operation_id)
             writer.close()

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -292,8 +292,8 @@ class _CallableModule(types.ModuleType):
     # Make `await <skill>(...)` shorthand for `await <skill>.run(...)`.
     # __call__ is looked up on the type, not the instance, so the
     # override has to live on the class.
-    async def __call__(self, *args, **kwargs):
-        return await self.run(*args, **kwargs)
+    def __call__(self, *args, **kwargs):
+        return self.run(*args, **kwargs)
 
 
 def _wrap_callable(mod, log_source, register=True):

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from rlm.broker import BrokerWaitTracker
 from rlm.tools.base import ToolContext, ToolOutcome
 from rlm.tools.git_block import find_blocked_in_ipython, refusal
 from rlm.tools.skills import discover_skills
@@ -196,6 +197,7 @@ class IPythonREPL:
         self._ipc_dir = None
         self._lock = threading.Lock()
         self._interrupt_requested = threading.Event()
+        self._broker_waits: BrokerWaitTracker | None = None
 
     def start(self):
         """Start the IPython kernel."""
@@ -335,10 +337,15 @@ if {allow_recursion!r}:
 """
         self._execute_silent(setup_code)
 
-    def set_broker_scope(self, scope_id: str | None) -> None:
+    def set_broker_scope(
+        self,
+        scope_id: str | None,
+        broker_waits: BrokerWaitTracker | None = None,
+    ) -> None:
         """Set the active recursive-call scope inside the kernel."""
         if self.broker_endpoint is not None:
             self._execute_silent(f"_rlm_broker.set_scope({scope_id!r})")
+        self._broker_waits = broker_waits
 
     def _execute_silent(self, code: str):
         """Execute code without capturing output (for setup)."""
@@ -400,7 +407,10 @@ if {allow_recursion!r}:
 
     def _execute_locked(self, code: str, timeout: int | None) -> str:
         msg_id = self._kc.execute(code)
-        deadline = None if timeout is None else time.monotonic() + timeout
+        charged_time = 0.0
+        last_wall_time = time.monotonic()
+        last_process_time: float | None = None
+        was_waiting = False
 
         outputs: list[str] = []
         try:
@@ -408,10 +418,33 @@ if {allow_recursion!r}:
                 if self._interrupt_requested.is_set():
                     self._interrupt_and_recover()
                     break
-                if deadline is None:
+                if timeout is None:
                     wait_timeout = 0.1
                 else:
-                    remaining = deadline - time.monotonic()
+                    now = time.monotonic()
+                    waits = (
+                        self._broker_waits.snapshot()
+                        if self._broker_waits is not None
+                        else None
+                    )
+                    is_waiting = waits is not None and waits.responsive
+                    # Trusted broker waits suspend wall time, but kernel CPU used
+                    # during the wait still belongs to this cell's execution budget.
+                    if (
+                        was_waiting
+                        and is_waiting
+                        and last_process_time is not None
+                        and waits.process_time is not None
+                    ):
+                        charged_time += max(0.0, waits.process_time - last_process_time)
+                    else:
+                        charged_time += now - last_wall_time
+                    last_wall_time = now
+                    last_process_time = (
+                        waits.process_time if waits is not None else None
+                    )
+                    was_waiting = is_waiting
+                    remaining = timeout - charged_time
                     if remaining <= 0:
                         self._interrupt_and_recover()
                         outputs.append(

--- a/src/rlm/tools/ipython.py
+++ b/src/rlm/tools/ipython.py
@@ -325,6 +325,14 @@ if {bool(self.broker_endpoint)!r}:
         {self.broker_endpoint.socket_path if self.broker_endpoint else None!r},
         {self.broker_endpoint.capability if self.broker_endpoint else None!r},
     ))
+    _rlm_run_code = get_ipython().run_code
+
+    @functools.wraps(_rlm_run_code)
+    async def _rlm_scoped_run_code(*args, **kwargs):
+        with _rlm_broker.cell_execution():
+            return await _rlm_run_code(*args, **kwargs)
+
+    get_ipython().run_code = _rlm_scoped_run_code
 
 for _name in {skill_names!r}:
     _module = __import__(_name)

--- a/tests/test_broker_waits.py
+++ b/tests/test_broker_waits.py
@@ -4,11 +4,10 @@ import asyncio
 
 import pytest
 
-from rlm import broker
+from rlm import broker, gather, run
 
 
-@pytest.mark.parametrize("return_exceptions", [False, True])
-async def test_gather_cancellation_releases_cell_lease(monkeypatch, return_exceptions):
+async def test_gather_cancellation_releases_cell_lease(monkeypatch):
     monkeypatch.setattr(broker, "_endpoint", broker.BrokerEndpoint("unused", "test"))
     monkeypatch.setattr(broker, "_scope_id", "cell")
     started = asyncio.Event()
@@ -25,27 +24,34 @@ async def test_gather_cancellation_releases_cell_lease(monkeypatch, return_excep
             cancelled.append(wait)
 
     monkeypatch.setattr(broker, "_request", request)
-    observed = []
-    with broker.cell_execution():
-        group = broker._subagent_aware_gather(
-            broker.run("one"), broker.run("two"), return_exceptions=return_exceptions
-        )
-        assert asyncio.isfuture(group)
-        await started.wait()
-        assert not any(wait.exclusive for wait in running)
 
-        def cancel():
-            observed.extend(wait.exclusive for wait in running)
-            group.cancel("stop")
-
-        asyncio.get_running_loop().call_soon(cancel)
-        with pytest.raises(asyncio.CancelledError):
+    async def cell():
+        with broker.cell_execution():
+            group = gather(run("one"), run("two"))
+            await asyncio.sleep(0)
+            assert not running
             await group
 
-        assert observed == [True, True]
-        assert len(cancelled) == 2
-        assert not any(wait.exclusive for wait in running)
-        assert group.done()
-        assert not group.cancelled()
-        assert not group.cancel()
+    task = asyncio.create_task(cell())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    assert all(wait.exclusive for wait in running)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(cancelled) == 2
+    assert not any(wait.exclusive for wait in running)
     assert broker._cell_task is None
+
+
+async def test_gather_rejects_non_subagent_calls(monkeypatch):
+    monkeypatch.setattr(broker, "_endpoint", broker.BrokerEndpoint("unused", "test"))
+    monkeypatch.setattr(broker, "_scope_id", "cell")
+    child = run("one")
+    other = asyncio.sleep(0)
+    try:
+        with pytest.raises(TypeError, match="only calls returned by rlm"):
+            await gather(child, other)
+    finally:
+        child.close()
+        other.close()

--- a/tests/test_broker_waits.py
+++ b/tests/test_broker_waits.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rlm import broker
+
+
+@pytest.mark.parametrize("return_exceptions", [False, True])
+async def test_gather_cancellation_releases_cell_lease(monkeypatch, return_exceptions):
+    monkeypatch.setattr(broker, "_endpoint", broker.BrokerEndpoint("unused", "test"))
+    monkeypatch.setattr(broker, "_scope_id", "cell")
+    started = asyncio.Event()
+    running = []
+    cancelled = []
+
+    async def request(payload, wait):
+        running.append(wait)
+        if len(running) == 2:
+            started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            cancelled.append(wait)
+
+    monkeypatch.setattr(broker, "_request", request)
+    observed = []
+    with broker.cell_execution():
+        group = broker._subagent_aware_gather(
+            broker.run("one"), broker.run("two"), return_exceptions=return_exceptions
+        )
+        assert asyncio.isfuture(group)
+        await started.wait()
+        assert not any(wait.exclusive for wait in running)
+
+        def cancel():
+            observed.extend(wait.exclusive for wait in running)
+            group.cancel("stop")
+
+        asyncio.get_running_loop().call_soon(cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await group
+
+        assert observed == [True, True]
+        assert len(cancelled) == 2
+        assert not any(wait.exclusive for wait in running)
+        assert group.done()
+        assert not group.cancelled()
+        assert not group.cancel()
+    assert broker._cell_task is None

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -156,6 +157,51 @@ print('SERPER_API_KEY=' not in child_env)
     assert secret not in source
     meta = json.loads((session.dir / "meta.json").read_text())
     assert meta["programmatic_tool_call_stats"]["by_tool_python"] == {"search": 1}
+
+
+async def test_brokered_skill_wait_counts_toward_execution_timeout(
+    monkeypatch, session
+):
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, **kwargs):
+            await asyncio.sleep(2)
+            raise AssertionError("timed-out search should be cancelled")
+
+    monkeypatch.setattr("rlm.skills.search.httpx.AsyncClient", FakeClient)
+    config = RuntimeConfig(
+        model="test-model",
+        provider=ProviderConfig(base_url="http://interceptor", api_key="secret"),
+        invocation=InvocationContext(),
+        policy=ExecutionPolicy(exec_timeout=1),
+        skills=("search",),
+        search_api_key="search-secret",
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall("ipython", {"code": "await search(query='needle')"})
+                ]
+            ),
+            DummyMessage(content="recovered"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+    )
+
+    result = await engine.run("search")
+
+    assert result.answer == "recovered"
+    assert "execution timed out after 1s" in tool_result(client)
 
 
 async def test_bash_returns_output():

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -486,6 +486,93 @@ async def test_execution_around_subagent_wait_remains_charged(session):
     assert "child:1.2" not in tool_result(client)
 
 
+async def test_background_subagent_does_not_shield_unrelated_wait(session):
+    config = _config(max_depth=1, exec_timeout=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(session.dir),
+        engine_factory=_DelayedEngine,
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": (
+                                "import asyncio\n"
+                                "child = asyncio.create_task(rlm('2.0'))\n"
+                                "await asyncio.sleep(2.0)\n"
+                                "print((await child).answer)"
+                            )
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="recovered"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    try:
+        result = await asyncio.wait_for(engine.run("delegate"), timeout=12)
+    finally:
+        await supervisor.aclose()
+
+    assert result.answer == "recovered"
+    assert "execution timed out after 1s" in tool_result(client)
+    assert "child:2.0" not in tool_result(client)
+
+
+async def test_mixed_gather_does_not_shield_non_broker_wait(session):
+    config = _config(max_depth=1, exec_timeout=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(session.dir),
+        engine_factory=_DelayedEngine,
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": (
+                                "import asyncio\n"
+                                "await asyncio.gather(rlm('2.0'), asyncio.sleep(2.0))"
+                            )
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="recovered"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    try:
+        result = await asyncio.wait_for(engine.run("delegate"), timeout=12)
+    finally:
+        await supervisor.aclose()
+
+    assert result.answer == "recovered"
+    assert "execution timed out after 1s" in tool_result(client)
+
+
 async def test_active_subagent_does_not_shield_stuck_kernel(session):
     _SometimesBlockingEngine.state = _EngineState()
     _SometimesBlockingEngine.started = asyncio.Event()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -440,6 +440,50 @@ async def test_real_kernel_excludes_parallel_subagent_wait_from_timeout(session)
     assert "execution timed out" not in tool_result(client)
 
 
+async def test_real_kernel_rebases_sequential_subagent_waits(session):
+    config = _config(max_depth=1, exec_timeout=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(session.dir),
+        engine_factory=_DelayedEngine,
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": (
+                                "first = await rlm('1.2')\n"
+                                "second = await rlm('1.3')\n"
+                                "print(first.answer, second.answer)"
+                            )
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="done"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    try:
+        result = await asyncio.wait_for(engine.run("delegate"), timeout=12)
+    finally:
+        await supervisor.aclose()
+
+    assert result.answer == "done"
+    assert tool_result(client).strip() == "child:1.2 child:1.3"
+    assert "execution timed out" not in tool_result(client)
+
+
 async def test_execution_around_subagent_wait_remains_charged(session):
     config = _config(max_depth=1, exec_timeout=1)
     supervisor = SessionTreeSupervisor(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -440,6 +440,52 @@ async def test_real_kernel_excludes_parallel_subagent_wait_from_timeout(session)
     assert "execution timed out" not in tool_result(client)
 
 
+async def test_execution_around_subagent_wait_remains_charged(session):
+    config = _config(max_depth=1, exec_timeout=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(session.dir),
+        engine_factory=_DelayedEngine,
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": (
+                                "import time\n"
+                                "time.sleep(0.55)\n"
+                                "result = await rlm('1.2')\n"
+                                "time.sleep(0.55)\n"
+                                "print(result.answer)"
+                            )
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="recovered"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    try:
+        result = await asyncio.wait_for(engine.run("delegate"), timeout=12)
+    finally:
+        await supervisor.aclose()
+
+    assert result.answer == "recovered"
+    assert "execution timed out after 1s" in tool_result(client)
+    assert "child:1.2" not in tool_result(client)
+
+
 async def test_active_subagent_does_not_shield_stuck_kernel(session):
     _SometimesBlockingEngine.state = _EngineState()
     _SometimesBlockingEngine.started = asyncio.Event()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -19,7 +19,11 @@ from rlm.types import RLMResult, TokenUsage
 
 
 def _config(
-    *, max_depth: int = 2, max_concurrent: int = 4, max_calls: int = 16
+    *,
+    max_depth: int = 2,
+    max_concurrent: int = 4,
+    max_calls: int = 16,
+    exec_timeout: int = 300,
 ) -> RuntimeConfig:
     return RuntimeConfig(
         model="test-model",
@@ -29,6 +33,7 @@ def _config(
             max_depth=max_depth,
             max_concurrent_subagents=max_concurrent,
             max_subagent_calls=max_calls,
+            exec_timeout=exec_timeout,
         ),
     )
 
@@ -79,6 +84,12 @@ class _SometimesBlockingEngine(_FastEngine):
             raise
         finally:
             state.active -= 1
+
+
+class _DelayedEngine(_FastEngine):
+    async def run(self, prompt: str) -> RLMResult:
+        await asyncio.sleep(float(prompt))
+        return RLMResult(answer=f"child:{prompt}", session_dir=self.session.dir)
 
 
 class _NestedEngine:
@@ -383,6 +394,98 @@ print(all(f'{name}=' not in subprocess_env for name in secret_names))
         "True",
     ]
     assert supervisor.total_calls == 2
+
+
+async def test_real_kernel_excludes_parallel_subagent_wait_from_timeout(session):
+    config = _config(max_depth=1, exec_timeout=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(session.dir),
+        engine_factory=_DelayedEngine,
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": (
+                                "import asyncio\n"
+                                "results = await asyncio.gather(rlm('1.4'), rlm('1.5'))\n"
+                                "print([result.answer for result in results])"
+                            )
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="done"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    try:
+        result = await engine.run("delegate")
+    finally:
+        await supervisor.aclose()
+
+    assert result.answer == "done"
+    assert tool_result(client).strip() == "['child:1.4', 'child:1.5']"
+    assert "execution timed out" not in tool_result(client)
+
+
+async def test_active_subagent_does_not_shield_stuck_kernel(session):
+    _SometimesBlockingEngine.state = _EngineState()
+    _SometimesBlockingEngine.started = asyncio.Event()
+    config = _config(max_depth=1, exec_timeout=1)
+    supervisor = SessionTreeSupervisor(
+        root_session=session,
+        runtime_config=config,
+        cwd=str(session.dir),
+        engine_factory=_SometimesBlockingEngine,
+    )
+    client = DummyClient(
+        [
+            DummyMessage(
+                tool_calls=[
+                    DummyToolCall(
+                        "ipython",
+                        {
+                            "code": (
+                                "import asyncio\n"
+                                "child = asyncio.create_task(rlm('wait'))\n"
+                                "await asyncio.sleep(0.2)\n"
+                                "while True: pass"
+                            )
+                        },
+                    )
+                ]
+            ),
+            DummyMessage(content="recovered"),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=config,
+        supervisor=supervisor,
+        invocation_id=supervisor.root_id,
+    )
+    try:
+        result = await asyncio.wait_for(engine.run("delegate"), timeout=12)
+    finally:
+        await supervisor.aclose()
+
+    assert result.answer == "recovered"
+    assert "execution timed out after 1s" in tool_result(client)
+    assert _SometimesBlockingEngine.state.cancelled == 1
+    assert supervisor.active_calls == 0
 
 
 async def test_real_kernel_cancels_child_and_remains_reusable(session):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -530,7 +530,45 @@ async def test_execution_around_subagent_wait_remains_charged(session):
     assert "child:1.2" not in tool_result(client)
 
 
-async def test_background_subagent_does_not_shield_unrelated_wait(session):
+@pytest.mark.parametrize(
+    "code",
+    [
+        "import asyncio\n"
+        "child = asyncio.create_task(rlm('3.0'))\n"
+        "await asyncio.sleep(2.0)\n"
+        "print((await child).answer)",
+        "import asyncio\n"
+        "children = asyncio.gather(rlm('3.0'), rlm('3.0'))\n"
+        "await asyncio.sleep(2.0)\n"
+        "print(await children)",
+        "import asyncio\n"
+        "async def child():\n"
+        "    return await rlm('3.0')\n"
+        "background = asyncio.create_task(child())\n"
+        "await asyncio.sleep(2.0)\n"
+        "print(await background)",
+        "import asyncio\n"
+        "async def child():\n"
+        "    return await rlm('3.0')\n"
+        "await asyncio.gather(child(), asyncio.sleep(2.0))\n"
+        "print('completed')",
+        "import asyncio\n"
+        "try:\n"
+        "    await asyncio.gather(rlm('invalid-delay'), rlm('3.0'))\n"
+        "except RuntimeError:\n"
+        "    pass\n"
+        "await asyncio.sleep(2.0)\n"
+        "print('completed')",
+    ],
+    ids=[
+        "task",
+        "unawaited-gather",
+        "helper-task",
+        "mixed-helper-gather",
+        "gather-error",
+    ],
+)
+async def test_background_subagent_does_not_shield_unrelated_wait(session, code):
     config = _config(max_depth=1, exec_timeout=1)
     supervisor = SessionTreeSupervisor(
         root_session=session,
@@ -544,14 +582,7 @@ async def test_background_subagent_does_not_shield_unrelated_wait(session):
                 tool_calls=[
                     DummyToolCall(
                         "ipython",
-                        {
-                            "code": (
-                                "import asyncio\n"
-                                "child = asyncio.create_task(rlm('2.0'))\n"
-                                "await asyncio.sleep(2.0)\n"
-                                "print((await child).answer)"
-                            )
-                        },
+                        {"code": code},
                     )
                 ]
             ),
@@ -572,7 +603,8 @@ async def test_background_subagent_does_not_shield_unrelated_wait(session):
 
     assert result.answer == "recovered"
     assert "execution timed out after 1s" in tool_result(client)
-    assert "child:2.0" not in tool_result(client)
+    assert "child:3.0" not in tool_result(client)
+    assert "completed" not in tool_result(client)
 
 
 async def test_mixed_gather_does_not_shield_non_broker_wait(session):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -413,7 +413,7 @@ async def test_real_kernel_excludes_parallel_subagent_wait_from_timeout(session)
                         {
                             "code": (
                                 "import asyncio\n"
-                                "results = await asyncio.gather(rlm('1.4'), rlm('1.5'))\n"
+                                "results = await rlm.gather(rlm('1.4'), rlm('1.5'))\n"
                                 "print([result.answer for result in results])"
                             )
                         },
@@ -542,6 +542,13 @@ async def test_execution_around_subagent_wait_remains_charged(session):
         "await asyncio.sleep(2.0)\n"
         "print(await children)",
         "import asyncio\n"
+        "await asyncio.gather(rlm('3.0'), rlm('3.0'))\n"
+        "print('completed')",
+        "import asyncio\n"
+        "children = asyncio.create_task(rlm.gather(rlm('3.0'), rlm('3.0')))\n"
+        "await asyncio.sleep(2.0)\n"
+        "print(await children)",
+        "import asyncio\n"
         "async def child():\n"
         "    return await rlm('3.0')\n"
         "background = asyncio.create_task(child())\n"
@@ -554,7 +561,7 @@ async def test_execution_around_subagent_wait_remains_charged(session):
         "print('completed')",
         "import asyncio\n"
         "try:\n"
-        "    await asyncio.gather(rlm('invalid-delay'), rlm('3.0'))\n"
+        "    await rlm.gather(rlm('invalid-delay'), rlm('3.0'))\n"
         "except RuntimeError:\n"
         "    pass\n"
         "await asyncio.sleep(2.0)\n"
@@ -563,6 +570,8 @@ async def test_execution_around_subagent_wait_remains_charged(session):
     ids=[
         "task",
         "unawaited-gather",
+        "ordinary-gather",
+        "background-rlm-gather",
         "helper-task",
         "mixed-helper-gather",
         "gather-error",


### PR DESCRIPTION
## Problem

A healthy recursive inference call can exceed an IPython cell's `exec_timeout`. The current wall-clock timeout then interrupts the kernel and cancels its children, even though the cell is only waiting for model output. Raising the timeout also gives stuck Python code more time.

This PR makes `exec_timeout` an active-execution budget. Responsive inference waits are exempt when the cell directly awaits a sub-agent or the new `rlm.gather` helper. Recursive work remains bounded by the existing tree resource policies and the hosting runtime.

## Interface and behavior

```python
result = await rlm("check auth.py")

results = await rlm.gather(
    rlm("check auth.py"),
    rlm("check login.py"),
)
```

`rlm.gather` accepts only sub-agent call coroutines, starts them concurrently when awaited or scheduled, and returns results in input order. Creating its coroutine does not start the children. The README and model instructions now recommend this API for parallel recursion.

Kernel CPU, skills, ordinary waits, `asyncio.gather`, and background sub-agent tasks still consume the execution budget. Existing `asyncio.gather(rlm(...), ...)` calls remain valid, but must use `rlm.gather` to receive the inference-wait exemption. An exhausted budget still interrupts the kernel and cancels descendants.

The exemption is tied to the task executing the cell and lasts only for its eligible await. Broker heartbeats report the current lease and kernel CPU time; the supervisor pauses wall-clock charging only while a lease is fresh. Exceptions and cancellation release the lease. Skills retain ordinary request/disconnect handling and send no heartbeats.

## Why an explicit helper

We considered transparently exempting ordinary `asyncio.gather(rlm(...), ...)`. Identifying sub-agent coroutines at creation time was insufficient: an eagerly scheduled gather or a background helper could suspend the timeout while the cell awaited unrelated work.

Correctly preserving that interface required a global asyncio hook and a Future proxy to track actual awaits while retaining eager scheduling and cancellation behavior. We chose the explicit `rlm.gather` API instead. It is a small async helper, makes the special timeout behavior visible at the call site, and leaves asyncio untouched. Cell-task tracking and liveness checks remain necessary to prevent background inference from shielding unrelated execution.

## Validation

- `uv run pytest tests/` — **179 passed** on Python 3.10.
- Ruff formatting and lint checks passed; `git diff --check` passed.
- Real-kernel tests cover direct, sequential, and parallel inference waits; charged local work and skills; background helpers and gathers; ordinary and mixed asyncio gathers; exception cleanup, cancellation, and kernel reuse.
- Focused tests verify lazy gather scheduling, cancellation releasing leases, and rejection of non-sub-agent calls.

Companion: PrimeIntellect-ai/verifiers#2525

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IPython timeout accounting and the in-kernel recursion API; mis-tuned heartbeats or lease logic could interrupt healthy cells or leave stuck code running longer, though coverage is extensive.
> 
> **Overview**
> **`exec_timeout` is now an active-execution budget for IPython cells**, not raw wall time. While a cell is exclusively awaiting **`await rlm(...)`** or **`await rlm.gather(...)`** with live broker heartbeats, wall-clock charging pauses; kernel CPU during those waits, skills, ordinary sleeps, **`asyncio.gather`**, background sub-agent tasks, and stale heartbeats still count toward the limit.
> 
> Adds **`rlm.gather`** (exported from **`rlm`**) as the supported way to run parallel sub-agents with the same timeout treatment. **`rlm.run` / `rlm()`** return coroutines tagged for the broker; the supervisor tracks per-scope **`BrokerWaitTracker`** state and accepts **`wait.heartbeat`** frames on child **`rlm.run`** connections. IPython wraps cell execution with **`cell_execution()`** and applies the new charged-time loop in **`_execute_locked`**.
> 
> Docs and system prompts now recommend **`rlm.gather`** instead of **`asyncio.gather`** for parallel recursion and spell out what still consumes the budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b2ff23156777a598dc4a1b412fa8fbe3b9af20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->