### PR TITLE
docs: clarify the search skill text return contract

### DIFF
--- a/src/rlm/prompt.py
+++ b/src/rlm/prompt.py
@@ -66,8 +66,9 @@ EDIT_SKILL_PROMPT = (
 )
 SEARCH_SKILL_PROMPT = (
     "For web search, use the pre-imported async `search` skill from IPython: "
-    '`await search(query="...")`. Results come back as title, URL, and snippet; '
-    "assign the result to a variable so you can revisit it. To cover "
+    '`await search(query="...")` returns one formatted text string containing '
+    "titles, URLs, and snippets, not a list of records. Assign it to a variable "
+    "and print it to read the results. To cover "
     "several angles at once, fan out with `asyncio.gather(search(...), search(...))`."
 )
 FETCH_SKILL_PROMPT = (

--- a/src/rlm/skills/search.py
+++ b/src/rlm/skills/search.py
@@ -61,7 +61,7 @@ async def run_with_api_key(
         num_results: Number of results to return.
 
     Returns:
-        Formatted results (title, URL, snippet).
+        One formatted text string containing titles, URLs, and snippets.
     """
     if not api_key:
         return "Error: SERPER_API_KEY environment variable is not set"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -79,6 +79,7 @@ def test_search_skill_prompt_included_only_when_search_is_installed():
 
     assert SEARCH_SKILL_PROMPT in prompt
     assert "await search(query=" in prompt
+    assert "one formatted text string" in prompt
     assert SEARCH_SKILL_PROMPT not in _prompt(
         [_Tool("ipython")], installed_skills=["search_docs"]
     )


### PR DESCRIPTION
The search skill returns one formatted text string containing all result titles, URLs, and snippets. The existing hint lists those fields without identifying the return type, which can lead the model to treat the string as structured records or iterate over its characters.

Clarify the existing contract in the model-facing prompt and skill docstring, and extend the existing prompt assertion. Search behavior and output are unchanged.

This PR now targets `main` directly and has no dependency on the compaction or agent-runtime redesign. The signed commit preserves the original patch exactly.

Validation: `uv run pytest tests/ -q` passes all 164 tests in 47.56 seconds on Python 3.13.14. All 8 prompt tests also pass independently; changed-file Ruff lint/format checks and `git diff --check` pass. No real-model behavioral improvement is claimed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and docstring-only changes with no runtime or API modifications.
> 
> **Overview**
> **Documentation-only** clarification of what `await search(...)` returns: a **single formatted text string** (titles, URLs, snippets), **not** a list of records—so agents assign/print it instead of iterating structured results.
> 
> Updates **`SEARCH_SKILL_PROMPT`** in the system prompt, the **`run_with_api_key`** docstring in `search.py`, and adds a prompt test asserting the new wording. **Search behavior and output are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f15cae90b5e842e5a484919f50222b8d826c53c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->