### PR TITLE
fix: reject incomplete compaction outputs using response metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Recursive calls are created by a session-local supervisor rather than by the IPy
 
 There is no model-driven compaction tool. Compaction is on by default and unlimited (the policy's `compaction` field turns it off, `max_compactions` caps it); the default 1M `max_total_tokens` tree budget keeps sessions bounded, since each compaction cycle itself spends new tokens. The engine reads the model context window from the provider's `/models` response and compacts when 16k tokens remain below it; small windows keep at least half. Set `summarize_at_tokens` to pin the threshold explicitly. Without a known window or explicit threshold, proactive compaction stays off, but a provider overflow still triggers it reactively. A tool result larger than 20KB is truncated to its head and tail before it enters the conversation, with a warning naming the original size.
 
-The engine asks the model for a plain-text handoff summary and resumes the task on a fresh branch seeded with that summary; reasoning is never part of it. A provider overflow (a 400 or 413 naming a context limit) triggers the same compaction reactively from the current state. A rejected checkpoint request falls back to the last state that passed a threshold check - by definition a state with a full reserve of room - and an empty or tool-calling reply is resampled; after three failed attempts the run ends cleanly with what the conversation holds. An overflow with no history beyond the task propagates: the task alone approaches the window and there is nothing to reclaim.
+The engine asks the model for a plain-text handoff summary and resumes the task on a fresh branch seeded with that summary; reasoning is never part of it. A provider overflow (a 400 or 413 naming a context limit) triggers the same compaction reactively from the current state. A rejected checkpoint request falls back to the last state that passed a threshold check - by definition a state with a full reserve of room - and an empty or tool-calling reply is resampled; after `max_compaction_attempts` failed attempts (default 5) the run ends cleanly with what the conversation holds. An overflow with no history beyond the task propagates: the task alone approaches the window and there is nothing to reclaim.
 
 The IPython kernel keeps running across the compaction, so all variables, imports, and in-memory data are preserved. The model is told to mention important variable names in its summary so the resumed branch knows what is available. The same policy applies to the main agent and all recursive agents.
 
@@ -146,6 +146,20 @@ message = child_history.windows[4].messages[2]  # If that child has reached wind
 ```
 
 Snapshots contain complete records as of the read; call `history(...)` again to observe new activity. `h.events` exposes lifecycle records, including each child's spawn prompt and rollback markers. The compacted context points to this API so the model can retrieve omitted details without putting the whole transcript back in context.
+
+Checkpoint acceptance uses only normally terminated, nonempty final text without tool calls.
+The provider may attach choice-level `vf_completion` metadata:
+`{"version":1,"status":"incomplete","reason":"unfinished_reasoning"}`.
+Known incomplete/invalid output is rejected even when it contains text or reports `stop`.
+Set `policy.require_compaction_completion_status=true` to require explicit `complete` evidence.
+Otherwise absent metadata or `unknown/parser_unavailable` uses the compatible final-text check;
+unsupported/malformed metadata and unknown termination are rejected.
+
+Attempts, including rejected ones, remain charged and represented in the Verifiers
+trace through intercepted model calls and ACP semantic links. Failed compaction
+attempts are omitted from the local recovery ledger. The active context changes only after a summary
+passes validation. `num_compaction_attempts` and `num_failed_compaction_attempts` distinguish
+attempt outcomes from successful `num_compactions`; failed attempts include cancelled requests.
 
 ## Session Directory
 

--- a/src/rlm/acp.py
+++ b/src/rlm/acp.py
@@ -105,6 +105,7 @@ class _LimitsSnapshot(_ContractModel):
     summarize_at_tokens: int | None = Field(default=None, gt=0)
     max_compactions: int | None = Field(default=None, gt=0)
     max_compaction_attempts: int = Field(gt=0)
+    require_compaction_completion_status: bool = False
     allow_git: bool
 
 

--- a/src/rlm/compaction.py
+++ b/src/rlm/compaction.py
@@ -75,6 +75,48 @@ class CompactionFailed(Exception):
     """Every checkpoint attempt failed - the caller ends the run cleanly instead."""
 
 
+def checkpoint_rejection_reason(
+    choice: Any, *, require_completion_status: bool = False
+) -> str | None:
+    """Validate a checkpoint without importing a provider or renderer implementation.
+
+    ``vf_completion`` is choice-level response metadata, never model-authored text.
+    Absent or explicitly unaudited parser metadata can use the compatible check;
+    known incomplete/invalid output and unsupported metadata always fail closed.
+    """
+    metadata = getattr(choice, "vf_completion", None)
+    if metadata is not None:
+        if not isinstance(metadata, dict) or type(metadata.get("version")) is not int:
+            return "invalid_completion_metadata"
+        if metadata["version"] != 1:
+            return "unsupported_completion_metadata"
+        status = metadata.get("status")
+        reason = metadata.get("reason")
+        if (
+            not isinstance(status, str)
+            or status not in {"complete", "incomplete", "invalid", "unknown"}
+            or not (reason is None or isinstance(reason, str))
+        ):
+            return "invalid_completion_metadata"
+        if status in {"incomplete", "invalid"}:
+            return reason or status
+        if status == "unknown" and (
+            require_completion_status or reason != "parser_unavailable"
+        ):
+            return reason or "unknown_completion_status"
+    elif require_completion_status:
+        return "missing_completion_status"
+    finish = getattr(choice, "finish_reason", None)
+    if finish != "stop":
+        return "output_truncated" if finish == "length" else "non_final_termination"
+    message = choice.message
+    if message.tool_calls:
+        return "tool_call"
+    if not isinstance(message.content, str) or not message.content.strip():
+        return "missing_final_output"
+    return None
+
+
 def is_context_overflow(error: APIStatusError) -> bool:
     details = f"{error} {error.body or ''}"
     # An overflow is deterministic: a 400, or a 413 for a byte-size cap.

--- a/src/rlm/config.py
+++ b/src/rlm/config.py
@@ -83,6 +83,8 @@ class ExecutionPolicy(_ConfigModel):
     still bounds the session."""
     max_compaction_attempts: int = Field(default=5, gt=0)
     """Summary-generation attempts within one compaction cycle."""
+    require_compaction_completion_status: bool = False
+    """Require versioned structural-completion evidence instead of the legacy final-text check."""
     max_concurrent_subagents: int = Field(default=4, gt=0)
     max_subagent_calls: int = Field(default=64, gt=0)
     allow_git: bool = False

--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -27,6 +27,7 @@ from rlm.compaction import (
     CompactionFailed,
     REPL_NOTE,
     SUMMARY_FRAMING,
+    checkpoint_rejection_reason,
     compactable,
     discover_threshold,
     estimated_tokens,
@@ -886,6 +887,9 @@ class RLMEngine:
             base = messages
             summary_text = ""
             for _ in range(self.max_compaction_attempts):
+                if cap := self._spent_tree_cap():
+                    raise CompactionFailed(f"{cap} reached before checkpoint attempt")
+                self._metrics.num_compaction_attempts += 1
                 checkpoint = [
                     *base,
                     {"role": "user", "content": checkpoint_prompt},
@@ -897,18 +901,23 @@ class RLMEngine:
                         compaction_id=compaction.compaction_id,
                     )
                 except APIStatusError as e:
+                    self._metrics.num_failed_compaction_attempts += 1
                     if not is_context_overflow(e):
                         raise
                     base = messages[: self._last_good]
                     continue
+                except BaseException:
+                    self._metrics.num_failed_compaction_attempts += 1
+                    raise
                 choice = response.choices[0]
-                message = choice.message
-                # Reasoning never enters the summary: only the reply's final text
-                # counts, so a reply that lives entirely in the reasoning channel
-                # is resampled like an empty one.
-                text = (message.content or "").strip()
-                if choice.finish_reason == "stop" and not message.tool_calls and text:
-                    summary_text = text
+                rejection = checkpoint_rejection_reason(
+                    choice,
+                    require_completion_status=self.runtime_config.policy.require_compaction_completion_status,
+                )
+                if rejection:
+                    self._metrics.num_failed_compaction_attempts += 1
+                if rejection is None:
+                    summary_text = choice.message.content.strip()
                     break
                 self._semantic_edges.release_summary_request(compaction.compaction_id)
             if not summary_text:
@@ -1017,6 +1026,7 @@ class RLMEngine:
                 "summarize_at_tokens": self.summarize_at_tokens,
                 "max_compactions": self.runtime_config.policy.max_compactions,
                 "max_compaction_attempts": self.max_compaction_attempts,
+                "require_compaction_completion_status": self.runtime_config.policy.require_compaction_completion_status,
                 "allow_git": self.runtime_config.policy.allow_git,
             },
             "semantic_edges": self._semantic_edges.snapshot(),

--- a/src/rlm/types.py
+++ b/src/rlm/types.py
@@ -150,6 +150,8 @@ class RLMMetrics:
 
     # Compaction metrics (auto-summarization at a token threshold)
     num_compactions: int = 0
+    num_compaction_attempts: int = 0
+    num_failed_compaction_attempts: int = 0
     has_compacted: int = 0  # 1 if num_compactions > 0, else 0; aggregates as the per-batch fraction of rollouts that compacted
     turns_since_last_compaction: int = 0
     turns_between_compactions_mean: float = 0.0

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -20,6 +20,7 @@ from conftest import (
 from rlm.compaction import (
     SUMMARY_FRAMING,
     CompactionFailed,
+    checkpoint_rejection_reason,
     is_context_overflow,
 )
 from rlm.config import (
@@ -122,6 +123,8 @@ def _config(
     summarize_at_tokens: int | None = None,
     compaction: bool = True,
     max_compaction_attempts: int = 5,
+    require_compaction_completion_status: bool = False,
+    max_total_tokens: int | None = 1_000_000,
 ):
     return RuntimeConfig(
         model="test-model",
@@ -133,6 +136,8 @@ def _config(
             compaction=compaction,
             summarize_at_tokens=summarize_at_tokens,
             max_compaction_attempts=max_compaction_attempts,
+            require_compaction_completion_status=require_compaction_completion_status,
+            max_total_tokens=max_total_tokens,
         ),
     )
 
@@ -455,3 +460,204 @@ async def test_subagent_recovers_from_context_overflow(tmp_path):
     assert engines[0].depth == 1
     assert engines[0]._metrics.num_compactions == 1
     assert len(clients[0].calls) == 4
+
+
+@pytest.mark.parametrize(
+    "metadata,finish,text,strict,reason",
+    [
+        (
+            {"version": 1, "status": "complete", "reason": None},
+            "stop",
+            "summary",
+            True,
+            None,
+        ),
+        (
+            {"version": 1, "status": "incomplete", "reason": "unfinished_reasoning"},
+            "stop",
+            "misparsed reasoning",
+            False,
+            "unfinished_reasoning",
+        ),
+        (
+            {"version": 1, "status": "invalid", "reason": "malformed_tool_call"},
+            "stop",
+            "text",
+            False,
+            "malformed_tool_call",
+        ),
+        (
+            {"version": 1, "status": "complete", "reason": None},
+            "length",
+            "partial",
+            True,
+            "output_truncated",
+        ),
+        (
+            {"version": 1, "status": "complete", "reason": None},
+            "stop",
+            "",
+            True,
+            "missing_final_output",
+        ),
+        (None, "stop", "summary", False, None),
+        (None, "stop", "summary", True, "missing_completion_status"),
+        (None, "length", "partial", False, "output_truncated"),
+        (None, None, "summary", False, "non_final_termination"),
+        (
+            {"version": 1, "status": "unknown", "reason": "parser_unavailable"},
+            "stop",
+            "summary",
+            False,
+            None,
+        ),
+        (
+            {"version": 1, "status": "unknown", "reason": "parser_unavailable"},
+            "stop",
+            "summary",
+            True,
+            "parser_unavailable",
+        ),
+        (
+            {"version": 1, "status": "unknown", "reason": "unknown_termination"},
+            "stop",
+            "summary",
+            False,
+            "unknown_termination",
+        ),
+        (
+            {"version": 2, "status": "complete"},
+            "stop",
+            "summary",
+            False,
+            "unsupported_completion_metadata",
+        ),
+        (
+            {"version": True, "status": "complete"},
+            "stop",
+            "summary",
+            False,
+            "invalid_completion_metadata",
+        ),
+        (
+            {"version": 1, "status": []},
+            "stop",
+            "summary",
+            False,
+            "invalid_completion_metadata",
+        ),
+        ([], "stop", "summary", False, "invalid_completion_metadata"),
+    ],
+)
+def test_checkpoint_completion_contract(metadata, finish, text, strict, reason):
+    choice = SimpleNamespace(
+        vf_completion=metadata,
+        finish_reason=finish,
+        message=SimpleNamespace(content=text, tool_calls=None),
+    )
+    assert (
+        checkpoint_rejection_reason(choice, require_completion_status=strict) == reason
+    )
+
+
+@pytest.mark.parametrize("succeeds", [False, True])
+async def test_rejected_checkpoint_preserves_history_budget_and_edges(
+    session, succeeds
+):
+    bad = _response(
+        DummyMessage(content="unfinished reasoning"),
+        prompt_tokens=10,
+        completion_tokens=3,
+    )
+    bad.choices[0].vf_completion = {
+        "version": 1,
+        "status": "incomplete",
+        "reason": "unfinished_reasoning",
+    }
+    good = _response(
+        DummyMessage(content="validated summary"), prompt_tokens=10, completion_tokens=4
+    )
+    good.choices[0].vf_completion = {"version": 1, "status": "complete", "reason": None}
+    client = _ScriptedClient(
+        [
+            _response(DummyMessage(content="work")),
+            bad,
+            good if succeeds else bad,
+            *([_response(DummyMessage(content="resumed"))] if succeeds else []),
+        ]
+    )
+    config = _config(
+        max_compaction_attempts=2, require_compaction_completion_status=True
+    )
+    engine = RLMEngine(client=client, session=session, runtime_config=config)
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "original task"},
+        {"role": "assistant", "content": "work"},
+    ]
+    original = deepcopy(messages)
+    try:
+        await engine._call_model(messages)
+        if succeeds:
+            await engine._compact_branch(messages, turn=1)
+            assert len(session.messages) == 2
+            assert "validated summary" in session.messages[1]["content"]
+            assert "unfinished reasoning" not in session.messages[1]["content"]
+            await engine._call_model(session.messages)
+        else:
+            with pytest.raises(CompactionFailed):
+                await engine._compact_branch(messages, turn=1)
+            assert messages == original
+        assert engine._metrics.num_compaction_attempts == 2
+        assert engine._metrics.num_failed_compaction_attempts == (1 if succeeds else 2)
+        assert engine._own_new_tokens == (31 if succeeds else 28)
+        assert client.calls[1]["messages"] == client.calls[2]["messages"]
+        snapshot = engine.execution_snapshot()
+        edges = snapshot["semantic_edges"]["edges"]
+        assert sum(e["type"] == "compaction_attempt" for e in edges) == 2
+        assert sum(e["type"] == "compaction" for e in edges) == int(succeeds)
+        rejected_id = client.calls[1]["extra_headers"]["X-ACP-Model-Request-ID"]
+        assert not any(e["source_request_id"] == rejected_id for e in edges)
+        events = [
+            json.loads(line)
+            for line in (session.dir / "messages.jsonl").read_text().splitlines()
+        ]
+        assert snapshot["metrics"]["num_compaction_attempts"] == 2
+        assert snapshot["metrics"]["num_failed_compaction_attempts"] == (
+            1 if succeeds else 2
+        )
+        assert not any(
+            e["type"]
+            in {"checkpoint_request", "checkpoint_response", "compaction_attempt"}
+            for e in events
+        )
+        assert "unfinished reasoning" not in json.dumps(events)
+        assert sum(e["type"] == "compaction" for e in events) == int(succeeds)
+    finally:
+        engine.close()
+
+
+async def test_compaction_does_not_retry_after_spending_tree_budget(session):
+    client = _ScriptedClient(
+        [
+            _response(DummyMessage(content=None), prompt_tokens=2, completion_tokens=3),
+        ]
+    )
+    engine = RLMEngine(
+        client=client, session=session, runtime_config=_config(max_total_tokens=5)
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "task"},
+    ]
+    original = deepcopy(messages)
+    try:
+        with pytest.raises(CompactionFailed, match="max_total_tokens"):
+            await engine._compact_branch(messages, turn=0)
+        assert messages == original
+        assert len(client.calls) == 1
+        assert engine._own_new_tokens == 5
+        assert engine._metrics.num_compaction_attempts == 1
+        assert engine._metrics.num_failed_compaction_attempts == 1
+    finally:
+        engine.close()


### PR DESCRIPTION
Reject unusable checkpoint summaries before replacing the active context. A nonempty response can still contain unfinished reasoning or invalid output even when the provider reports `finish_reason="stop"`.

Consume versioned, choice-level `vf_completion` metadata. Known incomplete or invalid responses are rejected. Strict verification is opt-in through `require_compaction_completion_status`; the default accepts normally terminated, nonempty final text without tool calls when completion metadata is absent or reports `unknown/parser_unavailable`. Malformed or unsupported metadata is rejected.

Verifiers records checkpoint model requests and responses through interception; ACP exports semantic attempt links and aggregate attempt/failure metrics. Rejected attempts remain charged and represented in that trace, but are omitted from the local agent recovery ledger. Retry limits and shared budgets bound attempts; cancellation and provider errors propagate.

Built on [the conversation-ledger PR](https://github.com/PrimeIntellect-ai/nano-rlm/pull/173). The completion metadata comes from [renderers](https://github.com/PrimeIntellect-ai/renderers/pull/153) through [Verifiers](https://github.com/PrimeIntellect-ai/verifiers/pull/2543); deploy compatible producers before enabling strict verification.

### Validation

The combined stack through [the checkpoint-headroom PR](https://github.com/PrimeIntellect-ai/nano-rlm/pull/176) passes **198 tests** on Python 3.13.14 and repository pre-commit checks. Coverage includes acceptance/rejection, attempt accounting, semantic edges, exhausted retries, and the separation between exported attempt accounting and local recovery history. This is a combined-stack result, not a separate full-suite run at this intermediate commit or a live-model evaluation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when context is replaced during compaction—a core session behavior path—with new provider-metadata coupling, though defaults preserve backward-compatible acceptance when metadata is missing.
> 
> **Overview**
> Compaction checkpoint acceptance no longer trusts `finish_reason="stop"` and nonempty text alone. Summaries must pass **`checkpoint_rejection_reason`**, which reads choice-level **`vf_completion`** metadata when present and falls back to the legacy final-text rules when metadata is absent or reports `unknown/parser_unavailable`.
> 
> **`policy.require_compaction_completion_status`** (also on ACP limits snapshots) opts into requiring explicit `complete` evidence; known incomplete/invalid or malformed metadata is rejected and the engine resamples until **`max_compaction_attempts`** (documented default 5). Rejected attempts increment **`num_compaction_attempts`** / **`num_failed_compaction_attempts`** and still spend tree token budget; context and **`messages.jsonl`** change only after a validated summary. Compaction aborts early if **`max_total_tokens`** is already spent instead of issuing another checkpoint call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cbe1dfbf0057a64d5edf8553ca8bc745d4ea103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->