### PR TITLE
fix: reject incomplete compaction summaries

### DIFF
--- a/src/rlm/engine.py
+++ b/src/rlm/engine.py
@@ -868,8 +868,8 @@ class RLMEngine:
         compaction = self._semantic_edges.begin_compaction(self._invocation_id)
         try:
             # A rejected checkpoint falls back to the last good snapshot (which has a
-            # full reserve of room, so it fits); an empty or tool-calling reply is
-            # resampled. Reasoning is never part of the summary.
+            # full reserve of room, so it fits); an incomplete, empty, or
+            # tool-calling reply is resampled. Reasoning is never part of the summary.
             base = messages
             summary_text = ""
             for _ in range(self.max_compaction_attempts):
@@ -888,12 +888,13 @@ class RLMEngine:
                         raise
                     base = messages[: self._last_good]
                     continue
-                message = response.choices[0].message
+                choice = response.choices[0]
+                message = choice.message
                 # Reasoning never enters the summary: only the reply's final text
                 # counts, so a reply that lives entirely in the reasoning channel
                 # is resampled like an empty one.
                 text = (message.content or "").strip()
-                if not message.tool_calls and text:
+                if choice.finish_reason == "stop" and not message.tool_calls and text:
                     summary_text = text
                     break
                 self._semantic_edges.release_summary_request(compaction.compaction_id)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -157,6 +157,80 @@ async def test_compaction_attempt_limit_is_configurable(session):
     assert len(client.calls) == 2
 
 
+@pytest.mark.parametrize(
+    "finish_reason", ["length", "content_filter", "tool_calls", None]
+)
+@pytest.mark.parametrize("recovers", [False, True])
+async def test_compaction_requires_normal_termination(session, finish_reason, recovers):
+    rejected = _response(
+        DummyMessage(content="unfinished summary"), finish_reason=finish_reason
+    )
+    client = _ScriptedClient(
+        [
+            rejected,
+            _response(DummyMessage(content="complete summary"))
+            if recovers
+            else rejected,
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=_config(max_compaction_attempts=2),
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "progress"},
+    ]
+    original = deepcopy(messages)
+    try:
+        if recovers:
+            await engine._compact_branch(messages, turn=0)
+            assert len(messages) == 2
+            assert "complete summary" in messages[1]["content"]
+            assert "unfinished summary" not in messages[1]["content"]
+            assert engine._metrics.num_compactions == 1
+        else:
+            with pytest.raises(CompactionFailed, match="after 2 attempts"):
+                await engine._compact_branch(messages, turn=0)
+            assert messages == original
+            assert engine._metrics.num_compactions == 0
+        assert len(client.calls) == 2
+        assert client.calls[0]["messages"] == client.calls[1]["messages"]
+    finally:
+        engine.close()
+
+
+@pytest.mark.parametrize("content", [None, "", " \n\t"])
+async def test_compaction_retries_reasoning_without_final_content(session, content):
+    message = DummyMessage(content=content)
+    message.reasoning_content = "unfinished reasoning"
+    client = _ScriptedClient(
+        [
+            _response(message),
+            _response(DummyMessage(content="complete summary")),
+        ]
+    )
+    engine = RLMEngine(
+        client=client,  # type: ignore[arg-type]
+        session=session,
+        runtime_config=_config(max_compaction_attempts=2),
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "task"},
+    ]
+    try:
+        await engine._compact_branch(messages, turn=0)
+        assert "complete summary" in messages[1]["content"]
+        assert "unfinished reasoning" not in messages[1]["content"]
+        assert len(client.calls) == 2
+        assert engine._metrics.num_compactions == 1
+    finally:
+        engine.close()
+
+
 async def test_tool_result_overflow_compacts_and_retries(session):
     client = _ScriptedClient(
         [


### PR DESCRIPTION
Compaction currently accepts any nonempty final text without tool calls, including a summary cut off by the generation limit. That partial summary then replaces the conversation history.

Require `finish_reason == "stop"` as well as nonempty, non-whitespace final content and no tool calls. Rejected responses use the existing retry budget; if all attempts fail, compaction raises `CompactionFailed` without replacing the original history.

This complements [renderers #152](https://github.com/PrimeIntellect-ai/renderers/pull/152), which keeps truncated reasoning in `reasoning_content` and leaves final content empty. Nano-rlm already rejects that empty content; regression coverage now locks in that behavior alongside rejection of truncated final text. No new Verifiers field or renderer API is required by this change.

Validation: `uv run pytest tests/` — **176 passed**. Ruff lint and formatting checks passed for the changed files. Regression tests cover abnormal finish reasons, reasoning-only responses, successful retries, and exhausted retries preserving history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when compaction commits a summary and replaces history; incorrect rejection could delay compaction, but retries and failure paths preserve the prior messages.
> 
> **Overview**
> Compaction checkpoint summaries are no longer accepted from any nonempty, tool-free reply. **`_compact_branch`** now requires **`finish_reason == "stop"`** alongside non-whitespace final **`content`**, so truncated (`length`), filtered, tool-calling, or otherwise incomplete checkpoint responses are retried like empty replies.
> 
> Failed attempts still use the existing **`max_compaction_attempts`** budget; exhaustion raises **`CompactionFailed`** without rewriting conversation history. New tests cover abnormal finish reasons (retry vs failure), reasoning-only responses with empty final content, and unchanged history when retries are exhausted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be04e445e12808a12ff7d799e4992e6af659adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->