### PR TITLE
fix: include git history guard prompt when the bash tool is active

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -25,7 +25,7 @@ BASE_TOOLKIT = (
     "pydantic",
 )
 
-SHELL_TOOL_NAMES = frozenset({"ipython"})
+SHELL_TOOL_NAMES = frozenset({"bash", "ipython"})
 GIT_HISTORY_GUARD_PROMPT = (
     "Do not cheat by using online solutions or hints specific to this task, or "
     "by copying or inferring solutions from other branches, tags, remotes, "

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -35,13 +35,14 @@ def _prompt(
 
 
 def test_git_history_guard_prompt_included_for_shell_tools():
-    prompt = _prompt([_Tool("ipython")])
+    for tool in ("ipython", "bash"):
+        prompt = _prompt([_Tool(tool)])
 
-    assert GIT_HISTORY_GUARD_PROMPT in prompt
-    assert "Do not cheat" in prompt
-    assert "online solutions or hints specific to this task" in prompt
-    assert "other branches, tags, remotes" in prompt
-    assert "`--all`" in prompt
+        assert GIT_HISTORY_GUARD_PROMPT in prompt
+        assert "Do not cheat" in prompt
+        assert "online solutions or hints specific to this task" in prompt
+        assert "other branches, tags, remotes" in prompt
+        assert "`--all`" in prompt
 
 
 def test_git_history_guard_prompt_omitted_when_unrestricted():


### PR DESCRIPTION
## Summary

The bash tool enforces the git-log history guard (`find_blocked_command` → refusal), but `SHELL_TOOL_NAMES` only counted `ipython` as a shell tool for prompt purposes. A bash-tool agent without ipython therefore got `Git history option '--all' is not allowed` refusals without `GIT_HISTORY_GUARD_PROMPT` ever telling it the restriction exists.

One-word fix: add `bash` to `SHELL_TOOL_NAMES` so the guard prompt is included whenever any guarded shell tool is active (still omitted when `allow_git=true` or no shell tool is enabled). Extended the existing prompt test to cover the bash case.

`uv run pytest tests/` — 164 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)